### PR TITLE
support duration for Properties

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -32,10 +32,15 @@ node_params = {
     'header_size': 1_000,
     'max_header_delay': '100ms',
     'gc_depth': 50,
-    'sync_retry_delay': '10_000ms',
+    'sync_retry_delay': '10000ms',
     'sync_retry_nodes': 3,
     'batch_size': 500_000,
-    'max_batch_delay': '100ms'
+    'max_batch_delay': '100ms',
+    'block_synchronizer': {
+        'certificates_synchronize_timeout': '2000ms',
+        'payload_synchronize_timeout': '2000ms',
+        'payload_availability_timeout': '2000ms'
+    }
 }
 ```
 They are defined as follows:
@@ -46,6 +51,9 @@ They are defined as follows:
 * `sync_retry_nodes`: How many nodes to sync when re-trying to send sync-request. These nodes are picked at random from the committee.
 * `batch_size`: The preferred batch size. The workers seal a batch of transactions when it reaches this size. Denominated in bytes.
 * `max_batch_delay`: The delay after which the workers seal a batch of transactions, even if `max_batch_size` is not reached. Denominated in ms.
+* `certificates_synchronize_timeout`: The timeout configuration when requesting certificates from peers.
+* `payload_synchronize_timeout`: Timeout when has requested the payload for a certificate and is waiting to receive them.
+* `payload_availability_timeout`: The timeout configuration when for when we ask the other peers to discover who has the payload available for the dictated certificates.
 
 ### Run the benchmark
 Once you specified both `bench_params` and `node_params` as desired, run:

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -30,12 +30,12 @@ The nodes parameters determine the configuration for the primaries and workers:
 ```python
 node_params = {
     'header_size': 1_000,
-    'max_header_delay': 100,
+    'max_header_delay': '100ms',
     'gc_depth': 50,
-    'sync_retry_delay': 10_000,
+    'sync_retry_delay': '10_000ms',
     'sync_retry_nodes': 3,
     'batch_size': 500_000,
-    'max_batch_delay': 100
+    'max_batch_delay': '100ms'
 }
 ```
 They are defined as follows:

--- a/benchmark/benchmark/config.py
+++ b/benchmark/benchmark/config.py
@@ -175,9 +175,6 @@ class NodeParameters:
         except KeyError as e:
             raise ConfigError(f'Malformed parameters: missing key {e}')
 
-        if not all(isinstance(x, int) for x in inputs):
-            raise ConfigError('Invalid parameters type')
-
         self.json = json
 
     def print(self, filename):

--- a/benchmark/fabfile.py
+++ b/benchmark/fabfile.py
@@ -24,14 +24,14 @@ def local(ctx, debug=True):
         'header_size': 1_000,  # bytes
         'max_header_delay': '200ms',  # ms
         'gc_depth': 50,  # rounds
-        'sync_retry_delay': '10000ms',  # ms
+        'sync_retry_delay': '10_000ms',  # ms
         'sync_retry_nodes': 3,  # number of nodes
         'batch_size': 500_000,  # bytes
         'max_batch_delay': '200ms',  # ms,
         'block_synchronizer': {
-            'certificates_synchronize_timeout': '2000ms',
-            'payload_synchronize_timeout': '2000ms',
-            'payload_availability_timeout': '2000ms'
+            'certificates_synchronize_timeout': '2_000ms',
+            'payload_synchronize_timeout': '2_000ms',
+            'payload_availability_timeout': '2_000ms'
         }
     }
     try:
@@ -112,13 +112,13 @@ def remote(ctx, debug=False):
         'header_size': 1_000,  # bytes
         'max_header_delay': '200ms',  # ms
         'gc_depth': 50,  # rounds
-        'sync_retry_delay': '10000ms',  # ms
+        'sync_retry_delay': '10_000ms',  # ms
         'sync_retry_nodes': 3,  # number of nodes
         'batch_size': 500_000,  # bytes
         'block_synchronizer': {
-            'certificates_synchronize_timeout': '2000ms',
-            'payload_synchronize_timeout': '2000ms',
-            'payload_availability_timeout': '2000ms'
+            'certificates_synchronize_timeout': '2_000ms',
+            'payload_synchronize_timeout': '2_000ms',
+            'payload_availability_timeout': '2_000ms'
         }
     }
     try:

--- a/benchmark/fabfile.py
+++ b/benchmark/fabfile.py
@@ -22,16 +22,16 @@ def local(ctx, debug=True):
     }
     node_params = {
         'header_size': 1_000,  # bytes
-        'max_header_delay': 200,  # ms
+        'max_header_delay': '200ms',  # ms
         'gc_depth': 50,  # rounds
-        'sync_retry_delay': 10_000,  # ms
+        'sync_retry_delay': '10_000ms',  # ms
         'sync_retry_nodes': 3,  # number of nodes
         'batch_size': 500_000,  # bytes
-        'max_batch_delay': 200,  # ms,
+        'max_batch_delay': '200ms',  # ms,
         'block_synchronizer': {
-            'certificates_synchronize_timeout_ms': 2_000,
-            'payload_synchronize_timeout_ms': 2_000,
-            'payload_availability_timeout_ms': 2_000
+            'certificates_synchronize_timeout': '2_000ms',
+            'payload_synchronize_timeout': '2_000ms',
+            'payload_availability_timeout': '2_000ms'
         }
     }
     try:
@@ -110,16 +110,15 @@ def remote(ctx, debug=False):
     }
     node_params = {
         'header_size': 1_000,  # bytes
-        'max_header_delay': 200,  # ms
+        'max_header_delay': '200ms',  # ms
         'gc_depth': 50,  # rounds
-        'sync_retry_delay': 10_000,  # ms
+        'sync_retry_delay': '10_000ms',  # ms
         'sync_retry_nodes': 3,  # number of nodes
         'batch_size': 500_000,  # bytes
-        'max_batch_delay': 200,  # ms
         'block_synchronizer': {
-            'certificates_synchronize_timeout_ms': 2_000,
-            'payload_synchronize_timeout_ms': 2_000,
-            'payload_availability_timeout_ms': 2_000
+            'certificates_synchronize_timeout': '2_000ms',
+            'payload_synchronize_timeout': '2_000ms',
+            'payload_availability_timeout': '2_000ms'
         }
     }
     try:

--- a/benchmark/fabfile.py
+++ b/benchmark/fabfile.py
@@ -24,14 +24,14 @@ def local(ctx, debug=True):
         'header_size': 1_000,  # bytes
         'max_header_delay': '200ms',  # ms
         'gc_depth': 50,  # rounds
-        'sync_retry_delay': '10_000ms',  # ms
+        'sync_retry_delay': '10000ms',  # ms
         'sync_retry_nodes': 3,  # number of nodes
         'batch_size': 500_000,  # bytes
         'max_batch_delay': '200ms',  # ms,
         'block_synchronizer': {
-            'certificates_synchronize_timeout': '2_000ms',
-            'payload_synchronize_timeout': '2_000ms',
-            'payload_availability_timeout': '2_000ms'
+            'certificates_synchronize_timeout': '2000ms',
+            'payload_synchronize_timeout': '2000ms',
+            'payload_availability_timeout': '2000ms'
         }
     }
     try:
@@ -112,13 +112,13 @@ def remote(ctx, debug=False):
         'header_size': 1_000,  # bytes
         'max_header_delay': '200ms',  # ms
         'gc_depth': 50,  # rounds
-        'sync_retry_delay': '10_000ms',  # ms
+        'sync_retry_delay': '10000ms',  # ms
         'sync_retry_nodes': 3,  # number of nodes
         'batch_size': 500_000,  # bytes
         'block_synchronizer': {
-            'certificates_synchronize_timeout': '2_000ms',
-            'payload_synchronize_timeout': '2_000ms',
-            'payload_availability_timeout': '2_000ms'
+            'certificates_synchronize_timeout': '2000ms',
+            'payload_synchronize_timeout': '2000ms',
+            'payload_availability_timeout': '2000ms'
         }
     }
     try:

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -10,6 +10,7 @@ serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
 thiserror = "1.0.30"
 tracing = { version = "0.1.34", features = ["log"] }
+tracing-test = { version = "0.2.1" }
 
 crypto = { path = "../crypto" }
 

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -13,3 +13,6 @@ tracing = { version = "0.1.34", features = ["log"] }
 
 crypto = { path = "../crypto" }
 
+[dev-dependencies]
+tempfile = "3.3.0"
+

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -10,10 +10,10 @@ serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
 thiserror = "1.0.30"
 tracing = { version = "0.1.34", features = ["log"] }
-tracing-test = { version = "0.2.1" }
 
 crypto = { path = "../crypto" }
 
 [dev-dependencies]
 tempfile = "3.3.0"
+tracing-test = { version = "0.2.1" }
 

--- a/config/src/duration_format.rs
+++ b/config/src/duration_format.rs
@@ -1,0 +1,79 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Allow us to serialize and deserialize Duration values in a more
+//! human friendly format (e.x in json files). When serialized then
+//! a string of the following format is written: [number]ms , for
+//! example "20ms". When deserialized, then a Duration is created.
+use serde::{Deserialize, Deserializer};
+use std::time::Duration;
+
+pub fn deserialize<'de, D>(deserializer: D) -> Result<Duration, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer)?;
+
+    if let Some(milis) = s.strip_suffix("ms") {
+        return milis
+            .parse::<u64>()
+            .map(Duration::from_millis)
+            .map_err(|e| serde::de::Error::custom(e.to_string()));
+    } else if let Some(seconds) = s.strip_suffix('s') {
+        return seconds
+            .parse::<u64>()
+            .map(Duration::from_secs)
+            .map_err(|e| serde::de::Error::custom(e.to_string()));
+    }
+
+    Err(serde::de::Error::custom(format!(
+        "Wrong format detected: {s}. It should be number in miliseconds, e.x 10ms"
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::duration_format;
+    use serde::Deserialize;
+    use std::time::Duration;
+
+    #[derive(Deserialize)]
+    struct MockProperties {
+        #[serde(with = "duration_format")]
+        property_1: Duration,
+        #[serde(with = "duration_format")]
+        property_2: Duration,
+    }
+
+    #[test]
+    fn parse_miliseconds_and_seconds() {
+        // GIVEN
+        let input = r#"{
+             "property_1": "1000ms",
+             "property_2": "8s"
+          }"#;
+
+        // WHEN
+        let result: MockProperties =
+            serde_json::from_str(input).expect("Couldn't deserialize string");
+
+        // THEN
+        assert_eq!(result.property_1.as_millis(), 1_000);
+        assert_eq!(result.property_2.as_secs(), 8);
+    }
+
+    #[test]
+    fn parse_error() {
+        // GIVEN
+        let input = r#"{
+             "property_1": "1000 ms",
+             "property_2": "8seconds"
+          }"#;
+
+        // WHEN
+        let result = serde_json::from_str::<MockProperties>(input);
+
+        // THEN
+        assert!(result.is_err());
+    }
+}

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -362,6 +362,7 @@ mod tests {
     use crate::{duration_format, Deserialize, Import, Parameters};
     use std::{fs::File, io::Write, time::Duration};
     use tempfile::tempdir;
+    use tracing_test::traced_test;
 
     #[derive(Deserialize)]
     struct MockProperties {
@@ -372,6 +373,7 @@ mod tests {
     }
 
     #[test]
+    #[traced_test]
     fn parse_properties() {
         // GIVEN
         let input = r#"{
@@ -424,6 +426,34 @@ mod tests {
                 .as_millis(),
             4_000
         );
+    }
+
+    #[test]
+    #[traced_test]
+    fn tracing_should_print_parameters() {
+        // GIVEN
+        let parameters = Parameters::default();
+
+        // WHEN
+        parameters.tracing();
+
+        // THEN
+        assert!(logs_contain("Header size set to 1000 B"));
+        assert!(logs_contain("Max header delay set to 100 ms"));
+        assert!(logs_contain("Garbage collection depth set to 50 rounds"));
+        assert!(logs_contain("Sync retry delay set to 5000 ms"));
+        assert!(logs_contain("Sync retry nodes set to 3 nodes"));
+        assert!(logs_contain("Batch size set to 500000 B"));
+        assert!(logs_contain("Max batch delay set to 100 ms"));
+        assert!(logs_contain(
+            "Synchronize certificates timeout set to 2000 ms"
+        ));
+        assert!(logs_contain(
+            "Payload (batches) availability timeout set to 2000 ms"
+        ));
+        assert!(logs_contain(
+            "Synchronize payload (batches) timeout set to 2000 ms"
+        ));
     }
 
     #[test]

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -373,17 +373,8 @@ impl<PublicKey: VerifyingKey> Committee<PublicKey> {
 /// a string of the following format is written: [number]ms , for
 /// example "20ms". When deserialized, then a Duration is created.
 mod duration_format {
-    use serde::{Deserialize, Deserializer, Serializer};
+    use serde::{Deserialize, Deserializer};
     use std::time::Duration;
-
-    #[allow(dead_code)]
-    pub fn serialize<S>(duration: &Duration, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let s = format!("{}ms", duration.as_millis());
-        serializer.serialize_str(&s)
-    }
 
     pub fn deserialize<'de, D>(deserializer: D) -> Result<Duration, D::Error>
     where

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -76,6 +76,8 @@ pub type WorkerId = u32;
 #[derive(Deserialize, Clone)]
 /// Holds all the node properties. An example is provided to
 /// showcase the usage and deserialization from a json file.
+/// To define a Duration on the property file can use either
+/// miliseconds or seconds (e.x 5s, 10ms , 2000ms)
 ///
 /// ```rust
 ///  use std::fs::File;
