### PR TITLE
[get_collections] fetch missing collections - implement must-block protocol for certificates

### DIFF
--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -93,6 +93,32 @@ pub struct Parameters {
     /// The delay after which the workers seal a batch of transactions, even if `max_batch_size`
     /// is not reached. Denominated in ms.
     pub max_batch_delay: u64,
+    /// The parameters for the block synchronizer
+    pub block_synchronizer: BlockSynchronizerParameters,
+}
+
+#[derive(Deserialize, Clone)]
+pub struct BlockSynchronizerParameters {
+    /// The timeout configuration when requesting certificates from peers.
+    /// Denominated in milliseconds.
+    pub certificates_synchronize_timeout_ms: u64,
+    /// Timeout when has requested the payload for a certificate and is
+    /// waiting to receive them. Denominated in milliseconds.
+    pub payload_synchronize_timeout_ms: u64,
+    /// The timeout configuration when for when we ask the other peers to
+    /// discover who has the payload available for the dictated certificates.
+    /// Denominated in milliseconds.
+    pub payload_availability_timeout_ms: u64,
+}
+
+impl Default for BlockSynchronizerParameters {
+    fn default() -> Self {
+        Self {
+            certificates_synchronize_timeout_ms: 2_000,
+            payload_synchronize_timeout_ms: 2_000,
+            payload_availability_timeout_ms: 2_000,
+        }
+    }
 }
 
 impl Default for Parameters {
@@ -105,6 +131,7 @@ impl Default for Parameters {
             sync_retry_nodes: 3,
             batch_size: 500_000,
             max_batch_delay: 100,
+            block_synchronizer: BlockSynchronizerParameters::default(),
         }
     }
 }
@@ -118,6 +145,18 @@ impl Parameters {
         info!("Sync retry nodes set to {} nodes", self.sync_retry_nodes);
         info!("Batch size set to {} B", self.batch_size);
         info!("Max batch delay set to {} ms", self.max_batch_delay);
+        info!(
+            "Synchronize certificates timeout set to {} ms",
+            self.block_synchronizer.certificates_synchronize_timeout_ms
+        );
+        info!(
+            "Payload (batches) availability timeout set to {} ms",
+            self.block_synchronizer.payload_availability_timeout_ms
+        );
+        info!(
+            "Synchronize payload (batches) timeout set to {} ms",
+            self.block_synchronizer.payload_synchronize_timeout_ms
+        );
     }
 }
 

--- a/primary/Cargo.toml
+++ b/primary/Cargo.toml
@@ -23,13 +23,13 @@ thiserror = "1.0.30"
 tokio = { version = "1.17.0", features = ["sync", "rt", "macros"] }
 tokio-util = { version = "0.7.1", features = ["codec"] }
 tracing = { version = "0.1.34", features = ["log"] }
+rand = { version = "0.7.3", features = ["small_rng"] }
 
 crypto = { path = "../crypto" }
 network = { path = "../network" }
 types = { path = "../types" }
 
 [dev-dependencies]
-rand = "0.7.3"
 tempfile = "3.3.0"
 types = { path = "../types", features = ["test"] }
 

--- a/primary/src/block_synchronizer/mod.rs
+++ b/primary/src/block_synchronizer/mod.rs
@@ -343,7 +343,7 @@ impl<PublicKey: VerifyingKey> BlockSynchronizer<PublicKey> {
             return None;
         }
 
