### PR TITLE
[benchmark] Just kill the tmux session at the end

### DIFF
--- a/benchmark/benchmark/commands.py
+++ b/benchmark/benchmark/commands.py
@@ -1,4 +1,5 @@
 # Copyright(C) Facebook, Inc. and its affiliates.
+import subprocess
 from os.path import join
 
 from benchmark.utils import PathMaker
@@ -57,7 +58,8 @@ class CommandMaker:
 
     @staticmethod
     def kill():
-        return 'tmux kill-server'
+        cmd = '''tmux list-sessions | awk 'BEGIN{FS=":"}{print $1}' | grep -eE (worker|primary|client)| xargs -n 1 tmux kill-session -t'''
+        return cmd
 
     @staticmethod
     def alias_binaries(origin):

--- a/benchmark/benchmark/utils.py
+++ b/benchmark/benchmark/utils.py
@@ -51,13 +51,13 @@ class PathMaker:
     @staticmethod
     def worker_log_file(i, j):
         assert isinstance(i, int) and i >= 0
-        assert isinstance(j, int) and i >= 0
+        assert isinstance(j, int) and j >= 0
         return join(PathMaker.logs_path(), f'worker-{i}-{j}.log')
 
     @staticmethod
     def client_log_file(i, j):
         assert isinstance(i, int) and i >= 0
-        assert isinstance(j, int) and i >= 0
+        assert isinstance(j, int) and j >= 0
         return join(PathMaker.logs_path(), f'client-{i}-{j}.log')
 
     @staticmethod


### PR DESCRIPTION
This kills the session we started instead of the whole server.
The session we start is named:
- [here for local runs](https://github.com/MystenLabs/narwhal/blob/main/benchmark/benchmark/local.py#L29)
- [here for remote runs](https://github.com/MystenLabs/narwhal/blob/main/benchmark/benchmark/remote.py#L134)

Fixes MystenLabs/sui#5220.

Tmux man page:
https://www.man7.org/linux/man-pages/man1/tmux.1.html