@@ -89,12 +91,12 @@ pub type WorkerId = u32;
 ///     "header_size": 1000,
 ///     "max_header_delay": "100ms",
 ///     "gc_depth": 50,
-///     "sync_retry_delay": "5000ms",
+///     "sync_retry_delay": "5s",
 ///     "sync_retry_nodes": 3,
 ///     "batch_size": 500000,
 ///     "max_batch_delay": "100ms",
 ///     "block_synchronizer": {
-///         "certificates_synchronize_timeout": "2000ms",
+///         "certificates_synchronize_timeout": "2s",
 ///         "payload_synchronize_timeout": "3000ms",
 ///         "payload_availability_timeout": "4000ms"
 ///     }
@@ -113,6 +115,7 @@ pub type WorkerId = u32;
 ///  let params = Parameters::import(file_path.to_str().unwrap()).expect("Error raised");
 ///
 ///  // THEN
+///  assert_eq!(params.sync_retry_delay.as_millis(), 5_000);
 ///  assert_eq!(params.block_synchronizer.certificates_synchronize_timeout.as_millis(), 2_000);
 ///  assert_eq!(params.block_synchronizer.payload_synchronize_timeout.as_millis(), 3_000);
 ///  assert_eq!(params.block_synchronizer.payload_availability_timeout.as_millis(), 4_000);
