### PR TITLE
[get_collections] : primaries handle must-block request

### DIFF
--- a/primary/src/helper.rs
+++ b/primary/src/helper.rs
@@ -11,6 +11,10 @@ use tokio::sync::mpsc::Receiver;
 use tracing::{error, warn};
 use types::{Certificate, CertificateDigest};
 
+#[cfg(test)]
+#[path = "tests/helper_tests.rs"]
+mod helper_tests;
+
 /// A task dedicated to help other authorities by replying to their certificates requests.
 pub struct Helper<PublicKey: VerifyingKey> {
     /// The committee information.
@@ -18,7 +22,7 @@ pub struct Helper<PublicKey: VerifyingKey> {
     /// The persistent storage.
     store: Store<CertificateDigest, Certificate<PublicKey>>,
     /// Input channel to receive certificates requests.
-    rx_primaries: Receiver<(Vec<CertificateDigest>, PublicKey)>,
+    rx_primaries: Receiver<PrimaryMessage<PublicKey>>,
     /// A network sender to reply to the sync requests.
     network: SimpleSender,
 }
@@ -27,7 +31,7 @@ impl<PublicKey: VerifyingKey> Helper<PublicKey> {
     pub fn spawn(
         committee: Committee<PublicKey>,
         store: Store<CertificateDigest, Certificate<PublicKey>>,
-        rx_primaries: Receiver<(Vec<CertificateDigest>, PublicKey)>,
+        rx_primaries: Receiver<PrimaryMessage<PublicKey>>,
     ) {
         tokio::spawn(async move {
             Self {
@@ -42,29 +46,81 @@ impl<PublicKey: VerifyingKey> Helper<PublicKey> {
     }
 
     async fn run(&mut self) {
-        while let Some((digests, origin)) = self.rx_primaries.recv().await {
-            // TODO [issue #195]: Do some accounting to prevent bad nodes from monopolizing our resources.
-
-            // get the requestors address.
-            let address = match self.committee.primary(&origin) {
-                Ok(x) => x.primary_to_primary,
-                Err(e) => {
-                    warn!("Unexpected certificate request: {e}");
-                    continue;
+        while let Some(request) = self.rx_primaries.recv().await {
+            match request {
+                // The CertificatesRequest will find any certificates that exist in
+                // the data source (dictated by the digests parameter). The results
+                // will be emitted one by one to the consumer.
+                PrimaryMessage::CertificatesRequest(digests, origin) => {
+                    self.process_certificates(digests, origin, false).await;
                 }
-            };
+                // The CertificatesBatchRequest will find any certificates that exist in
+                // the data source (dictated by the digests parameter). The results will
+                // be sent though back to the consumer as a batch - one message.
+                PrimaryMessage::CertificatesBatchRequest {
+                    certificate_ids,
+                    requestor,
+                } => {
+                    self.process_certificates(certificate_ids, requestor, true)
+                        .await;
+                }
+                _ => {
+                    panic!("Received unexpected message!");
+                }
+            }
+        }
+    }
 
-            // Reply to the request (the best we can).
-            for digest in digests {
-                match self.store.read(digest).await {
-                    Ok(Some(certificate)) => {
-                        // TODO: Remove this deserialization-serialization in the critical path.
-                        let bytes = bincode::serialize(&PrimaryMessage::Certificate(certificate))
+    async fn process_certificates(
+        &mut self,
+        digests: Vec<CertificateDigest>,
+        origin: PublicKey,
+        batch_mode: bool,
+    ) {
+        // get the requestors address.
+        let address = match self.committee.primary(&origin) {
+            Ok(x) => x.primary_to_primary,
+            Err(e) => {
+                warn!("Unexpected certificate request: {e}");
+                return;
+            }
+        };
+
+        // TODO [issue #195]: Do some accounting to prevent bad nodes from monopolizing our resources.
+
+        let certificates = match self.store.read_all(digests.to_owned()).await {
+            Ok(certificates) => certificates,
+            Err(err) => {
+                error!("Error while retrieving certificates: {err}");
+                vec![]
+            }
+        };
+
+        // When batch_mode = true, then the requested certificates will be sent back
+        // to the consumer as one message over the network. For the non found
+        // certificates only the digest will be sent instead.
+        //
+        // When batch_mode = false, then the requested certificates will be sent
+        // back to the consumer as separate messages one by one. If a certificate
+        // has not been found, then no message will be sent.
+        if batch_mode {
+            let response: Vec<(CertificateDigest, Option<Certificate<PublicKey>>)> =
+                digests.into_iter().zip(certificates).collect();
+
+            let message = bincode::serialize(&PrimaryMessage::CertificatesBatchResponse {
+                certificates: response,
+            })
+            .expect("Failed to serialize CertificatesBatchResponse message");
+
+            self.network.send(address, Bytes::from(message)).await;
+        } else {
+            for certificate in certificates {
+                if certificate.is_some() {
+                    // TODO: Remove this deserialization-serialization in the critical path.
+                    let bytes =
+                        bincode::serialize(&PrimaryMessage::Certificate(certificate.unwrap()))
                             .expect("Failed to serialize our own certificate");
-                        self.network.send(address, Bytes::from(bytes)).await;
-                    }
-                    Ok(None) => (),
-                    Err(e) => error!("{e}"),
+                    self.network.send(address, Bytes::from(bytes)).await;
                 }
             }
         }

--- a/primary/src/tests/helper_tests.rs
+++ b/primary/src/tests/helper_tests.rs
@@ -1,0 +1,215 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use crate::{
+    common::{create_db_stores, fixture_header_builder},
+    helper::Helper,
+    primary::PrimaryMessage,
+};
+use bincode::deserialize;
+use crypto::{ed25519::Ed25519PublicKey, Hash};
+use ed25519_dalek::Signer;
+use futures::StreamExt;
+use std::{
+    collections::{HashMap, HashSet},
+    net::SocketAddr,
+    time::Duration,
+};
+use tokio::{net::TcpListener, sync::mpsc::channel, task::JoinHandle, time::timeout};
+use tokio_util::codec::{Framed, LengthDelimitedCodec};
+use types::{
+    test_utils::{certificate, fixture_batch_with_transactions, keys, resolve_name_and_committee},
+    CertificateDigest,
+};
+
+#[tokio::test]
+async fn test_process_certificates_stream_mode() {
+    // GIVEN
+    let (_, certificate_store, _) = create_db_stores();
+    let key = keys().pop().unwrap();
+    let (name, committee) = resolve_name_and_committee(13010);
+    let (tx_primaries, rx_primaries) = channel(10);
+
+    // AND a helper
+    Helper::spawn(committee.clone(), certificate_store.clone(), rx_primaries);
+
+    // AND some mock certificates
+    let mut certificates = HashMap::new();
+    for _ in 0..5 {
+        let header = fixture_header_builder()
+            .with_payload_batch(fixture_batch_with_transactions(10), 0)
+            .build(|payload| key.sign(payload));
+
+        let certificate = certificate(&header);
+        let id = certificate.clone().digest();
+
+        // write the certificate
+        certificate_store.write(id, certificate.clone()).await;
+
+        certificates.insert(id, certificate.clone());
+    }
+
+    // AND spin up a mock node
+    let address = committee.primary(&name).unwrap();
+    let handler = listener(certificates.len(), address.primary_to_primary);
+
+    // WHEN requesting the certificates
+    tx_primaries
+        .send(PrimaryMessage::CertificatesRequest(
+            certificates.keys().copied().collect(),
+            name,
+        ))
+        .await
+        .expect("Couldn't send message");
+
+    if let Ok(result) = timeout(Duration::from_millis(4_000), handler).await {
+        assert!(result.is_ok(), "Error returned");
+
+        let result_digests: HashSet<CertificateDigest> = result
+            .unwrap()
+            .into_iter()
+            .map(|message| match message {
+                PrimaryMessage::Certificate(certificate) => certificate,
+                msg => {
+                    panic!("Didn't expect message {:?}", msg);
+                }
+            })
+            .map(|c| c.digest())
+            .collect();
+
+        assert_eq!(
+            result_digests.len(),
+            certificates.len(),
+            "Returned unique number of certificates don't match the expected"
+        );
+    } else {
+        panic!(
+            "Timed out while waiting for results. Did not receive all the expected certificates."
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_process_certificates_batch_mode() {
+    // GIVEN
+    let (_, certificate_store, _) = create_db_stores();
+    let key = keys().pop().unwrap();
+    let (name, committee) = resolve_name_and_committee(13010);
+    let (tx_primaries, rx_primaries) = channel(10);
+
+    // AND a helper
+    Helper::spawn(committee.clone(), certificate_store.clone(), rx_primaries);
+
+    // AND some mock certificates
+    let mut certificates = HashMap::new();
+    let mut missing_certificates = HashSet::new();
+
+    for i in 0..10 {
+        let header = fixture_header_builder()
+            .with_payload_batch(fixture_batch_with_transactions(10), 0)
+            .build(|payload| key.sign(payload));
+
+        let certificate = certificate(&header);
+        let id = certificate.clone().digest();
+
+        certificates.insert(id, certificate.clone());
+
+        // We want to simulate the scenario of both having some certificates
+        // found and some non found. Store only the half. The other half
+        // should be returned back as non found.
+        if i < 5 {
+            // write the certificate
+            certificate_store.write(id, certificate.clone()).await;
+        } else {
+            missing_certificates.insert(id);
+        }
+    }
+
+    // AND spin up a mock node
+    let address = committee.primary(&name).unwrap();
+    let handler = listener(1, address.primary_to_primary);
+
+    // WHEN requesting the certificates in batch mode
+    tx_primaries
+        .send(PrimaryMessage::CertificatesBatchRequest {
+            certificate_ids: certificates.keys().copied().collect(),
+            requestor: name,
+        })
+        .await
+        .expect("Couldn't send message");
+
+    if let Ok(result) = timeout(Duration::from_millis(4_000), handler).await {
+        assert!(result.is_ok(), "Error returned");
+
+        for message in result.unwrap() {
+            match message {
+                PrimaryMessage::CertificatesBatchResponse {
+                    certificates: result_certificates,
+                } => {
+                    let result_digests: HashSet<CertificateDigest> = result_certificates
+                        .iter()
+                        .map(|(digest, _)| *digest)
+                        .collect();
+
+                    assert_eq!(
+                        result_digests.len(),
+                        certificates.len(),
+                        "Returned unique number of certificates don't match the expected"
+                    );
+
+                    // ensure that we have non found certificates
+                    let non_found_certificates: usize = result_certificates
+                        .into_iter()
+                        .filter(|(digest, certificate)| {
+                            missing_certificates.contains(digest) && certificate.is_none()
+                        })
+                        .count();
+                    assert_eq!(
+                        non_found_certificates, 5,
+                        "Expected to have non found certificates"
+                    );
+                }
+                msg => {
+                    panic!("Didn't expect message {:?}", msg);
+                }
+            }
+        }
+    } else {
+        panic!(
+            "Timed out while waiting for results. Did not receive all the expected certificates."
+        );
+    }
+}
+
+pub fn listener(
+    num_of_expected_responses: usize,
+    address: SocketAddr,
+) -> JoinHandle<Vec<PrimaryMessage<Ed25519PublicKey>>> {
+    tokio::spawn(async move {
+        let listener = TcpListener::bind(&address).await.unwrap();
+        let (socket, _) = listener.accept().await.unwrap();
+        let transport = Framed::new(socket, LengthDelimitedCodec::new());
+        let (_writer, mut reader) = transport.split();
+
+        let mut responses = Vec::new();
+        loop {
+            match reader.next().await {
+                Some(Ok(received)) => {
+                    let message = received.freeze();
+                    match deserialize(&message) {
+                        Ok(msg) => {
+                            responses.push(msg);
+
+                            if responses.len() == num_of_expected_responses {
+                                return responses;
+                            }
+                        }
+                        Err(err) => {
+                            panic!("Error occurred {err}");
+                        }
+                    }
+                }
+                _ => panic!("Failed to receive network message"),
+            }
+        }
+    })
+}


### PR DESCRIPTION
Resolves: https://github.com/MystenLabs/narwhal/issues/126

This PR is a follow up on the implementation of the "must-block" protocol for requesting certificates in a batch manner from peer primary nodes. As part of this PR it is implemented the part of the primary that is responding to such request with the available certificates. Extended a slightly refactored the `helper` component. Also introduced some integration testing.