-        let key: RequestID = certificates_to_sync.iter().collect();
+        let key = RequestID::from_iter(certificates_to_sync.iter());
 
         let message = PrimaryMessage::<PublicKey>::PayloadAvailabilityRequest {
             certificate_ids: block_ids_to_sync,
@@ -401,7 +401,7 @@ impl<PublicKey: VerifyingKey> BlockSynchronizer<PublicKey> {
             return None;
         }
 
-        let key: RequestID = to_sync.iter().collect();
+        let key = RequestID::from_iter(to_sync.iter());
 
         let message = PrimaryMessage::<PublicKey>::CertificatesBatchRequest {
             certificate_ids: block_ids,

--- a/primary/src/block_synchronizer/mod.rs
+++ b/primary/src/block_synchronizer/mod.rs
@@ -1,0 +1,800 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use crate::{
+    block_synchronizer::{
+        peers::Peers,
+        responses::{CertificatesResponse, PayloadAvailabilityResponse, RequestID},
+        PendingIdentifier::{Header, Payload},
+    },
+    primary::PrimaryMessage,
+    utils, PayloadToken, PrimaryWorkerMessage,
+};
+use bytes::Bytes;
+use config::{BlockSynchronizerParameters, Committee, WorkerId};
+use crypto::{traits::VerifyingKey, Hash};
+use futures::{
+    future::{join_all, BoxFuture},
+    stream::FuturesUnordered,
+    FutureExt, StreamExt,
+};
+use network::SimpleSender;
+use rand::{rngs::SmallRng, SeedableRng};
+use std::{collections::HashMap, time::Duration};
+use store::Store;
+use thiserror::Error;
+use tokio::{
+    sync::mpsc::{channel, Receiver, Sender},
+    time::{sleep, timeout},
+};
+use tracing::log::{debug, error, warn};
+use types::{BatchDigest, Certificate, CertificateDigest};
+
+#[cfg(test)]
+#[path = "tests/block_synchronizer_tests.rs"]
+mod block_synchronizer_tests;
+mod peers;
+mod responses;
+
+/// The minimum percentage
+/// (number of responses received from primary nodes / number of requests sent to primary nodes)
+/// that should be reached when requesting the certificates from peers in order to
+/// proceed to next state.
+const CERTIFICATE_RESPONSES_RATIO_THRESHOLD: f32 = 0.5;
+
+type ResultSender<T> = Sender<BlockSynchronizeResult<Certificate<T>>>;
+type BlockSynchronizeResult<T> = Result<T, SyncError>;
+
+pub enum Command<PublicKey: VerifyingKey> {
+    #[allow(dead_code)]
+    /// A request to synchronize and output the block headers
+    /// This will not perform any attempt to fetch the header's
+    /// batches. This component does NOT check whether the
+    /// requested block_ids are already synchronized. This is the
+    /// consumer's responsibility.
+    SynchronizeBlockHeaders {
+        block_ids: Vec<CertificateDigest>,
+        respond_to: ResultSender<PublicKey>,
+    },
+    /// A request to synchronize the payload (batches) of the
+    /// provided certificates. The certificates are needed in
+    /// order to know which batches to ask from the peers
+    /// to sync and from which workers.
+    /// TODO: We expect to change how batches are stored and
+    /// represended (see https://github.com/MystenLabs/narwhal/issues/54
+    /// and https://github.com/MystenLabs/narwhal/issues/150 )
+    /// and this might relax the requirement to need certificates here.
+    ///
+    /// This component does NOT check whether the
+    //  requested block_ids are already synchronized. This is the
+    //  consumer's responsibility.
+    #[allow(dead_code)]
+    SynchronizeBlockPayload {
+        certificates: Vec<Certificate<PublicKey>>,
+        respond_to: ResultSender<PublicKey>,
+    },
+}
+
+// Those states are used for internal purposes only for the component.
+// We are implementing a very very naive state machine and go get from
+// one state to the other those commands are being used.
+enum State<PublicKey: VerifyingKey> {
+    HeadersSynchronized {
+        request_id: RequestID,
+        certificates: HashMap<CertificateDigest, Result<Certificate<PublicKey>, SyncError>>,
+    },
+    PayloadAvailabilityReceived {
+        request_id: RequestID,
+        certificates: HashMap<CertificateDigest, Result<Certificate<PublicKey>, SyncError>>,
+        peers: Peers<PublicKey, Certificate<PublicKey>>,
+    },
+    PayloadSynchronized {
+        request_id: RequestID,
+        result: Result<Certificate<PublicKey>, SyncError>,
+    },
+}
+
+#[derive(Debug, Error, Copy, Clone)]
+pub enum SyncError {
+    #[error("Block with id {block_id} could not be retrieved")]
+    Error { block_id: CertificateDigest },
+
+    #[error("Block with id {block_id} could not be retrieved, timeout while retrieving result")]
+    Timeout { block_id: CertificateDigest },
+}
+
+impl SyncError {
+    #[allow(dead_code)]
+    pub fn block_id(&self) -> CertificateDigest {
+        match *self {
+            SyncError::Error { block_id } | SyncError::Timeout { block_id } => block_id,
+        }
+    }
+}
+
+#[derive(Hash, Eq, PartialEq, Clone, Copy)]
+enum PendingIdentifier {
+    Header(CertificateDigest),
+    Payload(CertificateDigest),
+}
+
+impl PendingIdentifier {
+    #[allow(dead_code)]
+    fn id(&self) -> CertificateDigest {
+        match self {
+            PendingIdentifier::Header(id) | PendingIdentifier::Payload(id) => *id,
+        }
+    }
+}
+
+pub struct BlockSynchronizer<PublicKey: VerifyingKey> {
+    /// The public key of this primary.
+    name: PublicKey,
+
+    /// The committee information.
+    committee: Committee<PublicKey>,
+
+    /// Receive the commands for the synchronizer
+    rx_commands: Receiver<Command<PublicKey>>,
+
+    /// Receive the requested list of certificates through this channel
+    rx_certificate_responses: Receiver<CertificatesResponse<PublicKey>>,
+
+    /// Receive the availability for the requested certificates through this
+    /// channel
+    rx_payload_availability_responses: Receiver<PayloadAvailabilityResponse<PublicKey>>,
+
+    /// Pending block requests either for header or payload type
+    pending_requests: HashMap<PendingIdentifier, Vec<ResultSender<PublicKey>>>,
+
+    /// Requests managers
+    map_certificate_responses_senders: HashMap<RequestID, Sender<CertificatesResponse<PublicKey>>>,
+
+    /// Holds the senders to match a batch_availability responses
+    map_payload_availability_responses_senders:
+        HashMap<RequestID, Sender<PayloadAvailabilityResponse<PublicKey>>>,
+
+    /// Send network requests
+    network: SimpleSender,
+
+    /// The persistent storage for payload markers from workers
+    payload_store: Store<(BatchDigest, WorkerId), PayloadToken>,
+
+    /// Timeout when synchronizing the certificates
+    certificates_synchronize_timeout: Duration,
+
+    /// Timeout when synchronizing the payload
+    payload_synchronize_timeout: Duration,
+
+    /// Timeout when has requested the payload and waiting to receive
+    payload_availability_timeout: Duration,
+}
+
+impl<PublicKey: VerifyingKey> BlockSynchronizer<PublicKey> {
+    pub fn spawn(
+        name: PublicKey,
+        committee: Committee<PublicKey>,
+        rx_commands: Receiver<Command<PublicKey>>,
+        rx_certificate_responses: Receiver<CertificatesResponse<PublicKey>>,
+        rx_payload_availability_responses: Receiver<PayloadAvailabilityResponse<PublicKey>>,
+        network: SimpleSender,
+        payload_store: Store<(BatchDigest, WorkerId), PayloadToken>,
+        parameters: BlockSynchronizerParameters,
+    ) {
+        tokio::spawn(async move {
+            Self {
+                name,
+                committee,
+                rx_commands,
+                rx_certificate_responses,
+                rx_payload_availability_responses,
+                pending_requests: HashMap::new(),
+                map_certificate_responses_senders: HashMap::new(),
+                map_payload_availability_responses_senders: HashMap::new(),
+                network,
+                payload_store,
+                certificates_synchronize_timeout: Duration::from_millis(
+                    parameters.certificates_synchronize_timeout_ms,
+                ),
+                payload_synchronize_timeout: Duration::from_millis(
+                    parameters.payload_availability_timeout_ms,
+                ),
+                payload_availability_timeout: Duration::from_millis(
+                    parameters.payload_availability_timeout_ms,
+                ),
+            }
+            .run()
+            .await;
+        });
+    }
+
+    pub async fn run(&mut self) {
+        // Waiting is holding futures which are an outcome of processing
+        // of other methods, which we want to asynchronously handle them.
+        // We expect every future included in this list to produce an
+        // outcome of the "next state" to be executed - see the State enum.
+        // That allows us to implement a naive state machine mechanism and
+        // pass freely arbitrary data across those states for further
+        // processing.
+        let mut waiting = FuturesUnordered::new();
+
+        loop {
+            tokio::select! {
+                Some(command) = self.rx_commands.recv() => {
+                    match command {
+                        Command::SynchronizeBlockHeaders { block_ids, respond_to } => {
+                            let fut = self.handle_synchronize_block_headers_command(block_ids, respond_to).await;
+                            if fut.is_some() {
+                                waiting.push(fut.unwrap());
+                            }
+                        },
+                        Command::SynchronizeBlockPayload { certificates, respond_to } => {
+                            let fut = self.handle_synchronize_block_payload_command(certificates, respond_to).await;
+                            if fut.is_some() {
+                                waiting.push(fut.unwrap());
+                            }
+                        }
+                    }
+                },
+                Some(response) = self.rx_certificate_responses.recv() => {
+                    self.handle_certificates_response(response).await;
+                },
+                Some(response) = self.rx_payload_availability_responses.recv() => {
+                    self.handle_payload_availability_response(response).await;
+                },
+                Some(state) = waiting.next() => {
+                    match state {
+                        State::HeadersSynchronized { request_id, certificates } => {
+                            debug!("Result for the block headers synchronize request id {}", request_id);
+
+                            for (id, result) in certificates {
+                                self.notify_requestors_for_result(Header(id), result).await;
+                            }
+                        },
+                        State::PayloadAvailabilityReceived { request_id, certificates, peers } => {
+                             debug!("Result for the block payload synchronize request id {}", request_id);
+
+                            // now try to synchronise the payload only for the ones that have been found
+                            let futures = self.handle_synchronize_block_payloads(request_id, peers).await;
+                            for fut in futures {
+                                waiting.push(fut);
+                            }
+
+                            // notify immediately for block_ids that have been errored or timedout
+                            for (id, result) in certificates {
+                                if result.is_err() {
+                                    self.notify_requestors_for_result(Payload(id), result).await;
+                                }
+                            }
+                        },
+                        State::PayloadSynchronized { request_id, result } => {
+                            let id = result.as_ref().map_or_else(|e| e.block_id(), |r| r.digest());
+
+                            debug!("Block payload synchronize result received for certificate id {id} for request id {request_id}");
+
+                            self.notify_requestors_for_result(Payload(id), result).await;
+                        },
+                    }
+                }
+            }
+        }
+    }
+
+    async fn notify_requestors_for_result(
+        &mut self,
+        request: PendingIdentifier,
+        result: BlockSynchronizeResult<Certificate<PublicKey>>,
+    ) {
+        // remove the senders & broadcast result
+        if let Some(respond_to) = self.pending_requests.remove(&request) {
+            let futures: Vec<_> = respond_to.iter().map(|s| s.send(result.clone())).collect();
+
+            for r in join_all(futures).await {
+                if r.is_err() {
+                    error!("Couldn't send message to channel [{:?}]", r.err().unwrap());
+                }
+            }
+        }
+    }
+
+    // Helper method to mark a request as pending. It returns true if it is the
+    // first request for this identifier, otherwise false is returned instead.
+    fn resolve_pending_request(
+        &mut self,
+        identifier: PendingIdentifier,
+        respond_to: ResultSender<PublicKey>,
+    ) -> bool {
+        // add our self anyways to a pending request, as we don't expect to
+        // fail down the line of this method (unless crash)
+        let e = self.pending_requests.entry(identifier).or_default();
+        e.push(respond_to);
+
+        e.len() == 1
+    }
+
+    /// This method handles the command to synchronize the payload of the
+    /// provided certificates. It finds for which certificates we don't
+    /// have an already pending request and broadcasts a message to all
+    /// the primary peer nodes to scout which ones have and are able to send
+    /// us the payload. It returns a future which is responsible to run the
+    /// logic of waiting and gathering the replies from the primary nodes
+    /// for the payload availability. This future is returning the next State
+    /// to be executed.
+    async fn handle_synchronize_block_payload_command<'a>(
+        &mut self,
+        certificates: Vec<Certificate<PublicKey>>,
+        respond_to: ResultSender<PublicKey>,
+    ) -> Option<BoxFuture<'a, State<PublicKey>>> {
+        let mut certificates_to_sync = Vec::new();
+        let mut block_ids_to_sync = Vec::new();
+
+        for certificate in certificates.clone() {
+            let block_id = certificate.digest();
+
+            if self.resolve_pending_request(Payload(block_id), respond_to.clone()) {
+                certificates_to_sync.push(certificate);
+                block_ids_to_sync.push(block_id);
+            } else {
+                debug!("Nothing to request here, it's already in pending state");
+            }
+        }
+
+        // nothing new to sync! just return
+        if certificates_to_sync.is_empty() {
+            return None;
+        }
+
+        let key: RequestID = certificates_to_sync.iter().collect();
+
+        let message = PrimaryMessage::<PublicKey>::PayloadAvailabilityRequest {
+            certificate_ids: block_ids_to_sync,
+            requestor: self.name.clone(),
+        };
+
+        // broadcast the message to fetch  the certificates
+        let primaries = self.broadcast_batch_request(message).await;
+
+        let (sender, receiver) = channel(primaries.as_slice().len());
+
+        // record the request key to forward the results to the dedicated sender
+        self.map_payload_availability_responses_senders
+            .insert(key, sender);
+
+        // now create the future that will wait to gather the responses
+        Some(
+            Self::wait_for_payload_availability_responses(
+                self.payload_availability_timeout,
+                key,
+                certificates_to_sync,
+                primaries,
+                receiver,
+            )
+            .boxed(),
+        )
+    }
+
+    /// This method handles the command to synchronize the headers
+    /// (certificates) for the provided ids. It is deduping the ids for which
+    /// it already has a pending request and for the rest is broadcasting a
+    /// message to the other peer nodes to fetch the request certificates, if
+    /// available. We expect each peer node to respond with the actual
+    /// certificates that has available. The method returns a future that is
+    /// running the process of waiting to gather the node responses and
+    /// emit the result as the next State to be executed.
+    async fn handle_synchronize_block_headers_command<'a>(
+        &mut self,
+        block_ids: Vec<CertificateDigest>,
+        respond_to: ResultSender<PublicKey>,
+    ) -> Option<BoxFuture<'a, State<PublicKey>>> {
+        let mut to_sync = Vec::new();
+        // a new request to synchronise blocks
+        // check if there are pending requests. If yes, then ignore
+        for block_id in block_ids.clone() {
+            if self.resolve_pending_request(Header(block_id), respond_to.clone()) {
+                to_sync.push(block_id);
+            } else {
+                debug!("Nothing to request here, it's already in pending state");
+            }
+        }
+
+        // nothing new to sync! just return
+        if to_sync.is_empty() {
+            return None;
+        }
+
+        let key: RequestID = to_sync.iter().collect();
+
+        let message = PrimaryMessage::<PublicKey>::CertificatesBatchRequest {
+            certificate_ids: block_ids,
+            requestor: self.name.clone(),
+        };
+
+        // broadcast the message to fetch  the certificates
+        let primaries = self.broadcast_batch_request(message).await;
+
+        let (sender, receiver) = channel(primaries.as_slice().len());
+
+        // record the request key to forward the results to the dedicated sender
+        self.map_certificate_responses_senders.insert(key, sender);
+
+        // now create the future that will wait to gather the responses
+        Some(
+            Self::wait_for_certificate_responses(
+                self.certificates_synchronize_timeout,
+                key,
+                self.committee.clone(),
+                to_sync,
+                primaries,
+                receiver,
+            )
+            .boxed(),
+        )
+    }
+
+    // Broadcasts a message to all the other primary nodes.
+    // It returns back the primary names to which we have sent the requests.
+    async fn broadcast_batch_request(
+        &mut self,
+        message: PrimaryMessage<PublicKey>,
+    ) -> Vec<PublicKey> {
+        // Naively now just broadcast the request to all the primaries
+        let bytes = bincode::serialize(&message).expect("Failed to serialize request");
+
+        let primaries_addresses = self.committee.others_primaries(&self.name);
+
+        self.network
+            .broadcast(
+                primaries_addresses
+                    .clone()
+                    .into_iter()
+                    .map(|(_, address)| address.primary_to_primary)
+                    .collect(),
+                Bytes::from(bytes),
+            )
+            .await;
+
+        primaries_addresses
+            .into_iter()
+            .map(|(name, _)| name)
+            .collect()
+    }
+
+    async fn handle_synchronize_block_payloads<'a>(
+        &mut self,
+        request_id: RequestID,
+        mut peers: Peers<PublicKey, Certificate<PublicKey>>,
+    ) -> Vec<BoxFuture<'a, State<PublicKey>>> {
+        // Important step to do that first, so we give the opportunity
+        // to other future requests (with same set of ids) making a request.
+        self.map_payload_availability_responses_senders
+            .remove(&request_id);
+
+        // Rebalance the CertificateDigests to ensure that
+        // those are uniquely distributed across the peers.
+        peers.rebalance_values();
+
+        for peer in peers.peers().values() {
+            self.send_synchronize_payload_requests(peer.clone().name, peer.assigned_values())
+                .await
+        }
+
+        peers
+            .unique_values()
+            .into_iter()
+            .map(|certificate| {
+                Self::wait_for_block_payload(
+                    self.payload_synchronize_timeout,
+                    request_id,
+                    self.payload_store.clone(),
+                    certificate,
+                )
+                .boxed()
+            })
+            .collect()
+    }
+
+    /// This method sends the necessary requests to the worker nodes to
+    /// synchronize the missing batches. The batches will be synchronized
+    /// from the dictated primary_peer_name.
+    ///
+    /// # Arguments
+    ///
+    /// * `primary_peer_name` - The primary from which we are looking to sync the batches.
+    /// * `certificates` - The certificates for which we want to sync their batches.
+    async fn send_synchronize_payload_requests(
+        &mut self,
+        primary_peer_name: PublicKey,
+        certificates: Vec<Certificate<PublicKey>>,
+    ) {
+        let batches_by_worker = utils::map_certificate_batches_by_worker(certificates.as_slice());
+
+        for (worker_id, batch_ids) in batches_by_worker {
+            let worker_address = self
+                .committee
+                .worker(&self.name, &worker_id)
+                .expect("Worker id not found")
+                .primary_to_worker;
+
+            let message = PrimaryWorkerMessage::Synchronize(batch_ids, primary_peer_name.clone());
+            let bytes =
+                bincode::serialize(&message).expect("Failed to serialize batch sync request");
+            self.network.send(worker_address, Bytes::from(bytes)).await;
+        }
+    }
+
+    async fn wait_for_block_payload<'a>(
+        payload_synchronize_timeout: Duration,
+        request_id: RequestID,
+        payload_store: Store<(BatchDigest, WorkerId), PayloadToken>,
+        certificate: Certificate<PublicKey>,
+    ) -> State<PublicKey> {
+        let futures = certificate
+            .header
+            .payload
+            .iter()
+            .map(|(batch_digest, worker_id)| payload_store.notify_read((*batch_digest, *worker_id)))
+            .collect::<Vec<_>>();
+
+        // Wait for all the items to sync - have a timeout
+        let result = timeout(payload_synchronize_timeout, join_all(futures)).await;
+        if result.is_err()
+            || result
+                .unwrap()
+                .into_iter()
+                .any(|r| r.map_or_else(|_| true, |f| f.is_none()))
+        {
+            return State::PayloadSynchronized {
+                request_id,
+                result: Err(SyncError::Timeout {
+                    block_id: certificate.digest(),
+                }),
+            };
+        }
+
+        State::PayloadSynchronized {
+            request_id,
+            result: Ok(certificate),
+        }
+    }
+
+    async fn handle_payload_availability_response(
+        &mut self,
+        response: PayloadAvailabilityResponse<PublicKey>,
+    ) {
+        let sender = self
+            .map_payload_availability_responses_senders
+            .get(&response.request_id());
+
+        if let Some(s) = sender {
+            if let Err(e) = s.send(response).await {
+                error!("Could not send the response to the sender {:?}", e);
+            }
+        } else {
+            warn!("Couldn't find a sender to channel the response. Will drop the message.");
+        }
+    }
+
+    async fn handle_certificates_response(&mut self, response: CertificatesResponse<PublicKey>) {
+        let sender = self
+            .map_certificate_responses_senders
+            .get(&response.request_id());
+
+        if let Some(s) = sender {
+            if let Err(e) = s.send(response).await {
+                error!("Could not send the response to the sender {:?}", e);
+            }
+        } else {
+            warn!("Couldn't find a sender to channel the response. Will drop the message.");
+        }
+    }
+
+    async fn wait_for_certificate_responses(
+        fetch_certificates_timeout: Duration,
+        request_id: RequestID,
+        committee: Committee<PublicKey>,
+        block_ids: Vec<CertificateDigest>,
+        primaries_sent_requests_to: Vec<PublicKey>,
+        mut receiver: Receiver<CertificatesResponse<PublicKey>>,
+    ) -> State<PublicKey> {
+        let total_expected_certificates = block_ids.len();
+        let mut num_of_responses: u32 = 0;
+        let num_of_requests_sent: u32 = primaries_sent_requests_to.len() as u32;
+
+        let timer = sleep(fetch_certificates_timeout);
+        tokio::pin!(timer);
+
+        let mut peers = Peers::<PublicKey, Certificate<PublicKey>>::new(SmallRng::from_entropy());
+
+        loop {
+            tokio::select! {
+                Some(response) = receiver.recv() => {
+                    if peers.contains_peer(&response.from) {
+                        // skip , we already got an answer from this peer
+                        continue;
+                    }
+
+                    // check whether the peer is amongst the one we are expecting
+                    // response from. That shouldn't really happen, since the
+                    // responses we get are filtered by the request id, but still
+                    // worth double checking
+                    if !primaries_sent_requests_to.iter().any(|p|p.eq(&response.from)) {
+                        continue;
+                    }
+
+                    num_of_responses += 1;
+
+                    match response.validate_certificates(&committee) {
+                        Ok(certificates) => {
+                            // Ensure we got responses for the certificates we asked for.
+                            // Even if we have found one certificate that doesn't match
+                            // we reject the payload - it shouldn't happen.
+                            if certificates.iter().any(|c|!block_ids.contains(&c.digest())) {
+                                continue;
+                            }
+
+                            // add them as a new peer
+                            peers.add_peer(response.from.clone(), certificates);
+
+                            // We have received all possible responses
+                            if (peers.unique_values().len() == total_expected_certificates &&
+                            Self::reached_response_ratio(num_of_responses, num_of_requests_sent))
+                            || num_of_responses == num_of_requests_sent
+                            {
+                                let result = Self::resolve_block_synchronize_result(&peers, block_ids, false);
+
+                                return State::HeadersSynchronized {
+                                    request_id,
+                                    certificates: result,
+                                };
+                            }
+                        },
+                        Err(_) => {
+                            warn!("Got invalid certificates from peer");
+                        }
+                    }
+                },
+                () = &mut timer => {
+                    let result = Self::resolve_block_synchronize_result(&peers, block_ids, true);
+
+                    return State::HeadersSynchronized {
+                        request_id,
+                        certificates: result,
+                    };
+                }
+            }
+        }
+    }
+
+    async fn wait_for_payload_availability_responses(
+        fetch_certificates_timeout: Duration,
+        request_id: RequestID,
+        certificates: Vec<Certificate<PublicKey>>,
+        primaries_sent_requests_to: Vec<PublicKey>,
+        mut receiver: Receiver<PayloadAvailabilityResponse<PublicKey>>,
+    ) -> State<PublicKey> {
+        let total_expected_block_ids = certificates.len();
+        let mut num_of_responses: u32 = 0;
+        let num_of_requests_sent: u32 = primaries_sent_requests_to.len() as u32;
+        let certificates_by_id: HashMap<CertificateDigest, Certificate<PublicKey>> = certificates
+            .iter()
+            .map(|c| (c.digest(), c.clone()))
+            .collect();
+        let block_ids: Vec<CertificateDigest> = certificates_by_id
+            .iter()
+            .map(|(id, _)| id.to_owned())
+            .collect();
+
+        let timer = sleep(fetch_certificates_timeout);
+        tokio::pin!(timer);
+
+        let mut peers = Peers::<PublicKey, Certificate<PublicKey>>::new(SmallRng::from_entropy());
+
+        loop {
+            tokio::select! {
+                Some(response) = receiver.recv() => {
+                    if peers.contains_peer(&response.from) {
+                        // skip , we already got an answer from this peer
+                        continue;
+                    }
+
+                    // check whether the peer is amongst the one we are expecting
+                    // response from. That shouldn't really happen, since the
+                    // responses we get are filtered by the request id, but still
+                    // worth double checking
+                    if !primaries_sent_requests_to.iter().any(|p|p.eq(&response.from)) {
+                        continue;
+                    }
+
+                    num_of_responses += 1;
+
+                    // Ensure we got responses for the certificates we asked for.
+                    // Even if we have found one certificate that doesn't match
+                    // we reject the payload - it shouldn't happen. Also, add the
+                    // found ones in a vector.
+                    let mut available_certs_for_peer = Vec::new();
+                    for id in response.available_block_ids() {
+                        if let Some(c) = certificates_by_id.get(&id) {
+                            available_certs_for_peer.push(c.clone());
+                        } else {
+                            // We should expect to have found every
+                            // responded id to our list of certificates.
+                            continue;
+                        }
+                    }
+
+                    // add them as a new peer
+                    peers.add_peer(response.from.clone(), available_certs_for_peer);
+
+                    // We have received all possible responses
+                    if (peers.unique_values().len() == total_expected_block_ids &&
+                    Self::reached_response_ratio(num_of_responses, num_of_requests_sent))
+                    || num_of_responses == num_of_requests_sent
+                    {
+                        let result = Self::resolve_block_synchronize_result(&peers, block_ids, false);
+
+                        return State::PayloadAvailabilityReceived {
+                            request_id,
+                            certificates: result,
+                            peers,
+                        };
+                    }
+                },
+                () = &mut timer => {
+                    let result = Self::resolve_block_synchronize_result(&peers, block_ids, true);
+
+                    return State::PayloadAvailabilityReceived {
+                        request_id,
+                        certificates: result,
+                        peers,
+                    };
+                }
+            }
+        }
+    }
+
+    // It creates a map which holds for every expected block_id the corresponding
+    // result. The actually found certificates are hold inside the provided peers
+    // structure where for each peer (primary node) we keep the certificates that
+    // is able to serve. We reduce those to unique values (certificates) and
+    // produce the map. If a certificate has not been found amongst the ones
+    // that the peers can serve, then an error SyncError is produced for it. The
+    // error type changes according to the provided `timeout` value. If is true,
+    // the it means that the maximum time reached when waiting to get the results
+    // from the required peers. In this case the error result will be a Timeout.
+    // Otherwise it will be an Error. The outcome map can be used then to
+    // communicate the result for each requested certificate (if found, then
+    // certificate it self , or if error then the type of the error).
+    fn resolve_block_synchronize_result(
+        peers: &Peers<PublicKey, Certificate<PublicKey>>,
+        block_ids: Vec<CertificateDigest>,
+        timeout: bool,
+    ) -> HashMap<CertificateDigest, Result<Certificate<PublicKey>, SyncError>> {
+        let mut certificates_by_id: HashMap<CertificateDigest, Certificate<PublicKey>> = peers
+            .unique_values()
+            .into_iter()
+            .map(|c| (c.digest(), c))
+            .collect();
+
+        let mut result: HashMap<CertificateDigest, Result<Certificate<PublicKey>, SyncError>> =
+            HashMap::new();
+
+        for block_id in block_ids {
+            // if not found, then this is an Error - couldn't be retrieved
+            // by any peer - suspicious!
+            if let Some(certificate) = certificates_by_id.remove(&block_id) {
+                result.insert(block_id, Ok(certificate));
+            } else if timeout {
+                result.insert(block_id, Err(SyncError::Timeout { block_id }));
+            } else {
+                result.insert(block_id, Err(SyncError::Error { block_id }));
+            }
+        }
+
+        result
+    }
+
+    fn reached_response_ratio(num_of_responses: u32, num_of_expected_responses: u32) -> bool {
+        let ratio: f32 =
+            ((num_of_responses as f32 / num_of_expected_responses as f32) * 100.0).round();
+        ratio >= CERTIFICATE_RESPONSES_RATIO_THRESHOLD * 100.0
+    }
+}

