### PR TITLE
[enhancement]: adding issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,13 @@
+---
+name: Bug
+about: Create a new bug
+title: '<title>'
+labels: bug
+assignees: ''
+---
+
+### Description
+<!-- give the bug description here -->
+
+### Steps to reproduce
+<!-- provide the steps to reproduce here -->

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -1,0 +1,9 @@
+---
+name: Epic
+about: Create a new epic
+title: '<title>'
+labels: epic
+assignees: ''
+---
+
+### Description

--- a/.github/ISSUE_TEMPLATE/story.md
+++ b/.github/ISSUE_TEMPLATE/story.md
@@ -1,0 +1,14 @@
+---
+name: Story
+about: Create a new story
+title: '<title>'
+labels: story
+assignees: ''
+---
+
+### Epic
+<!-- here you can reference they parent Epic, given that this exists. Just insert the number of issue (e.x #34).
+If no Epic exists, ignore and feel free to delete the "Epic" section. -->
+Parent epic: #
+
+### Description

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,14 @@
+---
+name: Task
+about: Create a new task
+title: '<title>'
+labels: task
+assignees: ''
+---
+
+### Story
+<!-- here you can reference they parent Story, given that this exists. Just insert the number of issue (e.x #34).
+If no Story exists, ignore and feel free to delete the "Story" section. -->
+Parent story: #
+
+### Description


### PR DESCRIPTION
I believe this will help us better categorise the issues we open start having a clearer view of the overall in progress work .

I've also introduced two projects to help us in that direction. The one tracks the epics/stories and the other the tasks. Those can be found here https://github.com/MystenLabs/narwhal/projects . Also I've setup Go links for them so can be found under:
* go/narwhal-tasks
* go/narwhal-stories

every task that we are planning to work on - is in progress - and done - should be visible on the `go/narwhal-tasks` .

