### PR TITLE
fix: missing block_synchronizer config from fabfile

### DIFF
--- a/benchmark/fabfile.py
+++ b/benchmark/fabfile.py
@@ -27,7 +27,12 @@ def local(ctx, debug=True):
         'sync_retry_delay': 10_000,  # ms
         'sync_retry_nodes': 3,  # number of nodes
         'batch_size': 500_000,  # bytes
-        'max_batch_delay': 200  # ms
+        'max_batch_delay': 200,  # ms,
+        'block_synchronizer': {
+            'certificates_synchronize_timeout_ms': 2_000,
+            'payload_synchronize_timeout_ms': 2_000,
+            'payload_availability_timeout_ms': 2_000
+        }
     }
     try:
         ret = LocalBench(bench_params, node_params).run(debug)
@@ -110,7 +115,12 @@ def remote(ctx, debug=False):
         'sync_retry_delay': 10_000,  # ms
         'sync_retry_nodes': 3,  # number of nodes
         'batch_size': 500_000,  # bytes
-        'max_batch_delay': 200  # ms
+        'max_batch_delay': 200,  # ms
+        'block_synchronizer': {
+            'certificates_synchronize_timeout_ms': 2_000,
+            'payload_synchronize_timeout_ms': 2_000,
+            'payload_availability_timeout_ms': 2_000
+        }
     }
     try:
         Bench(ctx).run(bench_params, node_params, debug)

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -93,6 +93,8 @@ pub struct Parameters {
     /// The delay after which the workers seal a batch of transactions, even if `max_batch_size`
     /// is not reached. Denominated in ms.
     pub max_batch_delay: u64,
+    /// The parameters for the block synchronizer
+    pub block_synchronizer: BlockSynchronizerParameters,
 }
 
 #[derive(Deserialize, Clone)]
@@ -129,6 +131,7 @@ impl Default for Parameters {
             sync_retry_nodes: 3,
             batch_size: 500_000,
             max_batch_delay: 100,
+            block_synchronizer: BlockSynchronizerParameters::default(),
         }
     }
 }
@@ -142,6 +145,18 @@ impl Parameters {
         info!("Sync retry nodes set to {} nodes", self.sync_retry_nodes);
         info!("Batch size set to {} B", self.batch_size);
         info!("Max batch delay set to {} ms", self.max_batch_delay);
+        info!(
+            "Synchronize certificates timeout set to {} ms",
+            self.block_synchronizer.certificates_synchronize_timeout_ms
+        );
+        info!(
+            "Payload (batches) availability timeout set to {} ms",
+            self.block_synchronizer.payload_availability_timeout_ms
+        );
+        info!(
+            "Synchronize payload (batches) timeout set to {} ms",
+            self.block_synchronizer.payload_synchronize_timeout_ms
+        );
     }
 }
 


### PR DESCRIPTION
Resolves: https://github.com/MystenLabs/narwhal/issues/175

This PR fixes the issue of the missing block_synchronizer configuration from the fabfile which was causing the benchmarks fail - basically the primaries were crashing and never be able to bootstrap.

Re-pluggin the `block_synchronizer` will be as part of the https://github.com/MystenLabs/narwhal/pull/127