@@ -197,6 +200,11 @@ mod duration_format {
             return milis
                 .parse::<u64>()
                 .map(Duration::from_millis)
+                .map_err(|e| serde::de::Error::custom(e.to_string()));
+        } else if let Some(seconds) = s.strip_suffix('s') {
+            return seconds
+                .parse::<u64>()
+                .map(Duration::from_secs)
                 .map_err(|e| serde::de::Error::custom(e.to_string()));
         }
 

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -21,6 +21,8 @@ use std::{
 use thiserror::Error;
 use tracing::info;
 
+mod duration_format;
+
 #[derive(Error, Debug)]
 pub enum ConfigError {
     #[error("Node {0} is not in the committee")]
@@ -325,52 +327,12 @@ impl<PublicKey: VerifyingKey> Committee<PublicKey> {
     }
 }
 
-/// Allow us to serialize and deserialize Duration values in a more
-/// human friendly format (e.x in json files). When serialized then
-/// a string of the following format is written: [number]ms , for
-/// example "20ms". When deserialized, then a Duration is created.
-mod duration_format {
-    use serde::{Deserialize, Deserializer};
-    use std::time::Duration;
-
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<Duration, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let s = String::deserialize(deserializer)?;
-
-        if let Some(milis) = s.strip_suffix("ms") {
-            return milis
-                .parse::<u64>()
-                .map(Duration::from_millis)
-                .map_err(|e| serde::de::Error::custom(e.to_string()));
-        } else if let Some(seconds) = s.strip_suffix('s') {
-            return seconds
-                .parse::<u64>()
-                .map(Duration::from_secs)
-                .map_err(|e| serde::de::Error::custom(e.to_string()));
-        }
-
-        Err(serde::de::Error::custom(format!(
-            "Wrong format detected: {s}. It should be number in miliseconds, e.x 10ms"
-        )))
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use crate::{duration_format, Deserialize, Import, Parameters};
-    use std::{fs::File, io::Write, time::Duration};
+    use crate::{Import, Parameters};
+    use std::{fs::File, io::Write};
     use tempfile::tempdir;
     use tracing_test::traced_test;
-
-    #[derive(Deserialize)]
-    struct MockProperties {
-        #[serde(with = "duration_format")]
-        property_1: Duration,
-        #[serde(with = "duration_format")]
-        property_2: Duration,
-    }
 
     #[test]
     #[traced_test]
@@ -454,37 +416,5 @@ mod tests {
         assert!(logs_contain(
             "Synchronize payload (batches) timeout set to 2000 ms"
         ));
-    }
-
-    #[test]
-    fn parse_miliseconds_and_seconds() {
-        // GIVEN
-        let input = r#"{
-             "property_1": "1000ms",
-             "property_2": "8s"
-          }"#;
-
-        // WHEN
-        let result: MockProperties =
-            serde_json::from_str(input).expect("Couldn't deserialize string");
-
-        // THEN
-        assert_eq!(result.property_1.as_millis(), 1_000);
-        assert_eq!(result.property_2.as_secs(), 8);
-    }
-
-    #[test]
-    fn parse_error() {
-        // GIVEN
-        let input = r#"{
-             "property_1": "1000 ms",
-             "property_2": "8seconds"
-          }"#;
-
-        // WHEN
-        let result = serde_json::from_str::<MockProperties>(input);
-
-        // THEN
-        assert!(result.is_err());
     }
 }

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -173,47 +173,6 @@ impl Default for BlockSynchronizerParameters {
     }
 }
 
