### PR TITLE
[docs]: Add instructions to run formatter and linter locally

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,9 +8,30 @@ We actively welcome your pull requests.
 1. Fork the repo and create your branch from `main`.
 2. If you've added code that should be tested, add tests.
 3. If you've changed APIs, update the documentation.
-4. Ensure the test suite passes.
-5. Make sure your code lints.
+4. Ensure the test suite passes
+5. Make sure your code lints
 6. If you haven't already, complete the Contributor License Agreement ("CLA").
+
+## Run the linter
+The codebase uses the [Clippy](https://github.com/rust-lang/rust-clippy) linter to ensure that common mistakes are caught.
+To install follow the instructions on the Clippy repository. To run the linter locally use with the following properties:
+```
+cargo clippy --all -- -D clippy::all -D warnings -D clippy::disallowed_method
+```
+
+## Run the formatter
+To ensure that the codebase is following standard formatting properties, the 
+[Rustfmt](https://github.com/rust-lang/rustfmt) is being used on its `nightly` version
+(see instructions in Rustfmt repository to install the nightly version). To run the
+formatter locally you can use the follow command:
+```
+cargo +nightly fmt --all
+```
+The above command will format and apply the changes directly. If you want to just
+see the formatter recommendations, just run with the `--check` property:
+```
+cargo +nightly fmt --all -- --check
+```
 
 ## Contributor License Agreement ("CLA")
 In order to accept your pull request, we need you to submit a CLA. You only need


### PR DESCRIPTION
This PR enhances the `CONTRIBUTING` docs with instructions to run the used linter and formatter locally. I believe it would be useful to have those in place for anyone who want to contribute on the codebase.