### PR TITLE
[benchmarks] Repair benchmarks

### DIFF
--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -93,8 +93,6 @@ pub struct Parameters {
     /// The delay after which the workers seal a batch of transactions, even if `max_batch_size`
     /// is not reached. Denominated in ms.
     pub max_batch_delay: u64,
-    /// The parameters for the block synchronizer
-    pub block_synchronizer: BlockSynchronizerParameters,
 }
 
 #[derive(Deserialize, Clone)]
@@ -131,7 +129,6 @@ impl Default for Parameters {
             sync_retry_nodes: 3,
             batch_size: 500_000,
             max_batch_delay: 100,
-            block_synchronizer: BlockSynchronizerParameters::default(),
         }
     }
 }
@@ -145,18 +142,6 @@ impl Parameters {
         info!("Sync retry nodes set to {} nodes", self.sync_retry_nodes);
         info!("Batch size set to {} B", self.batch_size);
         info!("Max batch delay set to {} ms", self.max_batch_delay);
-        info!(
-            "Synchronize certificates timeout set to {} ms",
-            self.block_synchronizer.certificates_synchronize_timeout_ms
-        );
-        info!(
-            "Payload (batches) availability timeout set to {} ms",
-            self.block_synchronizer.payload_availability_timeout_ms
-        );
-        info!(
-            "Synchronize payload (batches) timeout set to {} ms",
-            self.block_synchronizer.payload_synchronize_timeout_ms
-        );
     }
 }
 

--- a/primary/src/lib.rs
+++ b/primary/src/lib.rs
@@ -10,6 +10,8 @@
 
 mod aggregators;
 mod block_remover;
+// TODO [#175][#127]: re-plug the blocksynchronzier
+#[allow(dead_code)]
 mod block_synchronizer;
 mod block_waiter;
 mod certificate_waiter;

--- a/primary/src/primary.rs
+++ b/primary/src/primary.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 use async_trait::async_trait;
 use bytes::Bytes;
-use config::{Committee, Parameters, WorkerId};
+use config::{BlockSynchronizerParameters, Committee, Parameters, WorkerId};
 use crypto::{
     traits::{EncodeDecodeBase64, Signer, VerifyingKey},
     SignatureService,
@@ -270,7 +270,7 @@ impl Primary {
             rx_payload_availability_responses,
             SimpleSender::new(),
             payload_store.clone(),
-            parameters.block_synchronizer,
+            BlockSynchronizerParameters::default(),
         );
 
         // Whenever the `Synchronizer` does not manage to validate a header due to missing parent certificates of

--- a/primary/src/primary.rs
+++ b/primary/src/primary.rs
@@ -3,7 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 use crate::{
     block_remover::DeleteBatchResult,
-    block_synchronizer::BlockSynchronizer,
+    // TODO[#175][#127]: re-plug the BlockSynchronizer
+    // block_synchronizer::BlockSynchronizer,
     block_waiter::{BatchMessage, BatchMessageError, BatchResult, BlockWaiter},
     certificate_waiter::CertificateWaiter,
     core::Core,
@@ -13,11 +14,18 @@ use crate::{
     payload_receiver::PayloadReceiver,
     proposer::Proposer,
     synchronizer::Synchronizer,
-    BlockRemover, DeleteBatchMessage,
+    BlockRemover,
+    DeleteBatchMessage,
 };
 use async_trait::async_trait;
 use bytes::Bytes;
-use config::{BlockSynchronizerParameters, Committee, Parameters, WorkerId};
+use config::{
+    // TODO[#175][#127]: re-plug the BlockSynchronizer
+    // BlockSynchronizerParameters,
+    Committee,
+    Parameters,
+    WorkerId,
+};
 use crypto::{
     traits::{EncodeDecodeBase64, Signer, VerifyingKey},
     SignatureService,
@@ -143,11 +151,13 @@ impl Primary {
         // to remove collections from Narwhal (e.x the remove_collections endpoint).
         let (_tx_block_removal_commands, rx_block_removal_commands) = channel(CHANNEL_CAPACITY);
         let (tx_batch_removal, rx_batch_removal) = channel(CHANNEL_CAPACITY);
+        /* TODO[#175][#175][#127]: re-plug the block synchronizer
         let (_tx_block_synchronizer_commands, rx_block_synchronizer_commands) =
             channel(CHANNEL_CAPACITY);
         let (_tx_certificate_responses, rx_certificate_responses) = channel(CHANNEL_CAPACITY);
         let (_tx_payload_availability_responses, rx_payload_availability_responses) =
             channel(CHANNEL_CAPACITY);
+        */
 
         // Write the parameters to the logs.
         parameters.tracing();
@@ -262,6 +272,7 @@ impl Primary {
 
         // Responsible for finding missing blocks (certificates) and fetching
         // them from the primary peers by synchronizing also their batches.
+        /* TODO[#175][#127]: re-plug the block synchronizer
         BlockSynchronizer::spawn(
             name.clone(),
             committee.clone(),
@@ -272,6 +283,7 @@ impl Primary {
             payload_store.clone(),
             BlockSynchronizerParameters::default(),
         );
+        */
 
         // Whenever the `Synchronizer` does not manage to validate a header due to missing parent certificates of
         // batch digests, it commands the `HeaderWaiter` to synchronize with other nodes, wait for their reply, and


### PR DESCRIPTION
This essentially unplugs the elements of #125 which interfere with the launch of the primary and the subsequent benchmarks. See #175 for the details of what needs fixing.

This punts to #127 (which actually plugs the channels and makes them do something) for reactivating things.