### PR TITLE
[feat] Make the DAG lock-less + bugfix

### DIFF
--- a/dag/Cargo.toml
+++ b/dag/Cargo.toml
@@ -15,6 +15,8 @@ rayon = "1.5.2"
 serde = "1.0.136"
 serde_with = "1.12.1"
 thiserror = "1.0.30"
+arc-swap = "1.5.0"
+once_cell = "1.10.0"
 
 [dev-dependencies]
 hex = "0.4.3"

--- a/dag/src/lib.rs
+++ b/dag/src/lib.rs
@@ -168,10 +168,7 @@ impl<T: Sync + Send + std::fmt::Debug> Node<T> {
 
     // A trivial node is one whose parents are all incompressible (or a leaf)
     fn is_trivial(&self) -> bool {
-        self.parents
-            .load()
-            .iter()
-            .all(|p| p.is_leaf() || !p.is_compressible())
+        self.parents.load().iter().all(|p| !p.is_compressible())
     }
 
     /// Compress the path from this node to the next incompressible layer of the DAG.
@@ -314,7 +311,7 @@ mod tests {
             let mut is_first = true;
             for node in iter {
                 if !is_first {
-                assert!(node.is_leaf()|| !node.is_compressible())
+                assert!(!node.is_compressible())
                 }
                 is_first = false;
             }

--- a/dag/src/node_dag.rs
+++ b/dag/src/node_dag.rs
@@ -74,7 +74,9 @@ impl<T: Affiliated> NodeDag<T> {
             .get(&digest)
             .ok_or(DagError::UnknownDigest(digest))?;
         match *node_ref {
-            Either::Left(ref node) => Ok(node.upgrade().ok_or(DagError::DroppedDigest(digest))?),
+            Either::Left(ref node) => Ok(NodeRef(
+                node.upgrade().ok_or(DagError::DroppedDigest(digest))?,
+            )),
             // the node is a head of the graph, just return
             Either::Right(ref node) => Ok(node.clone()),
         }
@@ -116,7 +118,7 @@ impl<T: Affiliated> NodeDag<T> {
         let strong_node_ref = Arc::new(RwLock::new(node));
         // important: do this first, before downgrading the head references
         self.node_table
-            .insert(digest, Either::Right(strong_node_ref));
+            .insert(digest, Either::Right(strong_node_ref.into()));
         // maintain the header invariant
         for mut parent in parent_digests
             .into_iter()

--- a/dag/src/node_dag.rs
+++ b/dag/src/node_dag.rs
@@ -80,7 +80,9 @@ impl<T: Affiliated> NodeDag<T> {
         }
     }
 
-    // Note: the dag currently does not do any causal completion, and maintains that
+    // Inserts a node in the Dag.
+    // 
+    // Note: the dag currently does not do any causal completion, and only verifies the invariant that
     // - insertion should be idempotent
     // - an unseen node is a head (not pointed) to by any other node.
     pub fn try_insert(&mut self, value: T) -> Result<(), DagError<T>> {


### PR DESCRIPTION
## Summary 

- The BFS, especially in a context where our data structure is a DAG and not a graph, was doing multiple passes on the graph. The traversal marks encountered nodes to avoid these duplicates.

- the DAG is now lock-less. This solves a concurrency issue where lock contention on leaves was preventing their deletion through path compression (#90).