### PR TITLE
feat: handle the payload availability message

### DIFF
--- a/primary/Cargo.toml
+++ b/primary/Cargo.toml
@@ -33,7 +33,8 @@ types = { path = "../types" }
 [dev-dependencies]
 tempfile = "3.3.0"
 test_utils = { path = "../test_utils"}
-
+itertools = "0.10.3"
+tracing-test = { version = "0.2.1" }
 
 [features]
 benchmark = []

--- a/primary/src/block_synchronizer/mod.rs
+++ b/primary/src/block_synchronizer/mod.rs
@@ -32,7 +32,7 @@ use types::{BatchDigest, Certificate, CertificateDigest};
 #[path = "tests/block_synchronizer_tests.rs"]
 mod block_synchronizer_tests;
 mod peers;
-mod responses;
+pub mod responses;
 
 /// The minimum percentage
 /// (number of responses received from primary nodes / number of requests sent to primary nodes)

--- a/primary/src/helper.rs
+++ b/primary/src/helper.rs
@@ -1,26 +1,31 @@
 // Copyright (c) 2021, Facebook, Inc. and its affiliates
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use crate::primary::PrimaryMessage;
-use config::Committee;
+use crate::{primary::PrimaryMessage, PayloadToken};
+use config::{Committee, WorkerId};
 use crypto::traits::VerifyingKey;
 use network::PrimaryNetwork;
 use store::Store;
 use tokio::sync::mpsc::Receiver;
 use tracing::{error, warn};
-use types::{Certificate, CertificateDigest};
+use types::{BatchDigest, Certificate, CertificateDigest};
 
 #[cfg(test)]
 #[path = "tests/helper_tests.rs"]
 mod helper_tests;
 
