### PR TITLE
fix: make sure benchmarks are compiled in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,6 +53,11 @@ jobs:
         with:
           command: test
           args: --all-features
+      - name: Compile micro-benchmarks
+        uses: actions-rs/cargo@v1
+        with:
+          command: bench
+          args: --all-features --no-run
 
   clippy:
     name: Clippy


### PR DESCRIPTION
This will avoid bit-rot