-/// Allow us to serialize and deserialize Duration values in a more
-/// human friendly format (e.x in json files). When serialized then
-/// a string of the following format is written: [number]ms , for
-/// example "20ms". When deserialized, then a Duration is created.
-mod duration_format {
-    use serde::{Deserialize, Deserializer, Serializer};
-    use std::time::Duration;
-
-    #[allow(dead_code)]
-    pub fn serialize<S>(duration: &Duration, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let s = format!("{}ms", duration.as_millis());
-        serializer.serialize_str(&s)
-    }
-
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<Duration, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let s = String::deserialize(deserializer)?;
-
-        if let Some(milis) = s.strip_suffix("ms") {
-            return milis
-                .parse::<u64>()
-                .map(Duration::from_millis)
-                .map_err(|e| serde::de::Error::custom(e.to_string()));
-        } else if let Some(seconds) = s.strip_suffix('s') {
-            return seconds
-                .parse::<u64>()
-                .map(Duration::from_secs)
-                .map_err(|e| serde::de::Error::custom(e.to_string()));
-        }
-
-        Err(serde::de::Error::custom(format!(
-            "Wrong format detected: {s}. It should be number in miliseconds, e.x 10ms"
-        )))
-    }
-}
-
 impl Default for Parameters {
     fn default() -> Self {
         Self {
@@ -406,5 +365,92 @@ impl<PublicKey: VerifyingKey> Committee<PublicKey> {
                     .map(|(_, addresses)| (name.deref().clone(), addresses.clone()))
             })
             .collect()
+    }
+}
+
+/// Allow us to serialize and deserialize Duration values in a more
+/// human friendly format (e.x in json files). When serialized then
+/// a string of the following format is written: [number]ms , for
+/// example "20ms". When deserialized, then a Duration is created.
+mod duration_format {
+    use serde::{Deserialize, Deserializer, Serializer};
+    use std::time::Duration;
+
+    #[allow(dead_code)]
+    pub fn serialize<S>(duration: &Duration, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let s = format!("{}ms", duration.as_millis());
+        serializer.serialize_str(&s)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Duration, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+
+        if let Some(milis) = s.strip_suffix("ms") {
+            return milis
+                .parse::<u64>()
+                .map(Duration::from_millis)
+                .map_err(|e| serde::de::Error::custom(e.to_string()));
+        } else if let Some(seconds) = s.strip_suffix('s') {
+            return seconds
+                .parse::<u64>()
+                .map(Duration::from_secs)
+                .map_err(|e| serde::de::Error::custom(e.to_string()));
+        }
+
+        Err(serde::de::Error::custom(format!(
+            "Wrong format detected: {s}. It should be number in miliseconds, e.x 10ms"
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{duration_format, Deserialize};
+    use std::time::Duration;
+
+    #[derive(Deserialize)]
+    struct MockProperties {
+        #[serde(with = "duration_format")]
+        property_1: Duration,
+        #[serde(with = "duration_format")]
+        property_2: Duration,
+    }
+
+    #[test]
+    fn parse_miliseconds_and_seconds() {
+        // GIVEN
+        let input = r#"{
+             "property_1": "1000ms",
+             "property_2": "8s"
+          }"#;
+
+        // WHEN
+        let result: MockProperties =
+            serde_json::from_str(input).expect("Couldn't deserialize string");
+
+        // THEN
+        assert_eq!(result.property_1.as_millis(), 1_000);
+        assert_eq!(result.property_2.as_secs(), 8);
+    }
+
+    #[test]
+    fn parse_error() {
+        // GIVEN
+        let input = r#"{
+             "property_1": "1000 ms",
+             "property_2": "8seconds"
+          }"#;
+
+        // WHEN
+        let result = serde_json::from_str::<MockProperties>(input);
+
+        // THEN
+        assert!(result.is_err());
     }
 }

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -348,8 +348,8 @@ mod tests {
              "max_batch_delay": "100ms",
              "block_synchronizer": {
                  "certificates_synchronize_timeout": "2s",
-                 "payload_synchronize_timeout": "3000ms",
-                 "payload_availability_timeout": "4000ms"
+                 "payload_synchronize_timeout": "3_000ms",
+                 "payload_availability_timeout": "4_000ms"
              }
           }"#;
 

--- a/primary/src/block_synchronizer/mod.rs
+++ b/primary/src/block_synchronizer/mod.rs
@@ -192,15 +192,9 @@ impl<PublicKey: VerifyingKey> BlockSynchronizer<PublicKey> {
                 map_payload_availability_responses_senders: HashMap::new(),
                 network,
                 payload_store,
-                certificates_synchronize_timeout: Duration::from_millis(
-                    parameters.certificates_synchronize_timeout_ms,
-                ),
-                payload_synchronize_timeout: Duration::from_millis(
-                    parameters.payload_availability_timeout_ms,
-                ),
-                payload_availability_timeout: Duration::from_millis(
-                    parameters.payload_availability_timeout_ms,
-                ),
+                certificates_synchronize_timeout: parameters.certificates_synchronize_timeout,
+                payload_synchronize_timeout: parameters.payload_availability_timeout,
+                payload_availability_timeout: parameters.payload_availability_timeout,
             }
             .run()
             .await;

--- a/primary/src/header_waiter.rs
+++ b/primary/src/header_waiter.rs
@@ -56,7 +56,7 @@ pub struct HeaderWaiter<PublicKey: VerifyingKey> {
     /// The depth of the garbage collector.
     gc_depth: Round,
     /// The delay to wait before re-trying sync requests.
-    sync_retry_delay: u64,
+    sync_retry_delay: Duration,
     /// Determine with how many nodes to sync when re-trying to send sync-request.
     sync_retry_nodes: usize,
 
@@ -86,7 +86,7 @@ impl<PublicKey: VerifyingKey> HeaderWaiter<PublicKey> {
         payload_store: Store<(BatchDigest, WorkerId), PayloadToken>,
         consensus_round: Arc<AtomicU64>,
         gc_depth: Round,
-        sync_retry_delay: u64,
+        sync_retry_delay: Duration,
         sync_retry_nodes: usize,
         rx_synchronizer: Receiver<WaiterMessage<PublicKey>>,
         tx_core: Sender<Header<PublicKey>>,
@@ -265,7 +265,7 @@ impl<PublicKey: VerifyingKey> HeaderWaiter<PublicKey> {
 
                     let mut retry = Vec::new();
                     for (digest, (_, timestamp)) in &self.parent_requests {
-                        if timestamp + (self.sync_retry_delay as u128) < now {
+                        if timestamp + self.sync_retry_delay.as_millis() < now {
                             debug!("Requesting sync for certificate {digest} (retry)");
                             retry.push(*digest);
                         }

--- a/primary/src/primary.rs
+++ b/primary/src/primary.rs
@@ -3,8 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 use crate::{
     block_remover::DeleteBatchResult,
-    // TODO[#175][#127]: re-plug the BlockSynchronizer
-    // block_synchronizer::BlockSynchronizer,
     block_waiter::{BatchMessage, BatchMessageError, BatchResult, BlockWaiter},
     certificate_waiter::CertificateWaiter,
     core::Core,
@@ -14,18 +12,11 @@ use crate::{
     payload_receiver::PayloadReceiver,
     proposer::Proposer,
     synchronizer::Synchronizer,
-    BlockRemover,
-    DeleteBatchMessage,
+    BlockRemover, DeleteBatchMessage,
 };
 use async_trait::async_trait;
 use bytes::Bytes;
-use config::{
-    // TODO[#175][#127]: re-plug the BlockSynchronizer
-    // BlockSynchronizerParameters,
-    Committee,
-    Parameters,
-    WorkerId,
-};
+use config::{Committee, Parameters, WorkerId};
 use crypto::{
     traits::{EncodeDecodeBase64, Signer, VerifyingKey},
     SignatureService,

--- a/primary/src/tests/proposer_tests.rs
+++ b/primary/src/tests/proposer_tests.rs
@@ -22,7 +22,7 @@ async fn propose_empty() {
         &committee(),
         signature_service,
         /* header_size */ 1_000,
-        /* max_header_delay */ 20,
+        /* max_header_delay */ Duration::from_millis(20),
         /* rx_core */ rx_parents,
         /* rx_workers */ rx_our_digests,
         /* tx_core */ tx_headers,
@@ -51,7 +51,8 @@ async fn propose_payload() {
         &committee(),
         signature_service,
         /* header_size */ 32,
-        /* max_header_delay */ 1_000_000, // Ensure it is not triggered.
+        /* max_header_delay */
+        Duration::from_millis(1_000_000), // Ensure it is not triggered.
         /* rx_core */ rx_parents,
         /* rx_workers */ rx_our_digests,
         /* tx_core */ tx_headers,

--- a/worker/src/synchronizer.rs
+++ b/worker/src/synchronizer.rs
@@ -40,7 +40,7 @@ pub struct Synchronizer<PublicKey: VerifyingKey> {
     /// The depth of the garbage collection.
     gc_depth: Round,
     /// The delay to wait before re-trying to send sync requests.
-    sync_retry_delay: u64,
+    sync_retry_delay: Duration,
     /// Determine with how many nodes to sync when re-trying to send sync-requests. These nodes
     /// are picked at random from the committee.
     sync_retry_nodes: usize,
@@ -65,7 +65,7 @@ impl<PublicKey: VerifyingKey> Synchronizer<PublicKey> {
         committee: Committee<PublicKey>,
         store: Store<BatchDigest, SerializedBatchMessage>,
         gc_depth: Round,
-        sync_retry_delay: u64,
+        sync_retry_delay: Duration,
         sync_retry_nodes: usize,
         rx_message: Receiver<PrimaryWorkerMessage<PublicKey>>,
         tx_primary: Sender<SerializedWorkerPrimaryMessage>,
@@ -215,7 +215,7 @@ impl<PublicKey: VerifyingKey> Synchronizer<PublicKey> {
 
                     let mut retry = Vec::new();
                     for (digest, (_, _, timestamp)) in &self.pending {
-                        if timestamp + (self.sync_retry_delay as u128) < now {
+                        if timestamp + self.sync_retry_delay.as_millis() < now {
                             debug!("Requesting sync for batch {digest} (retry)");
                             retry.push(*digest);
                         }

--- a/worker/src/tests/batch_maker_tests.rs
+++ b/worker/src/tests/batch_maker_tests.rs
@@ -15,7 +15,8 @@ async fn make_batch() {
     // Spawn a `BatchMaker` instance.
     BatchMaker::spawn(
         /* max_batch_size */ 200,
-        /* max_batch_delay */ 1_000_000, // Ensure the timer is not triggered.
+        /* max_batch_delay */
+        Duration::from_millis(1_000_000), // Ensure the timer is not triggered.
         rx_transaction,
         tx_message,
         /* workers_addresses */ dummy_addresses,
@@ -43,7 +44,8 @@ async fn batch_timeout() {
     // Spawn a `BatchMaker` instance.
     BatchMaker::spawn(
         /* max_batch_size */ 200,
-        /* max_batch_delay */ 50, // Ensure the timer is triggered.
+        /* max_batch_delay */
+        Duration::from_millis(50), // Ensure the timer is triggered.
         rx_transaction,
         tx_message,
         /* workers_addresses */ dummy_addresses,

--- a/worker/src/tests/synchronizer_tests.rs
+++ b/worker/src/tests/synchronizer_tests.rs
@@ -29,7 +29,8 @@ async fn synchronize() {
         committee.clone(),
         store.clone(),
         /* gc_depth */ 50, // Not used in this test.
-        /* sync_retry_delay */ 1_000_000, // Ensure it is not triggered.
+        /* sync_retry_delay */
+        Duration::from_millis(1_000_000), // Ensure it is not triggered.
         /* sync_retry_nodes */ 3, // Not used in this test.
         rx_message,
         tx_primary,
@@ -71,7 +72,8 @@ async fn test_successful_request_batch() {
         committee.clone(),
         store.clone(),
         /* gc_depth */ 50, // Not used in this test.
-        /* sync_retry_delay */ 1_000_000, // Ensure it is not triggered.
+        /* sync_retry_delay */
+        Duration::from_millis(1_000_000), // Ensure it is not triggered.
         /* sync_retry_nodes */ 3, // Not used in this test.
         rx_message,
         tx_primary,
@@ -125,7 +127,8 @@ async fn test_request_batch_not_found() {
         committee.clone(),
         store.clone(),
         /* gc_depth */ 50, // Not used in this test.
-        /* sync_retry_delay */ 1_000_000, // Ensure it is not triggered.
+        /* sync_retry_delay */
+        Duration::from_millis(1_000_000), // Ensure it is not triggered.
         /* sync_retry_nodes */ 3, // Not used in this test.
         rx_message,
         tx_primary,
@@ -178,7 +181,8 @@ async fn test_successful_batch_delete() {
         committee.clone(),
         store.clone(),
         /* gc_depth */ 50, // Not used in this test.
-        /* sync_retry_delay */ 1_000_000, // Ensure it is not triggered.
+        /* sync_retry_delay */
+        Duration::from_millis(1_000_000), // Ensure it is not triggered.
         /* sync_retry_nodes */ 3, // Not used in this test.
         rx_message,
         tx_primary,

--- a/worker/src/tests/worker_tests.rs
+++ b/worker/src/tests/worker_tests.rs
@@ -1,7 +1,7 @@
-use std::time::Duration;
 // Copyright (c) 2021, Facebook, Inc. and its affiliates
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
+use std::time::Duration;
 use super::*;
 use crate::{
     common::{

--- a/worker/src/tests/worker_tests.rs
+++ b/worker/src/tests/worker_tests.rs
@@ -1,3 +1,4 @@
+use std::time::Duration;
 // Copyright (c) 2021, Facebook, Inc. and its affiliates
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
@@ -66,7 +67,7 @@ async fn handle_client_batch_request() {
     let id = 0;
     let committee = committee_with_base_port(11_001);
     let parameters = Parameters {
-        max_header_delay: 100_000, // Ensure no batches are created.
+        max_header_delay: Duration::from_millis(100_000), // Ensure no batches are created.
         ..Parameters::default()
     };
 

--- a/worker/src/tests/worker_tests.rs
+++ b/worker/src/tests/worker_tests.rs
@@ -1,7 +1,6 @@
 // Copyright (c) 2021, Facebook, Inc. and its affiliates
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use std::time::Duration;
 use super::*;
 use crate::{
     common::{
@@ -14,6 +13,7 @@ use crypto::ed25519::Ed25519PublicKey;
 use futures::{SinkExt, StreamExt};
 use network::SimpleSender;
 use primary::WorkerPrimaryMessage;
+use std::time::Duration;
 use store::rocks;
 use tokio::net::TcpStream;
 use tokio_util::codec::{Framed, LengthDelimitedCodec};


### PR DESCRIPTION
Given the recent work on the `block_synchronizer` I got the need to use `Duration` as property coming from the `Properties` struct. Unfortunately, serializing a `Duration` looks like:
```
{
    "secs": xxxxxx, "nanos": xxxxxx
}
```

which is quite counter intuitive on a configuration file. I've wrote small deserialize/serialize methods to support defining durations in miliseconds and seconds in a simple manner, like:
```
{
   "property_1": "10ms",
   "property_2": "50s"
}
```

tried to keep it simple so I've avoided brining in any Regex library etc.

I've also refactored the code so we use only `Duration` on the properties whenever we need to (and from now on we should probably stick to that), so we avoid doing conversions and have the need to define time units as part of the variable names (e.x `_ms` ) or put the units in comments.