### PR TITLE
[dag] DAG Extensions 

### DIFF
--- a/dag/src/lib.rs
+++ b/dag/src/lib.rs
@@ -57,6 +57,23 @@ impl<T> From<Arc<Node<T>>> for NodeRef<T> {
     }
 }
 
+impl<T> NodeRef<T> {
+    /// Returns a NodeRef pointing at the Node passed as argument
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use dag::{ Node, NodeRef };
+    ///
+    /// let node = Node::new_leaf(1, false);
+    /// // Note the 2 derefs: one for the newtype, one for the Arc
+    /// assert_eq!(Node::new_leaf(1, false), **NodeRef::from_pointee(node));
+    /// ```
+    pub fn from_pointee(val: Node<T>) -> Self {
+        Arc::new(val).into()
+    }
+}
+
 /// Non reference-counted pointers to a Node
 pub type WeakNodeRef<T> = Weak<Node<T>>;
 
@@ -78,8 +95,26 @@ pub struct Node<T> {
     value: T,
 }
 
-impl<T: Sync + Send + std::fmt::Debug> Node<T> {
+impl<T: PartialEq> PartialEq for Node<T> {
+    fn eq(&self, other: &Self) -> bool {
+        *self.parents.load() == *other.parents.load()
+            && self.is_compressible() == other.is_compressible()
+            && self.value.eq(&other.value)
+    }
+}
+
+impl<T: Eq> Eq for Node<T> {}
+
+impl<T> Node<T> {
     /// Create a new DAG leaf node that contains the given value.
+    /// 
+    /// # Example
+    ///
+    /// ```
+    /// use dag::{ Node, NodeRef };
+    ///
+    /// let node = Node::new_leaf(1, false);
+    /// ```
     pub fn new_leaf(value: T, compressible: bool) -> Self {
         Self::new(value, compressible, Vec::default())
     }
@@ -102,7 +137,7 @@ impl<T: Sync + Send + std::fmt::Debug> Node<T> {
 
     /// Return the value payload of the node
     ///
-    /// # Examples
+    /// # Example
     ///
     /// ```
     /// use dag::Node;
@@ -190,7 +225,9 @@ impl<T: Sync + Send + std::fmt::Debug> Node<T> {
     fn is_trivial(&self) -> bool {
         self.parents.load().iter().all(|p| !p.is_compressible())
     }
+}
 
+impl<T: Sync + Send + std::fmt::Debug> Node<T> {
     /// Compress the path from this node to the next incompressible layer of the DAG.
     /// Returns the parents of the node.
     ///

--- a/dag/src/lib.rs
+++ b/dag/src/lib.rs
@@ -107,7 +107,7 @@ impl<T: Eq> Eq for Node<T> {}
 
 impl<T> Node<T> {
     /// Create a new DAG leaf node that contains the given value.
-    /// 
+    ///
     /// # Example
     ///
     /// ```

--- a/dag/src/lib.rs
+++ b/dag/src/lib.rs
@@ -193,8 +193,7 @@ impl<T> Node<T> {
     /// assert_eq!(node.make_compressible(), false);
     /// ```
     pub fn make_compressible(&self) -> bool {
-        let res = self.compressible.set(());
-        res.is_ok()
+        self.compressible.set(()).is_ok()
     }
 
     // What's the maximum distance from this to a leaf?

--- a/dag/src/lib.rs
+++ b/dag/src/lib.rs
@@ -142,6 +142,26 @@ impl<T: Sync + Send + std::fmt::Debug> Node<T> {
         self.compressible.get().is_some()
     }
 
+    /// Make the node compressible.
+    /// Returns true if the node was made compressible, false if it already was.
+    ///
+    /// Beware: this operation is irreversible.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dag::Node;
+    ///
+    /// let node = Node::new_leaf(1, false);
+    /// assert_eq!(node.make_compressible(), true);
+    /// let node2 = Node::new_leaf(2, true);
+    /// assert_eq!(node.make_compressible(), false);
+    /// ```
+    pub fn make_compressible(&self) -> bool {
+        let res = self.compressible.set(());
+        res.is_ok()
+    }
+
     // What's the maximum distance from this to a leaf?
     #[cfg(test)]
     fn height(&self) -> usize {
@@ -307,7 +327,7 @@ mod tests {
         ) {
             let first = dag.first().unwrap();
             let iter = bfs(first.clone());
-            // The first nodemay end up compressible
+            // The first nodemay end up compressible as a result of our random DAG
             let mut is_first = true;
             for node in iter {
                 if !is_first {

--- a/dag/src/node_dag.rs
+++ b/dag/src/node_dag.rs
@@ -111,7 +111,7 @@ impl<T: Affiliated> NodeDag<T> {
             .ok_or(DagError::UnknownDigest(hash))?;
         match *node_ref {
             Either::Right(ref _node) => Ok(true),
-            Either::Left(ref _ode) => Ok(false),
+            Either::Left(ref _node) => Ok(false),
         }
     }
 


### PR DESCRIPTION
This 
- adds many convenience methods and doc tests
- adds flipping the compressible bit to a DAG vertex, enacting the semantics we want for removal
- extends tests to check compression and removal semantics