--- a/primary/src/block_synchronizer/peers.rs
+++ b/primary/src/block_synchronizer/peers.rs
@@ -1,0 +1,414 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use crypto::{traits::VerifyingKey, Hash};
+use rand::{prelude::SliceRandom as _, rngs::SmallRng};
+use std::collections::HashMap;
+
+#[derive(Clone)]
+pub struct Peer<PublicKey: VerifyingKey, Value: Hash + Clone> {
+    pub name: PublicKey,
+
+    /// Those are the values that we got from the peer and that is able
+    /// to serve.
+    pub values_able_to_serve: HashMap<<Value as Hash>::TypedDigest, Value>,
+
+    /// Those are the assigned values after a re-balancing event
+    assigned_values: HashMap<<Value as Hash>::TypedDigest, Value>,
+}
+
+impl<PublicKey: VerifyingKey, Value: Hash + Clone> Peer<PublicKey, Value> {
+    pub fn new(name: PublicKey, values_able_to_serve: Vec<Value>) -> Self {
+        let certs: HashMap<<Value as crypto::Hash>::TypedDigest, Value> = values_able_to_serve
+            .into_iter()
+            .map(|c| (c.digest(), c))
+            .collect();
+
+        Peer {
+            name,
+            values_able_to_serve: certs,
+            assigned_values: HashMap::new(),
+        }
+    }
+
+    pub fn assign_values(&mut self, certificate: Value) {
+        self.assigned_values
+            .insert(certificate.digest(), certificate);
+    }
+
+    pub fn assigned_values(&self) -> Vec<Value> {
+        self.assigned_values.values().cloned().collect()
+    }
+}
+
+/// A helper structure to allow us store the peer result values
+/// and redistribute the common ones between them evenly.
+/// The implementation is NOT considered thread safe. Especially
+/// the re-balancing process is not guaranteed to be atomic and
+/// thread safe which could lead to potential issues if used in
+/// such environment.
+pub struct Peers<PublicKey: VerifyingKey, Value: Hash + Clone> {
+    /// A map with all the peers assigned on this pool.
+    peers: HashMap<PublicKey, Peer<PublicKey, Value>>,
+
+    /// When true, it means that the values have been assigned to peers and no
+    /// more mutating operations can be applied
+    rebalanced: bool,
+
+    /// Keeps all the unique values in the map so we don't
+    /// have to recompute every time they are needed by
+    /// iterating over the peers.
+    unique_values: HashMap<<Value as Hash>::TypedDigest, Value>,
+
+    /// An rng used to shuffle the list of peers
+    rng: SmallRng,
+}
+
+impl<PublicKey: VerifyingKey, Value: Hash + Clone> Peers<PublicKey, Value> {
+    pub fn new(rng: SmallRng) -> Self {
+        Self {
+            peers: HashMap::new(),
+            unique_values: HashMap::new(),
+            rebalanced: false,
+            rng,
+        }
+    }
+
+    pub fn peers(&self) -> &HashMap<PublicKey, Peer<PublicKey, Value>> {
+        &self.peers
+    }
+
+    pub fn unique_values(&self) -> Vec<Value> {
+        self.unique_values.values().cloned().collect()
+    }
+
+    pub fn contains_peer(&mut self, name: &PublicKey) -> bool {
+        self.peers.contains_key(name)
+    }
+
+    pub fn add_peer(&mut self, name: PublicKey, available_values: Vec<Value>) {
+        self.ensure_not_rebalanced();
+
+        // update the unique values
+        for value in &available_values {
+            self.unique_values.insert(value.digest(), value.to_owned());
+        }
+
+        self.peers
+            .insert(name.clone(), Peer::new(name, available_values));
+    }
+
+    /// Re-distributes the values to the peers in a load balanced manner.
+    /// We expect to have duplicates across the peers. The goal is in the end
+    /// for each peer to have a unique list of values and those lists to
+    /// not differ significantly in length, so we balance the load.
+    /// Once the peers are rebalanced, then no other operation that mutates
+    /// the struct is allowed.
+    pub fn rebalance_values(&mut self) {
+        self.ensure_not_rebalanced();
+
+        let values = self.unique_values();
+
+        for v in values {
+            self.reassign_value(v);
+        }
+
+        self.rebalanced = true;
+    }
+
+    fn reassign_value(&mut self, value: Value) {
+        let id = value.digest();
+        let mut peer = self.peer_to_assign_value(id);
+
+        peer.assign_values(value);
+
+        self.peers.insert((&peer.name).clone(), peer);
+
+        self.delete_values_from_peers(id);
+    }
+
+    /// Finds a peer to assign the value identified by the provided `id`.
+    /// This method will perform two operations:
+    /// 1) Will filter only the peers that value dictated by the
+    /// provided `value_id`
+    /// 2) Will pick a peer in random to assign the value to
+    fn peer_to_assign_value(
+        &mut self,
+        value_id: <Value as Hash>::TypedDigest,
+    ) -> Peer<PublicKey, Value> {
+        // step 1 - find the peers who have this id
+        let peers_with_value: Vec<Peer<PublicKey, Value>> = self
+            .peers
+            .iter()
+            .filter(|p| p.1.values_able_to_serve.contains_key(&value_id))
+            .map(|p| p.1.clone())
+            .collect();
+
+        // step 2 - pick at random a peer to assign the value.
+        // For now we consider this good enough and we avoid doing any
+        // explicit client-side load balancing as this should be tackled
+        // on the server-side via demand control.
+        if let Some(peer) = peers_with_value.choose(&mut self.rng) {
+            peer.to_owned()
+        } else {
+            panic!("At least one peer should be available when trying to assign a value!");
+        }
+    }
+
+    // Deletes the value identified by the provided id from the list of
+    // available values from all the peers.
+    fn delete_values_from_peers(&mut self, id: <Value as Hash>::TypedDigest) {
+        for (_, peer) in self.peers.iter_mut() {
+            peer.values_able_to_serve.remove(&id);
+        }
+    }
+
+    fn ensure_not_rebalanced(&mut self) {
+        debug_assert!(
+            !self.rebalanced,
+            "rebalance has been called, this operation is not allowed"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::block_synchronizer::peers::Peers;
+    use blake2::{digest::Update, VarBlake2b};
+    use crypto::{
+        ed25519::{Ed25519KeyPair, Ed25519PublicKey},
+        traits::KeyPair,
+        Digest, Hash, DIGEST_LEN,
+    };
+    use rand::{
+        rngs::{SmallRng, StdRng},
+        SeedableRng,
+    };
+    use std::{
+        borrow::Borrow,
+        collections::{HashMap, HashSet},
+        fmt,
+    };
+
+    #[test]
+    fn test_assign_certificates_to_peers_when_all_respond() {
+        struct TestCase {
+            num_of_certificates: u8,
+            num_of_peers: u8,
+        }
+
+        let test_cases: Vec<TestCase> = vec![
+            TestCase {
+                num_of_certificates: 5,
+                num_of_peers: 4,
+            },
+            TestCase {
+                num_of_certificates: 8,
+                num_of_peers: 2,
+            },
+            TestCase {
+                num_of_certificates: 3,
+                num_of_peers: 2,
+            },
+            TestCase {
+                num_of_certificates: 20,
+                num_of_peers: 5,
+            },
+            TestCase {
+                num_of_certificates: 10,
+                num_of_peers: 1,
+            },
+        ];
+
+        for test in test_cases {
+            println!(
+                "Testing case where num_of_certificates={} , num_of_peers={}",
+                test.num_of_certificates, test.num_of_peers
+            );
+            let mut mock_certificates = Vec::new();
+
+            for i in 0..test.num_of_certificates {
+                mock_certificates.push(MockCertificate(i));
+            }
+
+            let mut rng = StdRng::from_seed([0; 32]);
+
+            let mut peers =
+                Peers::<Ed25519PublicKey, MockCertificate>::new(SmallRng::from_entropy());
+
+            for _ in 0..test.num_of_peers {
+                let key_pair = Ed25519KeyPair::generate(&mut rng);
+                peers.add_peer(key_pair.public().clone(), mock_certificates.clone());
+            }
+
+            // WHEN
+            peers.rebalance_values();
+
+            // THEN
+            assert_eq!(peers.peers.len() as u8, test.num_of_peers);
+
+            // The certificates should be balanced to the peers.
+            let mut seen_certificates = HashSet::new();
+
+            for peer in peers.peers().values() {
+                for c in peer.assigned_values() {
+                    //println!("Cert for peer {}: {}", peer.name.encode_base64(), c.0);
+                    assert!(
+                        seen_certificates.insert(c.digest()),
+                        "Certificate already assigned to another peer"
+                    );
+                }
+            }
+
+            // ensure that all the initial certificates have been assigned
+            assert_eq!(
+                seen_certificates.len(),
+                mock_certificates.len(),
+                "Returned certificates != Expected certificates"
+            );
+
+            for c in mock_certificates {
+                assert!(
+                    seen_certificates.contains(&c.digest()),
+                    "Expected certificate not found in set of returned ones"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_assign_certificates_to_peers_when_all_respond_uniquely() {
+        struct TestCase {
+            num_of_certificates_each_peer: u8,
+            num_of_peers: u8,
+        }
+
+        let test_cases: Vec<TestCase> = vec![
+            TestCase {
+                num_of_certificates_each_peer: 5,
+                num_of_peers: 4,
+            },
+            TestCase {
+                num_of_certificates_each_peer: 8,
+                num_of_peers: 2,
+            },
+            TestCase {
+                num_of_certificates_each_peer: 3,
+                num_of_peers: 2,
+            },
+            TestCase {
+                num_of_certificates_each_peer: 20,
+                num_of_peers: 5,
+            },
+            TestCase {
+                num_of_certificates_each_peer: 10,
+                num_of_peers: 1,
+            },
+            TestCase {
+                num_of_certificates_each_peer: 0,
+                num_of_peers: 4,
+            },
+        ];
+
+        for test in test_cases {
+            println!(
+                "Testing case where num_of_certificates_each_peer={} , num_of_peers={}",
+                test.num_of_certificates_each_peer, test.num_of_peers
+            );
+            let mut mock_certificates_by_peer = HashMap::new();
+
+            let mut rng = StdRng::from_seed([0; 32]);
+
+            let mut peers =
+                Peers::<Ed25519PublicKey, MockCertificate>::new(SmallRng::from_entropy());
+
+            for peer_index in 0..test.num_of_peers {
+                let key_pair = Ed25519KeyPair::generate(&mut rng);
+                let peer_name = key_pair.public().clone();
+                let mut mock_certificates = Vec::new();
+
+                for i in 0..test.num_of_certificates_each_peer {
+                    mock_certificates.push(MockCertificate(
+                        i + (peer_index * test.num_of_certificates_each_peer),
+                    ));
+                }
+
+                peers.add_peer(peer_name.clone(), mock_certificates.clone());
+
+                mock_certificates_by_peer.insert(peer_name, mock_certificates.clone());
+            }
+
+            // WHEN
+            peers.rebalance_values();
+
+            // THEN
+            assert_eq!(peers.peers().len() as u8, test.num_of_peers);
+
+            // The certificates should be balanced to the peers.
+            let mut seen_certificates = HashSet::new();
+
+            for peer in peers.peers().values() {
+                // we want to ensure that a peer has got at least a certificate
+                let peer_certs = mock_certificates_by_peer.get(&peer.name).unwrap();
+                assert_eq!(
+                    peer.assigned_values().len(),
+                    peer_certs.len(),
+                    "Expected peer to have been assigned the required certificates"
+                );
+
+                for c in peer.assigned_values() {
+                    let found = peer_certs
+                        .clone()
+                        .into_iter()
+                        .any(|c| c.digest().eq(&c.digest()));
+
+                    assert!(found, "Assigned certificate not in set of expected");
+                    assert!(
+                        seen_certificates.insert(c.digest()),
+                        "Certificate already assigned to another peer"
+                    );
+                }
+            }
+        }
+    }
+
+    // The mock certificate structure we'll use for our tests
+    // It's easier to debug since the value is a u8 which can
+    // be easily understood, print etc.
+    #[derive(Clone)]
+    struct MockCertificate(u8);
+
+    #[derive(Clone, Copy, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
+    pub struct MockDigest([u8; DIGEST_LEN]);
+
+    impl From<MockDigest> for Digest {
+        fn from(hd: MockDigest) -> Self {
+            Digest::new(hd.0)
+        }
+    }
+
+    impl fmt::Debug for MockDigest {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+            write!(f, "{}", base64::encode(&self.0))
+        }
+    }
+
+    impl fmt::Display for MockDigest {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+            write!(f, "{}", base64::encode(&self.0).get(0..16).unwrap())
+        }
+    }
+
+    impl Hash for MockCertificate {
+        type TypedDigest = MockDigest;
+
+        fn digest(&self) -> MockDigest {
+            let v = self.0.borrow();
+
+            let hasher_update = |hasher: &mut VarBlake2b| {
+                hasher.update([*v].as_ref());
+            };
+
+            MockDigest(crypto::blake2b_256(hasher_update))
+        }
+    }
+}

--- a/primary/src/block_synchronizer/responses.rs
+++ b/primary/src/block_synchronizer/responses.rs
@@ -1,3 +1,5 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
 use blake2::digest::Update;
 use config::Committee;
 use crypto::{traits::VerifyingKey, Digest, Hash};

--- a/primary/src/block_synchronizer/responses.rs
+++ b/primary/src/block_synchronizer/responses.rs
@@ -1,0 +1,133 @@
+use blake2::digest::Update;
+use config::Committee;
+use crypto::{traits::VerifyingKey, Digest, Hash};
+use std::fmt::{Display, Formatter};
+use thiserror::Error;
+use tracing::log::{error, warn};
+use types::{Certificate, CertificateDigest};
+
+// RequestID helps us identify an incoming request and
+// all the consequent network requests associated with it.
+#[derive(Clone, Debug, Copy, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct RequestID(pub [u8; crypto::DIGEST_LEN]);
+
+impl RequestID {
+    // Create a request key (deterministically) from arbitrary data.
+    pub fn new(data: &[u8]) -> Self {
+        RequestID(crypto::blake2b_256(|hasher| hasher.update(data)))
+    }
+}
+
+impl<'a> FromIterator<&'a CertificateDigest> for RequestID {
+    fn from_iter<T: IntoIterator<Item = &'a CertificateDigest>>(ids: T) -> Self {
+        let mut ids_sorted: Vec<&CertificateDigest> = ids.into_iter().collect();
+        ids_sorted.sort();
+
+        let result: Vec<u8> = ids_sorted
+            .into_iter()
+            .flat_map(|d| Digest::from(*d).to_vec())
+            .collect();
+
+        RequestID::new(&result)
+    }
+}
+
+impl<'a, PublicKey: VerifyingKey> FromIterator<&'a Certificate<PublicKey>> for RequestID {
+    fn from_iter<T: IntoIterator<Item = &'a Certificate<PublicKey>>>(certificates: T) -> Self {
+        let ids: Vec<CertificateDigest> = certificates.into_iter().map(|c| c.digest()).collect();
+
+        ids.iter().collect()
+    }
+}
+
+impl Display for RequestID {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", base64::encode(&self.0))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PayloadAvailabilityResponse<PublicKey: VerifyingKey> {
+    pub block_ids: Vec<(CertificateDigest, bool)>,
+    pub from: PublicKey,
+}
+
+impl<PublicKey: VerifyingKey> PayloadAvailabilityResponse<PublicKey> {
+    pub fn request_id(&self) -> RequestID {
+        let ids: Vec<CertificateDigest> = self.block_ids.iter().map(|entry| entry.0).collect();
+
+        ids.iter().collect()
+    }
+
+    pub fn available_block_ids(&self) -> Vec<CertificateDigest> {
+        self.block_ids
+            .iter()
+            .filter_map(|(id, available)| if *available { Some(*id) } else { None })
+            .collect()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CertificatesResponse<PublicKey: VerifyingKey> {
+    pub certificates: Vec<(CertificateDigest, Option<Certificate<PublicKey>>)>,
+    pub from: PublicKey,
+}
+
+impl<PublicKey: VerifyingKey> CertificatesResponse<PublicKey> {
+    pub fn request_id(&self) -> RequestID {
+        let ids: Vec<CertificateDigest> = self.certificates.iter().map(|entry| entry.0).collect();
+
+        ids.iter().collect()
+    }
+
+    /// This method does two things:
+    /// 1) filters only the found certificates
+    /// 2) validates the certificates
+    /// Even if one found certificate is not valid, an error is returned. Otherwise
+    /// and Ok result is returned with (any) found certificates.
+    pub fn validate_certificates(
+        &self,
+        committee: &Committee<PublicKey>,
+    ) -> Result<Vec<Certificate<PublicKey>>, CertificatesResponseError<PublicKey>> {
+        let peer_found_certs: Vec<Certificate<PublicKey>> = self
+            .certificates
+            .iter()
+            .filter_map(|e| e.1.clone())
+            .collect();
+
+        if peer_found_certs.as_slice().is_empty() {
+            // no certificates found, skip
+            warn!(
+                "No certificates are able to be served from {:?}",
+                &self.from
+            );
+            return Ok(vec![]);
+        }
+
+        let invalid_certificates: Vec<Certificate<PublicKey>> = peer_found_certs
+            .clone()
+            .into_iter()
+            .filter(|c| c.verify(committee).is_err())
+            .collect();
+
+        if !invalid_certificates.is_empty() {
+            error!("Found at least one invalid certificate from peer {:?}. Will ignore all certificates", self.from);
+
+            return Err(CertificatesResponseError::ValidationError {
+                name: self.from.clone(),
+                invalid_certificates,
+            });
+        }
+
+        Ok(peer_found_certs)
+    }
+}
+
+#[derive(Debug, Error, Clone, PartialEq)]
+pub enum CertificatesResponseError<PublicKey: VerifyingKey> {
+    #[error("Found invalid certificates form peer {name} - potentially Byzantine.")]
+    ValidationError {
+        name: PublicKey,
+        invalid_certificates: Vec<Certificate<PublicKey>>,
+    },
+}

--- a/primary/src/block_synchronizer/tests/block_synchronizer_tests.rs
+++ b/primary/src/block_synchronizer/tests/block_synchronizer_tests.rs
@@ -1,0 +1,618 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use crate::{
+    block_synchronizer::{
+        responses::PayloadAvailabilityResponse, BlockSynchronizer, CertificatesResponse, Command,
+        PendingIdentifier, RequestID, SyncError,
+    },
+    common::{create_db_stores, fixture_header_builder},
+    primary::PrimaryMessage,
+    PrimaryWorkerMessage,
+};
+use bincode::deserialize;
+use config::BlockSynchronizerParameters;
+use crypto::{ed25519::Ed25519PublicKey, Hash};
+use ed25519_dalek::Signer;
+use futures::{future::try_join_all, stream::FuturesUnordered, StreamExt};
+use network::SimpleSender;
+use serde::de::DeserializeOwned;
+use std::{
+    collections::{HashMap, HashSet},
+    net::SocketAddr,
+    time::Duration,
+};
+use tokio::{
+    net::TcpListener,
+    sync::mpsc::channel,
+    task::JoinHandle,
+    time::{sleep, timeout},
+};
+use tokio_util::codec::{Framed, LengthDelimitedCodec};
+use tracing::log::debug;
+use types::{
+    test_utils::{certificate, fixture_batch_with_transactions, keys, resolve_name_and_committee},
+    Certificate, CertificateDigest,
+};
+
+#[tokio::test]
+async fn test_successful_headers_synchronization() {
+    // GIVEN
+    let (_, _, payload_store) = create_db_stores();
+
+    // AND the necessary keys
+    let (name, committee) = resolve_name_and_committee(13100);
+
+    let (tx_commands, rx_commands) = channel(10);
+    let (tx_certificate_responses, rx_certificate_responses) = channel(10);
+    let (_, rx_payload_availability_responses) = channel(10);
+
+    // AND some blocks (certificates)
+    let mut certificates: HashMap<CertificateDigest, Certificate<Ed25519PublicKey>> =
+        HashMap::new();
+
+    let key = keys().pop().unwrap();
+    let worker_id_0 = 0;
+    let worker_id_1 = 1;
+
+    // AND generate headers with distributed batches between 2 workers (0 and 1)
+    for _ in 0..8 {
+        let batch_1 = fixture_batch_with_transactions(10);
+        let batch_2 = fixture_batch_with_transactions(10);
+
+        let header = fixture_header_builder()
+            .with_payload_batch(batch_1.clone(), worker_id_0)
+            .with_payload_batch(batch_2.clone(), worker_id_1)
+            .build(|payload| key.sign(payload));
+
+        let certificate = certificate(&header);
+
+        certificates.insert(certificate.clone().digest(), certificate.clone());
+    }
+
+    // AND create the synchronizer
+    BlockSynchronizer::spawn(
+        name.clone(),
+        committee.clone(),
+        rx_commands,
+        rx_certificate_responses,
+        rx_payload_availability_responses,
+        SimpleSender::new(),
+        payload_store.clone(),
+        BlockSynchronizerParameters::default(),
+    );
+
+    // AND the channel to respond to
+    let (tx_synchronize, mut rx_synchronize) = channel(10);
+
+    // AND let's assume that all the primaries are responding with the full set
+    // of requested certificates.
+    let handlers: FuturesUnordered<JoinHandle<Vec<PrimaryMessage<Ed25519PublicKey>>>> = committee
+        .others_primaries(&name)
+        .iter()
+        .map(|primary| {
+            println!("New primary added: {:?}", primary.1.primary_to_primary);
+            listener::<PrimaryMessage<Ed25519PublicKey>>(1, primary.1.primary_to_primary)
+        })
+        .collect();
+
+    // WHEN
+    tx_commands
+        .send(Command::SynchronizeBlockHeaders {
+            block_ids: certificates.keys().copied().collect(),
+            respond_to: tx_synchronize,
+        })
+        .await
+        .ok()
+        .unwrap();
+
+    // wait for the primaries to receive all the requests
+    if let Ok(result) = timeout(Duration::from_millis(4_000), try_join_all(handlers)).await {
+        assert!(result.is_ok(), "Error returned");
+
+        let mut primaries = committee.others_primaries(&name);
+
+        for mut primary_responses in result.unwrap() {
+            // ensure that only one request has been received
+            assert_eq!(primary_responses.len(), 1, "Expected only one request");
+
+            match primary_responses.remove(0) {
+                PrimaryMessage::CertificatesBatchRequest {
+                    certificate_ids,
+                    requestor,
+                } => {
+                    let response_certificates: Vec<(
+                        CertificateDigest,
+                        Option<Certificate<Ed25519PublicKey>>,
+                    )> = certificate_ids
+                        .iter()
+                        .map(|id| {
+                            if let Some(certificate) = certificates.get(id) {
+                                (*id, Some(certificate.clone()))
+                            } else {
+                                panic!(
+                                    "Received certificate with id {id} not amongst the expected"
+                                );
+                            }
+                        })
+                        .collect();
+
+                    debug!("{:?}", requestor);
+
+                    tx_certificate_responses
+                        .send(CertificatesResponse {
+                            certificates: response_certificates,
+                            from: primaries.pop().unwrap().0,
+                        })
+                        .await
+                        .unwrap();
+                }
+                _ => {
+                    panic!("Unexpected request has been received!");
+                }
+            }
+        }
+    }
+
+    // THEN
+    let timer = sleep(Duration::from_millis(5_000));
+    tokio::pin!(timer);
+
+    let total_expected_results = certificates.len();
+    let mut total_results_received = 0;
+
+    loop {
+        tokio::select! {
+            Some(result) = rx_synchronize.recv() => {
+                assert!(result.is_ok(), "Error result received: {:?}", result.err().unwrap());
+
+                if result.is_ok() {
+                    let certificate = result.ok().unwrap();
+
+                    println!("Received certificate result: {:?}", certificate.clone());
+
+                    assert!(certificates.contains_key(&certificate.digest()));
+
+                    total_results_received += 1;
+                }
+
+                if total_results_received == total_expected_results {
+                    break;
+                }
+            },
+            () = &mut timer => {
+                panic!("Timeout, no result has been received in time")
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_successful_payload_synchronization() {
+    // GIVEN
+    let (_, _, payload_store) = create_db_stores();
+
+    // AND the necessary keys
+    let (name, committee) = resolve_name_and_committee(13000);
+
+    let (tx_commands, rx_commands) = channel(10);
+    let (_tx_certificate_responses, rx_certificate_responses) = channel(10);
+    let (tx_payload_availability_responses, rx_payload_availability_responses) = channel(10);
+
+    // AND some blocks (certificates)
+    let mut certificates: HashMap<CertificateDigest, Certificate<Ed25519PublicKey>> =
+        HashMap::new();
+
+    let key = keys().pop().unwrap();
+    let worker_id_0: u32 = 0;
+    let worker_id_1: u32 = 1;
+
+    // AND generate headers with distributed batches between 2 workers (0 and 1)
+    for _ in 0..8 {
+        let batch_1 = fixture_batch_with_transactions(10);
+        let batch_2 = fixture_batch_with_transactions(10);
+
+        let header = fixture_header_builder()
+            .with_payload_batch(batch_1.clone(), worker_id_0)
+            .with_payload_batch(batch_2.clone(), worker_id_1)
+            .build(|payload| key.sign(payload));
+
+        let certificate = certificate(&header);
+
+        certificates.insert(certificate.clone().digest(), certificate.clone());
+    }
+
+    // AND create the synchronizer
+    BlockSynchronizer::spawn(
+        name.clone(),
+        committee.clone(),
+        rx_commands,
+        rx_certificate_responses,
+        rx_payload_availability_responses,
+        SimpleSender::new(),
+        payload_store.clone(),
+        BlockSynchronizerParameters::default(),
+    );
+
+    // AND the channel to respond to
+    let (tx_synchronize, mut rx_synchronize) = channel(10);
+
+    // AND let's assume that all the primaries are responding with the full set
+    // of requested certificates.
+    let handlers_primaries: FuturesUnordered<JoinHandle<Vec<PrimaryMessage<Ed25519PublicKey>>>> =
+        committee
+            .others_primaries(&name)
+            .iter()
+            .map(|primary| {
+                println!("New primary added: {:?}", primary.1.primary_to_primary);
+                listener::<PrimaryMessage<Ed25519PublicKey>>(1, primary.1.primary_to_primary)
+            })
+            .collect();
+
+    // AND spin up the corresponding worker nodes
+    let mut workers = vec![
+        (worker_id_0, committee.worker(&name, &worker_id_0).unwrap()),
+        (worker_id_1, committee.worker(&name, &worker_id_1).unwrap()),
+    ];
+
+    let handlers_workers: FuturesUnordered<
+        JoinHandle<Vec<PrimaryWorkerMessage<Ed25519PublicKey>>>,
+    > = workers
+        .iter()
+        .map(|worker| {
+            println!("New worker added: {:?}", worker.1.primary_to_worker);
+            listener::<PrimaryWorkerMessage<Ed25519PublicKey>>(-1, worker.1.primary_to_worker)
+        })
+        .collect();
+
+    // WHEN
+    tx_commands
+        .send(Command::SynchronizeBlockPayload {
+            certificates: certificates.values().cloned().collect(),
+            respond_to: tx_synchronize,
+        })
+        .await
+        .ok()
+        .unwrap();
+
+    // wait for the primaries to receive all the requests
+    if let Ok(result) = timeout(
+        Duration::from_millis(4_000),
+        try_join_all(handlers_primaries),
+    )
+    .await
+    {
+        assert!(result.is_ok(), "Error returned");
+
+        let mut primaries = committee.others_primaries(&name);
+
+        for mut primary_responses in result.unwrap() {
+            // ensure that only one request has been received
+            assert_eq!(primary_responses.len(), 1, "Expected only one request");
+
+            match primary_responses.remove(0) {
+                PrimaryMessage::PayloadAvailabilityRequest {
+                    certificate_ids,
+                    requestor,
+                } => {
+                    let response: Vec<(CertificateDigest, bool)> = certificate_ids
+                        .iter()
+                        .map(|id| (*id, certificates.contains_key(id)))
+                        .collect();
+
+                    debug!("{:?}", requestor);
+
+                    tx_payload_availability_responses
+                        .send(PayloadAvailabilityResponse {
+                            block_ids: response,
+                            from: primaries.pop().unwrap().0,
+                        })
+                        .await
+                        .unwrap();
+                }
+                _ => {
+                    panic!("Unexpected request has been received!");
+                }
+            }
+        }
+    }
+
+    // now wait to receive all the requests from the workers
+    if let Ok(result) = timeout(Duration::from_millis(4_000), try_join_all(handlers_workers)).await
+    {
+        assert!(result.is_ok(), "Error returned");
+
+        for messages in result.unwrap() {
+            // since everything is in order, just pop the next worker
+            let worker = workers.pop().unwrap();
+
+            for m in messages {
+                match m {
+                    PrimaryWorkerMessage::Synchronize(batch_ids, _) => {
+                        //println!("Synchronize message for batch ids {:?}", batch_ids);
+                        // Assume that the request is the correct one and just immediately
+                        // store the batch to the payload store.
+                        for batch_id in batch_ids {
+                            payload_store.write((batch_id, worker.0), 1).await;
+                        }
+                    }
+                    _ => {
+                        panic!("Unexpected request received");
+                    }
+                }
+            }
+        }
+    }
+
+    // THEN
+    let timer = sleep(Duration::from_millis(5_000));
+    tokio::pin!(timer);
+
+    let total_expected_results = certificates.len();
+    let mut total_results_received = 0;
+
+    loop {
+        tokio::select! {
+            Some(result) = rx_synchronize.recv() => {
+                assert!(result.is_ok(), "Error result received: {:?}", result.err().unwrap());
+
+                if result.is_ok() {
+                    let certificate = result.ok().unwrap();
+
+                    println!("Received certificate result: {:?}", certificate.clone());
+
+                    assert!(certificates.contains_key(&certificate.digest()));
+
+                    total_results_received += 1;
+                }
+
+                if total_results_received == total_expected_results {
+                    break;
+                }
+            },
+            () = &mut timer => {
+                panic!("Timeout, no result has been received in time")
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_multiple_overlapping_requests() {
+    // GIVEN
+    let (_, _, payload_store) = create_db_stores();
+    let (name, committee) = resolve_name_and_committee(13001);
+
+    let (_, rx_commands) = channel(10);
+    let (_, rx_certificate_responses) = channel(10);
+    let (_, rx_payload_availability_responses) = channel(10);
+
+    // AND some blocks (certificates)
+    let mut certificates: HashMap<CertificateDigest, Certificate<Ed25519PublicKey>> =
+        HashMap::new();
+
+    let key = keys().pop().unwrap();
+
+    // AND generate headers with distributed batches between 2 workers (0 and 1)
+    for _ in 0..5 {
+        let header = fixture_header_builder()
+            .with_payload_batch(fixture_batch_with_transactions(10), 0)
+            .build(|payload| key.sign(payload));
+
+        let certificate = certificate(&header);
+
+        certificates.insert(certificate.clone().digest(), certificate.clone());
+    }
+
+    let mut block_ids: Vec<CertificateDigest> = certificates.keys().copied().collect();
+
+    let mut block_synchronizer = BlockSynchronizer {
+        name,
+        committee,
+        rx_commands,
+        rx_certificate_responses,
+        rx_payload_availability_responses,
+        pending_requests: HashMap::new(),
+        map_certificate_responses_senders: HashMap::new(),
+        map_payload_availability_responses_senders: HashMap::new(),
+        network: SimpleSender::new(),
+        payload_store,
+        certificates_synchronize_timeout: Duration::from_millis(2_000),
+        payload_synchronize_timeout: Duration::from_millis(2_000),
+        payload_availability_timeout: Duration::from_millis(2_000),
+    };
+
+    // ResultSender
+    let get_mock_sender = || {
+        let (tx, _) = channel(10);
+        tx
+    };
+
+    // WHEN
+    let result = block_synchronizer
+        .handle_synchronize_block_headers_command(block_ids.clone(), get_mock_sender())
+        .await;
+    assert!(
+        result.is_some(),
+        "Should have created a future to fetch certificates"
+    );
+
+    // THEN
+
+    // ensure that pending values have been updated
+    for digest in block_ids.clone() {
+        assert!(
+            block_synchronizer
+                .pending_requests
+                .contains_key(&PendingIdentifier::Header(digest)),
+            "Expected to have certificate {} pending to retrieve",
+            digest
+        );
+    }
+
+    // AND that the request is pending for all the block_ids
+    let request_id: RequestID = block_ids.iter().collect();
+
+    assert!(
+        block_synchronizer
+            .map_certificate_responses_senders
+            .contains_key(&request_id),
+        "Expected to have a request for request id {:?}",
+        &request_id
+    );
+
+    // AND when trying to request same block ids + extra
+    let extra_certificate_id = CertificateDigest::default();
+    block_ids.push(extra_certificate_id);
+    let result = block_synchronizer
+        .handle_synchronize_block_headers_command(block_ids, get_mock_sender())
+        .await;
+    assert!(
+        result.is_some(),
+        "Should have created a future to fetch certificates"
+    );
+
+    // THEN only the extra id will be requested
+    assert_eq!(
+        block_synchronizer.map_certificate_responses_senders.len(),
+        2
+    );
+
+    let request_id: RequestID = vec![extra_certificate_id].iter().collect();
+    assert!(
+        block_synchronizer
+            .map_certificate_responses_senders
+            .contains_key(&request_id),
+        "Expected to have a request for request id {}",
+        &request_id
+    );
+}
+
+#[tokio::test]
+async fn test_timeout_while_waiting_for_certificates() {
+    // GIVEN
+    let (_, _, payload_store) = create_db_stores();
+
+    // AND the necessary keys
+    let (name, committee) = resolve_name_and_committee(13001);
+    let key = keys().pop().unwrap();
+
+    let (tx_commands, rx_commands) = channel(10);
+    let (_, rx_certificate_responses) = channel(10);
+    let (_, rx_payload_availability_responses) = channel(10);
+
+    // AND some random block ids
+    let block_ids: Vec<CertificateDigest> = (0..10)
+        .into_iter()
+        .map(|_| {
+            let header = fixture_header_builder()
+                .with_payload_batch(fixture_batch_with_transactions(10), 0)
+                .build(|payload| key.sign(payload));
+
+            certificate(&header).digest()
+        })
+        .collect();
+
+    // AND create the synchronizer
+    BlockSynchronizer::spawn(
+        name.clone(),
+        committee.clone(),
+        rx_commands,
+        rx_certificate_responses,
+        rx_payload_availability_responses,
+        SimpleSender::new(),
+        payload_store.clone(),
+        BlockSynchronizerParameters::default(),
+    );
+
+    // AND the channel to respond to
+    let (tx_synchronize, mut rx_synchronize) = channel(10);
+
+    // WHEN
+    tx_commands
+        .send(Command::SynchronizeBlockHeaders {
+            block_ids: block_ids.clone(),
+            respond_to: tx_synchronize,
+        })
+        .await
+        .ok()
+        .unwrap();
+
+    // THEN
+    let timer = sleep(Duration::from_millis(5_000));
+    tokio::pin!(timer);
+
+    let mut total_results_received = 0;
+
+    let mut block_ids_seen: HashSet<CertificateDigest> = HashSet::new();
+
+    loop {
+        tokio::select! {
+            Some(result) = rx_synchronize.recv() => {
+                assert!(result.is_err(), "Expected error result, instead received: {:?}", result.unwrap());
+
+                match result.err().unwrap() {
+                    SyncError::Timeout { block_id } => {
+                        // ensure the results are unique and within the expected set
+                        assert!(block_ids_seen.insert(block_id), "Already received response for this block id - this shouldn't happen");
+                        assert!(block_ids.iter().any(|d|d.eq(&block_id)), "Received not expected block id");
+                    },
+                    err => panic!("Didn't expect this sync error: {:?}", err)
+                }
+
+                total_results_received += 1;
+
+                // received all expected results, now break
+                if total_results_received == block_ids.as_slice().len() {
+                    break;
+                }
+            },
+            () = &mut timer => {
+                panic!("Timeout, no result has been received in time")
+            }
+        }
+    }
+}
+
+pub fn listener<T>(num_of_expected_responses: i32, address: SocketAddr) -> JoinHandle<Vec<T>>
+where
+    T: Send + DeserializeOwned + 'static,
+{
+    tokio::spawn(async move {
+        let listener = TcpListener::bind(&address).await.unwrap();
+        let (socket, _) = listener.accept().await.unwrap();
+        let transport = Framed::new(socket, LengthDelimitedCodec::new());
+        let (_writer, mut reader) = transport.split();
+
+        let mut responses = Vec::new();
+
+        loop {
+            match timeout(Duration::from_secs(1), reader.next()).await {
+                Err(_) => {
+                    // timeout happened - just return whatever has already
+                    return responses;
+                }
+                Ok(Some(Ok(received))) => {
+                    let message = received.freeze();
+                    match deserialize(&message) {
+                        Ok(msg) => {
+                            responses.push(msg);
+
+                            // if -1 is given, then we don't count the number of messages
+                            // but we just rely to receive as many as possible until timeout
+                            // happens when waiting for requests.
+                            if num_of_expected_responses != -1
+                                && responses.len() as i32 == num_of_expected_responses
+                            {
+                                return responses;
+                            }
+                        }
+                        Err(err) => {
+                            panic!("Error occurred {err}");
+                        }
+                    }
+                }
+                _ => panic!("Failed to receive network message"),
+            }
+        }
+    })
+}

--- a/primary/src/lib.rs
+++ b/primary/src/lib.rs
@@ -10,6 +10,7 @@
 
 mod aggregators;
 mod block_remover;
+mod block_synchronizer;
 mod block_waiter;
 mod certificate_waiter;
 mod core;
@@ -20,6 +21,7 @@ mod payload_receiver;
 mod primary;
 mod proposer;
 mod synchronizer;
+mod utils;
 
 #[cfg(test)]
 #[path = "tests/common.rs"]

--- a/primary/src/tests/block_waiter_tests.rs
+++ b/primary/src/tests/block_waiter_tests.rs
@@ -38,7 +38,7 @@ async fn test_successfully_retrieve_block() {
     let (_, certificate_store, _) = create_db_stores();
 
     // AND the necessary keys
-    let (name, committee) = resolve_name_and_committee(13000);
+    let (name, committee) = resolve_name_and_committee(12000);
 
     // AND store certificate
     let header = fixture_header_with_payload(2);
@@ -132,7 +132,7 @@ async fn test_successfully_retrieve_multiple_blocks() {
     let (_, certificate_store, _) = create_db_stores();
 
     // AND the necessary keys
-    let (name, committee) = resolve_name_and_committee(13001);
+    let (name, committee) = resolve_name_and_committee(14001);
 
     let key = keys().pop().unwrap();
     let mut block_ids = Vec::new();

--- a/primary/src/tests/common.rs
+++ b/primary/src/tests/common.rs
@@ -1,6 +1,5 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-
 use config::WorkerId;
 use crypto::{ed25519::Ed25519PublicKey, traits::KeyPair, Hash};
 use store::{reopen, rocks, rocks::DBMap, Store};

--- a/primary/src/utils.rs
+++ b/primary/src/utils.rs
@@ -1,0 +1,27 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use config::WorkerId;
+use crypto::traits::VerifyingKey;
+use std::collections::HashMap;
+use types::{BatchDigest, Certificate};
+
+// a helper method that collects all the batches from each certificate and maps
+// them by the worker id.
+pub fn map_certificate_batches_by_worker<PublicKey>(
+    certificates: &[Certificate<PublicKey>],
+) -> HashMap<WorkerId, Vec<BatchDigest>>
+where
+    PublicKey: VerifyingKey,
+{
+    let mut batches_by_worker: HashMap<WorkerId, Vec<BatchDigest>> = HashMap::new();
+    for certificate in certificates.iter() {
+        for (batch_id, worker_id) in &certificate.header.payload {
+            batches_by_worker
+                .entry(*worker_id)
+                .or_default()
+                .push(*batch_id);
+        }
+    }
+
+    batches_by_worker
+}

--- a/types/src/test_utils/mod.rs
+++ b/types/src/test_utils/mod.rs
@@ -55,46 +55,62 @@ pub fn committee() -> Committee<Ed25519PublicKey> {
             .map(|(i, kp)| {
                 let id = kp.public();
                 let primary = PrimaryAddresses {
-                    primary_to_primary: format!("127.0.0.1:{}", 100 + i).parse().unwrap(),
-                    worker_to_primary: format!("127.0.0.1:{}", 200 + i).parse().unwrap(),
+                    primary_to_primary: format!("127.0.0.1:{}", 100 + i * 10).parse().unwrap(),
+                    worker_to_primary: format!("127.0.0.1:{}", 200 + i * 10).parse().unwrap(),
                 };
                 let workers = vec![
                     (
                         0,
                         WorkerAddresses {
-                            primary_to_worker: format!("127.0.0.1:{}", 300 + i).parse().unwrap(),
-                            transactions: format!("127.0.0.1:{}", 400 + i).parse().unwrap(),
-                            worker_to_worker: format!("127.0.0.1:{}", 500 + i).parse().unwrap(),
+                            primary_to_worker: format!("127.0.0.1:{}", 300 + i * 10)
+                                .parse()
+                                .unwrap(),
+                            transactions: format!("127.0.0.1:{}", 400 + i * 10).parse().unwrap(),
+                            worker_to_worker: format!("127.0.0.1:{}", 500 + i * 10)
+                                .parse()
+                                .unwrap(),
                         },
                     ),
                     (
                         1,
                         WorkerAddresses {
-                            primary_to_worker: format!("127.0.0.1:{}", 300 + i + 1)
+                            primary_to_worker: format!("127.0.0.1:{}", 300 + i * 10 + 1)
                                 .parse()
                                 .unwrap(),
-                            transactions: format!("127.0.0.1:{}", 400 + i + 1).parse().unwrap(),
-                            worker_to_worker: format!("127.0.0.1:{}", 500 + i + 1).parse().unwrap(),
+                            transactions: format!("127.0.0.1:{}", 400 + i * 10 + 1)
+                                .parse()
+                                .unwrap(),
+                            worker_to_worker: format!("127.0.0.1:{}", 500 + i * 10 + 1)
+                                .parse()
+                                .unwrap(),
                         },
                     ),
                     (
                         2,
                         WorkerAddresses {
-                            primary_to_worker: format!("127.0.0.1:{}", 300 + i + 2)
+                            primary_to_worker: format!("127.0.0.1:{}", 300 + i * 10 + 2)
                                 .parse()
                                 .unwrap(),
-                            transactions: format!("127.0.0.1:{}", 400 + i + 2).parse().unwrap(),
-                            worker_to_worker: format!("127.0.0.1:{}", 500 + i + 2).parse().unwrap(),
+                            transactions: format!("127.0.0.1:{}", 400 + i * 10 + 2)
+                                .parse()
+                                .unwrap(),
+                            worker_to_worker: format!("127.0.0.1:{}", 500 + i * 10 + 2)
+                                .parse()
+                                .unwrap(),
                         },
                     ),
                     (
                         3,
                         WorkerAddresses {
-                            primary_to_worker: format!("127.0.0.1:{}", 300 + i + 3)
+                            primary_to_worker: format!("127.0.0.1:{}", 300 + i * 10 + 3)
                                 .parse()
                                 .unwrap(),
-                            transactions: format!("127.0.0.1:{}", 400 + i + 3).parse().unwrap(),
-                            worker_to_worker: format!("127.0.0.1:{}", 500 + i + 3).parse().unwrap(),
+                            transactions: format!("127.0.0.1:{}", 400 + i * 10 + 3)
+                                .parse()
+                                .unwrap(),
+                            worker_to_worker: format!("127.0.0.1:{}", 500 + i * 10 + 3)
+                                .parse()
+                                .unwrap(),
                         },
                     ),
                 ]


### PR DESCRIPTION
Resolves: https://github.com/MystenLabs/narwhal/issues/97

This PR is introducing a new component to fetch missing collections in a batch manner. Most of the details can be found on the linked issue.

The `block_synchronizer` has been introduced which is accepting commands `SynchroniseBlocks` via its input channel , to synchronize a list of blocks. The synchronized blocks will be sent to the provided `respond_to` channel where the result for each block will be individually sent. That will allow the consumer to do some immediate processing and not wait until all the blocks are synchronized.

Also, one of the things that had to pay attention was the distribution of the load across the nodes when it comes to syncing the `batches`. The protocol as is will do the following:
1) **Send a request to** all the primary nodes (peer) to ask and fetch the required Certificates
2) **Receive their responses** and **validate them**. The whole response of a peer is discarded even if one certificate is found invalid (signature not correct)
3) On step (2) we are expecting to receive responses **with overlapping values** from the peers. That is not a bad thing when it comes to synchronizing the batches , since we can **distribute the load** across the primaries. That's why we don't immediately continue on the `sync batches` step once we have gathered all the required certificates, but we wait to receive responses from more peers so we have enough to load balance later (this is tuneable via the `CERTIFICATE_RESPONSES_RATIO_THRESHOLD` const)
4) We are utilising the introduced structure `Peers` to hold the responses per peer and do re-distribute the certificates to the peers. Basically each peer will be responsible for a unique set of certificates. Then we will send a command `PrimaryWorkerMessage::Synchronize` to our worker nodes to synchronize the missing batches for those certificates from that specific peer.
5) **For each block/certificate** that we have successfully synced the batches (we are waiting for this) , we emit the response to the caller.

Across the whole process timeouts have been introduced to ensure that we don't hung forever waiting for results. Some arbitrary values have been set for now and those can be tuned later.

**Certificates distribution algorithm**
On the step (4) above I've mentioned on the distribution of certificates to the peers...so if we have multiple peers who can serve the same certificates, we want to make sure that we split those as evenly as possible to fetch later the batches so we don't overload/create hot spots. The one I came up with I would say is quite simple but seems to be working fairly in most cases - I am sure there are much more exotic out there which we could use as improvements. The idea is that for each peer we maintain two lists, 
* `one that holds the available certificates that can serve` (basically this is populated with the peer's response)
* and another with the `assigned certificates to serve`

then when we `rebalance the certificates` across the nodes we basically do the following:

```
for each certificate {
   1) Find the peers who can serve this certificate
   2) Calculate the `sum` of the `sizes` of the two lists for each peer (`certificates_able_to_serve.len()` + `assigned_certificates.len()`
   3) Order them from the minimum sum to the maximum.
   4) If two peers have the same `sum`, then we compare the `assigned_certificates.len()` , then one with the smallest is prioritised and is considered smaller - it's the one that has the least elements assigned. 
   5) In the finally sorted list take the first element (position `0`). That should be the one to assign the certificate to.
   6) Delete the certificate from everyone's `certificates_able_to_serve` list
}
```

The above algorithm takes into account for each peer both how many elements has available to be assigned and how many elements have been already assigned. To make things fair we want to give the opportunity to the ones that don't have enough elements, or have not yet assigned enough elements - so we don't end up in an unbalanced scenario where one peers gets most of the certificates because it can serve them while the other doesn't.