### PR TITLE
fix: block_remover test failures on DB creation

### DIFF
--- a/primary/src/block_remover.rs
+++ b/primary/src/block_remover.rs
@@ -103,6 +103,7 @@ pub struct DeleteBatchMessage {
 /// # use std::collections::BTreeMap;
 /// # use primary::Certificate;
 /// # use config::WorkerId;
+/// # use tempfile::tempdir;
 /// # use primary::{BlockRemover, BlockRemoverCommand, DeleteBatchMessage, Header, PayloadToken};
 /// # use primary::{BatchDigest, CertificateDigest, HeaderDigest};
 ///
@@ -112,8 +113,10 @@ pub struct DeleteBatchMessage {
 ///     const HEADERS_CF: &str = "headers";
 ///     const PAYLOAD_CF: &str = "payload";
 ///
+///     let temp_dir = tempdir().expect("Failed to open temporary directory").into_path();
+///
 ///     // Basic setup: datastore, channels & BlockWaiter
-///     let rocksdb = rocks::open_cf(temp_dir(), None, &[CERTIFICATES_CF, HEADERS_CF, PAYLOAD_CF])
+///     let rocksdb = rocks::open_cf(temp_dir, None, &[CERTIFICATES_CF, HEADERS_CF, PAYLOAD_CF])
 ///         .expect("Failed creating database");
 ///
 ///     let (certificate_map, headers_map, payload_map) = reopen!(&rocksdb,

--- a/primary/src/block_waiter.rs
+++ b/primary/src/block_waiter.rs
@@ -160,14 +160,17 @@ type RequestKey = Vec<u8>;
 /// # use config::Committee;
 /// # use std::collections::BTreeMap;
 /// # use primary::Certificate;
+/// # use tempfile::tempdir;
 /// # use primary::{BatchMessage, BlockWaiter, BlockCommand,BatchDigest, CertificateDigest, Batch};
 ///
 /// #[tokio::main(flavor = "current_thread")]
 /// # async fn main() {
 ///     const CERTIFICATES_CF: &str = "certificates";
 ///
+///     let temp_dir = tempdir().expect("Failed to open temporary directory").into_path();
+///
 ///     // Basic setup: datastore, channels & BlockWaiter
-///     let rocksdb = rocks::open_cf(temp_dir(), None, &[CERTIFICATES_CF])
+///     let rocksdb = rocks::open_cf(temp_dir, None, &[CERTIFICATES_CF])
 ///         .expect("Failed creating database");
 ///
 ///     let (certificate_map) = reopen!(&rocksdb,


### PR DESCRIPTION
Resolves: https://github.com/MystenLabs/narwhal/issues/113

This PR fixes the issue reported on #113 . Before, the Rust's `tempdir()` was used which points to the common `tempdir` folder which creates a conflict when multiple tests run (since the same Rocks db file will try to be locked). The crate https://crates.io/crates/tempfile has been used instead (as we do in other parts of the codebase) to create a temporary tempdirs and use those to initialise the test Rocksdb databases. 

Unfortunately I can't really confirm whether this is actually fixing the reported issue, since I couldn't reproduce neither locally nor in CI, but based on the setup I believe that this was the root cause of the issue.