-/// A task dedicated to help other authorities by replying to their certificates requests.
+/// A task dedicated to help other authorities by replying to their certificate &
+/// payload availability requests.
 pub struct Helper<PublicKey: VerifyingKey> {
+    /// The node's name
+    name: PublicKey,
     /// The committee information.
     committee: Committee<PublicKey>,
-    /// The persistent storage.
-    store: Store<CertificateDigest, Certificate<PublicKey>>,
-    /// Input channel to receive certificates requests.
+    /// The certificate persistent storage.
+    certificate_store: Store<CertificateDigest, Certificate<PublicKey>>,
+    /// The payloads (batches) persistent storage.
+    payload_store: Store<(BatchDigest, WorkerId), PayloadToken>,
+    /// Input channel to receive requests.
     rx_primaries: Receiver<PrimaryMessage<PublicKey>>,
     /// A network sender to reply to the sync requests.
     primary_network: PrimaryNetwork,
@@ -28,14 +33,18 @@ pub struct Helper<PublicKey: VerifyingKey> {
 
 impl<PublicKey: VerifyingKey> Helper<PublicKey> {
     pub fn spawn(
+        name: PublicKey,
         committee: Committee<PublicKey>,
-        store: Store<CertificateDigest, Certificate<PublicKey>>,
+        certificate_store: Store<CertificateDigest, Certificate<PublicKey>>,
+        payload_store: Store<(BatchDigest, WorkerId), PayloadToken>,
         rx_primaries: Receiver<PrimaryMessage<PublicKey>>,
     ) {
         tokio::spawn(async move {
             Self {
+                name,
                 committee,
-                store,
+                certificate_store,
+                payload_store,
                 rx_primaries,
                 primary_network: PrimaryNetwork::default(),
             }
@@ -63,11 +72,101 @@ impl<PublicKey: VerifyingKey> Helper<PublicKey> {
                     self.process_certificates(certificate_ids, requestor, true)
                         .await;
                 }
+                // A request that another primary sends us to check whether we have
+                // available to serve the payloads for the provided certificate_ids.
+                PrimaryMessage::PayloadAvailabilityRequest {
+                    certificate_ids,
+                    requestor,
+                } => {
+                    self.process_payload_availability(certificate_ids, requestor)
+                        .await;
+                }
                 _ => {
                     panic!("Received unexpected message!");
                 }
             }
         }
+    }
+
+    /// Checks for each provided digest of the list of digests they node has
+    /// the corresponding certificate within its storage and the payload as
+    /// well. If yes, then the requestor can follow up and request the batches
+    /// payload from the primary's workers via the standard syncing approach.
+    async fn process_payload_availability(
+        &mut self,
+        digests: Vec<CertificateDigest>,
+        origin: PublicKey,
+    ) {
+        // get the requestor's address.
+        let address = match self.committee.primary(&origin) {
+            Ok(x) => x.primary_to_primary,
+            Err(e) => {
+                warn!("Primary origin node not found in committee: {e}");
+                return;
+            }
+        };
+
+        let mut result: Vec<(CertificateDigest, bool)> = Vec::new();
+
+        let certificates = match self.certificate_store.read_all(digests.to_owned()).await {
+            Ok(certificates) => certificates,
+            Err(err) => {
+                error!("Error while retrieving certificates: {err}");
+
+                // just return at this point. Send back to the requestor
+                // that we don't have availability - ideally we would like
+                // to communicate an error (so they could potentially retry).
+                result = digests.into_iter().map(|d| (d, false)).collect();
+
+                let message = PrimaryMessage::<PublicKey>::PayloadAvailabilityResponse {
+                    payload_availability: result,
+                    from: self.name.clone(),
+                };
+                self.primary_network
+                    .unreliable_send(address, &message)
+                    .await;
+
+                return;
+            }
+        };
+
+        let certificates_and_ids: Vec<(CertificateDigest, Option<Certificate<PublicKey>>)> =
+            digests.into_iter().zip(certificates).collect();
+
+        for (id, certificate_option) in certificates_and_ids {
+            // Find the batches only for the certificates that exist
+            if let Some(certificate) = certificate_option {
+                let payload: Vec<(BatchDigest, WorkerId)> =
+                    certificate.header.payload.into_iter().collect();
+
+                let payload_available = match self.payload_store.read_all(payload).await {
+                    Ok(payload_result) => {
+                        payload_result.into_iter().all(|x| x.is_some()).to_owned()
+                    }
+                    Err(err) => {
+                        // we'll assume that we don't have available the payloads,
+                        // otherwise and error response should be sent back.
+                        error!("Error while retrieving payloads: {err}");
+                        false
+                    }
+                };
+
+                result.push((id, payload_available));
+            } else {
+                // We don't have the certificate available in first place,
+                // so we can't even look up for the batches.
+                result.push((id, false));
+            }
+        }
+
+        // now send the result back to the requestor
+        let message = PrimaryMessage::<PublicKey>::PayloadAvailabilityResponse {
+            payload_availability: result,
+            from: self.name.clone(),
+        };
+        self.primary_network
+            .unreliable_send(address, &message)
+            .await;
     }
 
     async fn process_certificates(
@@ -76,22 +175,25 @@ impl<PublicKey: VerifyingKey> Helper<PublicKey> {
         origin: PublicKey,
         batch_mode: bool,
     ) {
-        // get the requestors address.
+        // get the requestor's address.
         let address = match self.committee.primary(&origin) {
             Ok(x) => x.primary_to_primary,
             Err(e) => {
-                warn!("Unexpected certificate request: {e}");
+                warn!("Primary origin node not found in committee: {e}");
                 return;
             }
         };
 
         // TODO [issue #195]: Do some accounting to prevent bad nodes from monopolizing our resources.
 
-        let certificates = match self.store.read_all(digests.to_owned()).await {
+        let certificates = match self.certificate_store.read_all(digests.to_owned()).await {
             Ok(certificates) => certificates,
             Err(err) => {
                 error!("Error while retrieving certificates: {err}");
-                vec![]
+
+                // just return at this point since we have no way
+                // to communicate to the requestor an error.
+                return;
             }
         };
 
@@ -114,14 +216,12 @@ impl<PublicKey: VerifyingKey> Helper<PublicKey> {
                 .unreliable_send(address, &message)
                 .await;
         } else {
-            for certificate in certificates {
-                if certificate.is_some() {
-                    // TODO: Remove this deserialization-serialization in the critical path.
-                    let message = PrimaryMessage::Certificate(certificate.unwrap());
-                    self.primary_network
-                        .unreliable_send(address, &message)
-                        .await;
-                }
+            for certificate in certificates.into_iter().flatten() {
+                // TODO: Remove this deserialization-serialization in the critical path.
+                let message = PrimaryMessage::Certificate(certificate);
+                self.primary_network
+                    .unreliable_send(address, &message)
+                    .await;
             }
         }
     }

--- a/primary/src/lib.rs
+++ b/primary/src/lib.rs
@@ -31,6 +31,7 @@ mod common;
 
 pub use crate::{
     block_remover::{BlockRemover, BlockRemoverCommand, DeleteBatchMessage},
+    block_synchronizer::responses::PayloadAvailabilityResponse,
     block_waiter::{BatchMessage, BlockCommand, BlockWaiter},
     primary::{
         PayloadToken, Primary, PrimaryWorkerMessage, WorkerPrimaryError, WorkerPrimaryMessage,

--- a/primary/src/primary.rs
+++ b/primary/src/primary.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use crate::{
     block_remover::DeleteBatchResult,
+    block_synchronizer::BlockSynchronizer,
     block_waiter::{BatchMessage, BatchMessageError, BatchResult, BlockWaiter},
     certificate_waiter::CertificateWaiter,
     core::Core,
@@ -12,7 +13,7 @@ use crate::{
     payload_receiver::PayloadReceiver,
     proposer::Proposer,
     synchronizer::Synchronizer,
-    BlockRemover, DeleteBatchMessage,
+    BlockRemover, DeleteBatchMessage, PayloadAvailabilityResponse,
 };
 use async_trait::async_trait;
 use config::{Committee, Parameters, WorkerId};
@@ -20,7 +21,7 @@ use crypto::{
     traits::{EncodeDecodeBase64, Signer, VerifyingKey},
     SignatureService,
 };
-use network::PrimaryToWorkerNetwork;
+use network::{PrimaryNetwork, PrimaryToWorkerNetwork};
 use serde::{Deserialize, Serialize};
 use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
@@ -94,7 +95,7 @@ impl Primary {
         let (tx_headers_loopback, rx_headers_loopback) = channel(CHANNEL_CAPACITY);
         let (tx_certificates_loopback, rx_certificates_loopback) = channel(CHANNEL_CAPACITY);
         let (tx_primary_messages, rx_primary_messages) = channel(CHANNEL_CAPACITY);
-        let (tx_cert_requests, rx_cert_requests) = channel(CHANNEL_CAPACITY);
+        let (tx_helper_requests, rx_helper_requests) = channel(CHANNEL_CAPACITY);
         // _tx_get_block_commands should be used by the handler that will issue the requests
         // to fetch the collections from Narwhal (e.x the get_collections endpoint).
         let (_tx_get_block_commands, rx_get_block_commands) = channel(CHANNEL_CAPACITY);
@@ -103,13 +104,11 @@ impl Primary {
         // to remove collections from Narwhal (e.x the remove_collections endpoint).
         let (_tx_block_removal_commands, rx_block_removal_commands) = channel(CHANNEL_CAPACITY);
         let (tx_batch_removal, rx_batch_removal) = channel(CHANNEL_CAPACITY);
-        /* TODO[#175][#175][#127]: re-plug the block synchronizer
         let (_tx_block_synchronizer_commands, rx_block_synchronizer_commands) =
             channel(CHANNEL_CAPACITY);
         let (_tx_certificate_responses, rx_certificate_responses) = channel(CHANNEL_CAPACITY);
-        let (_tx_payload_availability_responses, rx_payload_availability_responses) =
+        let (tx_payload_availability_responses, rx_payload_availability_responses) =
             channel(CHANNEL_CAPACITY);
-        */
 
         // Write the parameters to the logs.
         parameters.tracing();
@@ -126,7 +125,8 @@ impl Primary {
         address.set_ip(Primary::INADDR_ANY);
         PrimaryReceiverHandler {
             tx_primary_messages,
-            tx_cert_requests,
+            tx_helper_requests,
+            tx_payload_availability_responses,
         }
         .spawn(address);
         info!(
@@ -218,18 +218,16 @@ impl Primary {
 
         // Responsible for finding missing blocks (certificates) and fetching
         // them from the primary peers by synchronizing also their batches.
-        /* TODO[#175][#127]: re-plug the block synchronizer
         BlockSynchronizer::spawn(
             name.clone(),
             committee.clone(),
             rx_block_synchronizer_commands,
             rx_certificate_responses,
             rx_payload_availability_responses,
-            SimpleSender::new(),
+            PrimaryNetwork::default(),
             payload_store.clone(),
-            BlockSynchronizerParameters::default(),
+            parameters.block_synchronizer,
         );
-        */
 
         // Whenever the `Synchronizer` does not manage to validate a header due to missing parent certificates of
         // batch digests, it commands the `HeaderWaiter` to synchronize with other nodes, wait for their reply, and
@@ -238,7 +236,7 @@ impl Primary {
             name.clone(),
             committee.clone(),
             certificate_store.clone(),
-            payload_store,
+            payload_store.clone(),
             consensus_round.clone(),
             parameters.gc_depth,
             parameters.sync_retry_delay,
@@ -270,8 +268,15 @@ impl Primary {
             /* tx_core */ tx_headers,
         );
 
-        // The `Helper` is dedicated to reply to certificates requests from other primaries.
-        Helper::spawn(committee.clone(), certificate_store, rx_cert_requests);
+        // The `Helper` is dedicated to reply to certificates & payload availability requests
+        // from other primaries.
+        Helper::spawn(
+            name.clone(),
+            committee.clone(),
+            certificate_store,
+            payload_store,
+            rx_helper_requests,
+        );
 
         // NOTE: This log entry is used to compute performance.
         info!(
@@ -290,7 +295,8 @@ impl Primary {
 #[derive(Clone)]
 struct PrimaryReceiverHandler<PublicKey: VerifyingKey> {
     tx_primary_messages: Sender<PrimaryMessage<PublicKey>>,
-    tx_cert_requests: Sender<PrimaryMessage<PublicKey>>,
+    tx_helper_requests: Sender<PrimaryMessage<PublicKey>>,
+    tx_payload_availability_responses: Sender<PayloadAvailabilityResponse<PublicKey>>,
 }
 
 impl<PublicKey: VerifyingKey> PrimaryReceiverHandler<PublicKey> {
@@ -315,13 +321,29 @@ impl<PublicKey: VerifyingKey> PrimaryToPrimary for PrimaryReceiverHandler<Public
 
         match message {
             PrimaryMessage::CertificatesRequest(_, _) => self
-                .tx_cert_requests
+                .tx_helper_requests
                 .send(message)
                 .await
                 .expect("Failed to send primary message"),
             PrimaryMessage::CertificatesBatchRequest { .. } => self
-                .tx_cert_requests
+                .tx_helper_requests
                 .send(message)
+                .await
+                .expect("Failed to send primary message"),
+            PrimaryMessage::PayloadAvailabilityRequest { .. } => self
+                .tx_helper_requests
+                .send(message)
+                .await
+                .expect("Failed to send primary message"),
+            PrimaryMessage::PayloadAvailabilityResponse {
+                payload_availability,
+                from,
+            } => self
+                .tx_payload_availability_responses
+                .send(PayloadAvailabilityResponse {
+                    block_ids: payload_availability.to_vec(),
+                    from: from.clone(),
+                })
                 .await
                 .expect("Failed to send primary message"),
             _ => self

--- a/primary/src/tests/helper_tests.rs
+++ b/primary/src/tests/helper_tests.rs
@@ -1,29 +1,41 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use crate::{common::create_db_stores, helper::Helper, primary::PrimaryMessage};
+use crate::{common::create_db_stores, helper::Helper, primary::PrimaryMessage, PayloadToken};
+use bincode::Options;
+use config::WorkerId;
 use crypto::{ed25519::Ed25519PublicKey, Hash};
 use ed25519_dalek::Signer;
+use itertools::Itertools;
 use std::{
+    borrow::Borrow,
     collections::{HashMap, HashSet},
     time::Duration,
 };
+use store::{reopen, rocks, rocks::DBMap, Store};
 use test_utils::{
     certificate, fixture_batch_with_transactions, fixture_header_builder, keys,
-    resolve_name_and_committee, PrimaryToPrimaryMockServer,
+    resolve_name_and_committee, temp_dir, PrimaryToPrimaryMockServer, CERTIFICATES_CF, PAYLOAD_CF,
 };
 use tokio::{sync::mpsc::channel, time::timeout};
-use types::CertificateDigest;
+use tracing_test::traced_test;
+use types::{BatchDigest, Certificate, CertificateDigest};
 
 #[tokio::test]
 async fn test_process_certificates_stream_mode() {
     // GIVEN
-    let (_, certificate_store, _) = create_db_stores();
+    let (_, certificate_store, payload_store) = create_db_stores();
     let key = keys().pop().unwrap();
     let (name, committee) = resolve_name_and_committee(13080);
     let (tx_primaries, rx_primaries) = channel(10);
 
     // AND a helper
-    Helper::spawn(committee.clone(), certificate_store.clone(), rx_primaries);
+    Helper::spawn(
+        name.clone(),
+        committee.clone(),
+        certificate_store.clone(),
+        payload_store.clone(),
+        rx_primaries,
+    );
 
     // AND some mock certificates
     let mut certificates = HashMap::new();
@@ -81,13 +93,19 @@ async fn test_process_certificates_stream_mode() {
 #[tokio::test]
 async fn test_process_certificates_batch_mode() {
     // GIVEN
-    let (_, certificate_store, _) = create_db_stores();
+    let (_, certificate_store, payload_store) = create_db_stores();
     let key = keys().pop().unwrap();
     let (name, committee) = resolve_name_and_committee(13020);
     let (tx_primaries, rx_primaries) = channel(10);
 
     // AND a helper
-    Helper::spawn(committee.clone(), certificate_store.clone(), rx_primaries);
+    Helper::spawn(
+        name.clone(),
+        committee.clone(),
+        certificate_store.clone(),
+        payload_store.clone(),
+        rx_primaries,
+    );
 
     // AND some mock certificates
     let mut certificates = HashMap::new();
@@ -161,4 +179,210 @@ async fn test_process_certificates_batch_mode() {
         non_found_certificates, 5,
         "Expected to have non found certificates"
     );
+}
+
+#[tokio::test]
+async fn test_process_payload_availability_success() {
+    // GIVEN
+    let (_, certificate_store, payload_store) = create_db_stores();
+    let key = keys().pop().unwrap();
+    let (name, committee) = resolve_name_and_committee(13710);
+    let (tx_primaries, rx_primaries) = channel(10);
+
+    // AND a helper
+    Helper::spawn(
+        name.clone(),
+        committee.clone(),
+        certificate_store.clone(),
+        payload_store.clone(),
+        rx_primaries,
+    );
+
+    // AND some mock certificates
+    let mut certificates = HashMap::new();
+    let mut missing_certificates = HashSet::new();
+
+    for i in 0..10 {
+        let header = fixture_header_builder()
+            .with_payload_batch(fixture_batch_with_transactions(10), 0)
+            .build(|payload| key.sign(payload));
+
+        let certificate = certificate(&header);
+        let id = certificate.clone().digest();
+
+        certificates.insert(id, certificate.clone());
+
+        // We want to simulate the scenario of both having some certificates
+        // found and some non found. Store only the half. The other half
+        // should be returned back as non found.
+        if i < 7 {
+            // write the certificate
+            certificate_store.write(id, certificate.clone()).await;
+
+            for payload in certificate.header.payload {
+                payload_store.write(payload, 1).await;
+            }
+        } else {
+            missing_certificates.insert(id);
+        }
+    }
+
+    // AND spin up a mock node
+    let address = committee.primary(&name).unwrap();
+    let mut handler = PrimaryToPrimaryMockServer::spawn(address.primary_to_primary);
+
+    // WHEN requesting the payload availability for all the certificates
+    tx_primaries
+        .send(PrimaryMessage::PayloadAvailabilityRequest {
+            certificate_ids: certificates.keys().copied().collect(),
+            requestor: name,
+        })
+        .await
+        .expect("Couldn't send message");
+
+    let received = timeout(Duration::from_millis(4_000), handler.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    let message: PrimaryMessage<Ed25519PublicKey> = received.deserialize().unwrap();
+    let payload_availability = match message {
+        PrimaryMessage::PayloadAvailabilityResponse {
+            payload_availability,
+            from: _,
+        } => payload_availability,
+        msg => {
+            panic!("Didn't expect message {:?}", msg);
+        }
+    };
+
+    let result_digests: HashSet<CertificateDigest> = payload_availability
+        .iter()
+        .map(|(digest, _)| *digest)
+        .collect();
+
+    assert_eq!(
+        result_digests.len(),
+        certificates.len(),
+        "Returned unique number of certificates don't match the expected"
+    );
+
+    // ensure that we have no payload availability for some
+    let availability_map = payload_availability.into_iter().counts_by(|c| c.1);
+
+    for (available, found) in availability_map {
+        if available {
+            assert_eq!(found, 7, "Expected to have available payloads");
+        } else {
+            assert_eq!(found, 3, "Expected to have non available payloads");
+        }
+    }
+}
+
+#[tokio::test]
+#[traced_test]
+async fn test_process_payload_availability_when_failures() {
+    // GIVEN
+    // We initialise the test stores manually to allow us
+    // inject some wrongly serialised values to cause data store errors.
+    let rocksdb = rocks::open_cf(temp_dir(), None, &[CERTIFICATES_CF, PAYLOAD_CF])
+        .expect("Failed creating database");
+
+    let (certificate_map, payload_map) = reopen!(&rocksdb,
+        CERTIFICATES_CF;<CertificateDigest, Certificate<Ed25519PublicKey>>,
+        PAYLOAD_CF;<(BatchDigest, WorkerId), PayloadToken>);
+
+    let certificate_store: Store<CertificateDigest, Certificate<Ed25519PublicKey>> =
+        Store::new(certificate_map);
+    let payload_store: Store<(types::BatchDigest, WorkerId), PayloadToken> =
+        Store::new(payload_map);
+
+    let key = keys().pop().unwrap();
+    let (name, committee) = resolve_name_and_committee(11340);
+    let (tx_primaries, rx_primaries) = channel(10);
+
+    // AND a helper
+    Helper::spawn(
+        name.clone(),
+        committee.clone(),
+        certificate_store.clone(),
+        payload_store.clone(),
+        rx_primaries,
+    );
+
+    // AND some mock certificates
+    let mut certificate_ids = Vec::new();
+    for _ in 0..10 {
+        let header = fixture_header_builder()
+            .with_payload_batch(fixture_batch_with_transactions(10), 0)
+            .build(|payload| key.sign(payload));
+
+        let certificate = certificate(&header);
+        let id = certificate.clone().digest();
+
+        // In order to test an error scenario that is coming from the data store,
+        // we are going to store for the provided certificate ids some unexpected
+        // payload in order to blow up the deserialisation.
+        let serialised_key = bincode::DefaultOptions::new()
+            .with_big_endian()
+            .with_fixint_encoding()
+            .serialize(&id.borrow())
+            .expect("Couldn't serialise key");
+
+        // Just serialise the "false" value
+        let dummy_value = bincode::serialize(false.borrow()).expect("Couldn't serialise value");
+
+        rocksdb
+            .put_cf(
+                &rocksdb
+                    .cf_handle(CERTIFICATES_CF)
+                    .expect("Couldn't find column family"),
+                serialised_key,
+                dummy_value,
+            )
+            .expect("Couldn't insert value");
+
+        certificate_ids.push(id);
+    }
+
+    // AND spin up a mock node
+    let address = committee.primary(&name).unwrap();
+    let mut handler = PrimaryToPrimaryMockServer::spawn(address.primary_to_primary);
+
+    // WHEN requesting the payload availability for all the certificates
+    tx_primaries
+        .send(PrimaryMessage::PayloadAvailabilityRequest {
+            certificate_ids,
+            requestor: name,
+        })
+        .await
+        .expect("Couldn't send message");
+
+    let received = timeout(Duration::from_millis(4_000), handler.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    let message: PrimaryMessage<Ed25519PublicKey> = received.deserialize().unwrap();
+    let payload_availability = match message {
+        PrimaryMessage::PayloadAvailabilityResponse {
+            payload_availability,
+            from: _,
+        } => payload_availability,
+        msg => {
+            panic!("Didn't expect message {:?}", msg);
+        }
+    };
+
+    // ensure that we have no payload availability for some
+    let availability_map = payload_availability.into_iter().counts_by(|c| c.1);
+
+    for (available, found) in availability_map {
+        if available {
+            assert_eq!(found, 0, "Didn't expect to have available payloads");
+        } else {
+            assert_eq!(found, 10, "All payloads should be unavailable");
+        }
+    }
+
+    // And ensure that log files include the error message
+    assert!(logs_contain("Error while retrieving certificates"));
 }

--- a/types/src/primary.rs
+++ b/types/src/primary.rs
@@ -469,6 +469,7 @@ pub enum PrimaryMessage<PublicKey: VerifyingKey> {
 
     PayloadAvailabilityResponse {
         payload_availability: Vec<(CertificateDigest, bool)>,
+        from: PublicKey,
     },
 }
 


### PR DESCRIPTION
Resolves: https://github.com/MystenLabs/narwhal/issues/164

This PR is implementing the handling of the `PrimaryMessage::PayloadAvailabilityRequest` message on the primary nodes. I've enhanced the `helper` component as this is probably the closest could re-use. I've avoided introducing something new at this point, until we need to expand further the protocol with more messages etc. I've also performed a small refactoring on the helper so I can de-dupe some code around sending the message back to the requestor.