### PR TITLE
fix: tests in retrieving multiple blocks fail randomly

### DIFF
--- a/primary/src/tests/block_waiter_tests.rs
+++ b/primary/src/tests/block_waiter_tests.rs
@@ -129,7 +129,7 @@ async fn test_successfully_retrieve_multiple_blocks() {
     let (_, certificate_store, _) = create_db_stores();
 
     // AND the necessary keys
-    let (name, committee) = resolve_name_and_committee(13000);
+    let (name, committee) = resolve_name_and_committee(13001);
 
     let key = keys().pop().unwrap();
     let mut block_ids = Vec::new();
@@ -265,7 +265,7 @@ async fn test_one_pending_request_for_block_at_time() {
     let (_, certificate_store, _) = create_db_stores();
 
     // AND the necessary keys
-    let (name, committee) = resolve_name_and_committee(13000);
+    let (name, committee) = resolve_name_and_committee(13002);
 
     // AND store certificate
     let header = common::fixture_header_with_payload(2);
@@ -333,7 +333,7 @@ async fn test_unlocking_pending_get_block_request_after_response() {
     let (_, certificate_store, _) = create_db_stores();
 
     // AND the necessary keys
-    let (name, committee) = resolve_name_and_committee(13000);
+    let (name, committee) = resolve_name_and_committee(13003);
 
     // AND store certificate
     let header = common::fixture_header_with_payload(2);
@@ -392,7 +392,7 @@ async fn test_batch_timeout() {
     let (_, certificate_store, _) = create_db_stores();
 
     // AND the necessary keys
-    let (name, committee) = resolve_name_and_committee(13000);
+    let (name, committee) = resolve_name_and_committee(13004);
 
     // AND store certificate
     let header = common::fixture_header_with_payload(2);
@@ -448,7 +448,7 @@ async fn test_batch_timeout() {
 async fn test_return_error_when_certificate_is_missing() {
     // GIVEN
     let (_, certificate_store, _) = create_db_stores();
-    let (name, committee) = resolve_name_and_committee(13000);
+    let (name, committee) = resolve_name_and_committee(13005);
 
     // AND create a certificate but don't store it
     let certificate = Certificate::<Ed25519PublicKey>::default();

--- a/primary/src/tests/common.rs
+++ b/primary/src/tests/common.rs
@@ -309,7 +309,9 @@ pub fn create_db_stores() -> (
     )
 }
 
-// helper method to get a name and a committee
+// helper method to get a name and a committee. Special care should be given on
+// the base_port parameter to not collide between tests. It is advisable to
+// provide unique base_port numbers across the tests.
 pub fn resolve_name_and_committee(
     base_port: u16,
 ) -> (Ed25519PublicKey, Committee<Ed25519PublicKey>) {


### PR DESCRIPTION
Resolves #132 

Based on the output on the description of the https://github.com/MystenLabs/narwhal/issues/132, I believe this is caused because the same ports have been used for the mock servers of the tests `test_successfully_retrieve_block` and `test_successfully_retrieve_multiple_blocks`. That was leading to a collision when trying to bring up both servers and eventually the second one panic and not working to serve the batches, resulting to a failing test. I've changes all the ports to ensure there is no overlap. Didn't manage to replicate the issue, but I believe this is the root cause of the mentioned bug.