### PR TITLE
Create Central Accounting layer

### DIFF
--- a/network/src/accounting_receiver.rs
+++ b/network/src/accounting_receiver.rs
@@ -1,52 +1,41 @@
 // Copyright (c) 2021, Facebook, Inc. and its affiliates
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
+use crate::central_accounting::{AccountingMessage, ReceiverId};
 use crate::error::NetworkError;
-use async_trait::async_trait;
+use crate::receiver::TcpWriter;
+use crate::Writer;
 use bytes::Bytes;
-use futures::stream::{SplitSink, StreamExt as _};
+use futures::stream::StreamExt as _;
 use futures::SinkExt;
-use std::borrow::BorrowMut;
-use std::{error::Error, net::SocketAddr};
+use std::net::SocketAddr;
 use tokio::net::{TcpListener, TcpStream};
-use tokio::sync::mpsc::{channel, Receiver as mspcReceiver, Sender};
+use tokio::sync::mpsc::{channel, Receiver, Sender};
 use tokio_util::codec::{Framed, LengthDelimitedCodec};
 use tracing::{debug, info, warn};
 
-/// Convenient alias for the writer end of the TCP channel.
-pub type TcpWriter = SplitSink<Framed<TcpStream, LengthDelimitedCodec>, Bytes>;
-
-/// Convenient alias for the output of the dispatch function.
-pub type Writer = Sender<Bytes>;
-
-#[async_trait]
-pub trait MessageHandler: Clone + Send + Sync + 'static {
-    /// Defines how to handle an incoming message. A typical usage is to define a `MessageHandler` with a
-    /// number of `Sender<T>` channels. Then implement `dispatch` to deserialize incoming messages and
-    /// forward them through the appropriate delivery channel. Then `writer` can be used to send back
-    /// responses or acknowledgments to the sender machine (see unit tests for examples).
-    async fn dispatch(&self, writer: &mut Writer, message: Bytes) -> Result<(), Box<dyn Error>>;
-}
-
 /// For each incoming request, we spawn a new runner responsible to receive messages and forward them
-/// through the provided deliver channel.
-pub struct Receiver<Handler: MessageHandler> {
+/// to the CentralAccounting layer through the provided channel.
+pub struct AccountingReceiver {
     /// Address to listen to.
     address: SocketAddr,
-    /// Struct responsible to define how to handle received messages.
-    handler: Handler,
 }
 
-impl<Handler: MessageHandler> Receiver<Handler> {
+impl AccountingReceiver {
+    /// Create a new AccountingReceiver.
+    pub fn new(address: SocketAddr) -> Self {
+        AccountingReceiver { address }
+    }
+
     /// Spawn a new network receiver handling connections from any incoming peer.
-    pub fn spawn(address: SocketAddr, handler: Handler) {
+    pub fn spawn(self, id: ReceiverId, tx_message: Sender<AccountingMessage>) {
         tokio::spawn(async move {
-            Self { address, handler }.run().await;
+            self.run(id, tx_message).await;
         });
     }
 
     /// Main loop responsible to accept incoming connections and spawn a new runner to handle it.
-    async fn run(&self) {
+    async fn run(self, id: ReceiverId, tx_forwarding: Sender<AccountingMessage>) {
         let listener = TcpListener::bind(&self.address)
             .await
             .expect("Failed to bind TCP port");
@@ -62,30 +51,34 @@ impl<Handler: MessageHandler> Receiver<Handler> {
                 }
             };
             info!("Incoming connection established with {peer}");
-            Self::spawn_runner(socket, peer, self.handler.clone()).await;
+
+            Self::spawn_runner(socket, peer, id, tx_forwarding.clone()).await;
         }
     }
 
-    /// Spawn a new runner to handle a specific TCP connection. It receives messages and process them
-    /// using the provided handler.
-    async fn spawn_runner(socket: TcpStream, peer: SocketAddr, handler: Handler) {
+    /// Spawn a new runner to handle a specific TCP connection. It receives messages and forwards them
+    /// using to the CentralAccounting layer.
+    async fn spawn_runner(
+        socket: TcpStream,
+        peer: SocketAddr,
+        receiver_id: ReceiverId,
+        tx_forwarding: Sender<AccountingMessage>,
+    ) {
         tokio::spawn(async move {
             let transport = Framed::new(socket, LengthDelimitedCodec::new());
-            let (writer, mut reader) = transport.split();
-
-            let (tx_response, tr_response): (Writer, mspcReceiver<Bytes>) = channel(100);
-            Self::spawn_response_writer(tr_response, writer).await;
+            let (tcp_writer, mut reader) = transport.split();
+            let (tx_response, tr_response): (Writer, Receiver<Bytes>) = channel(100);
+            Self::spawn_response_writer(tr_response, tcp_writer).await;
 
             while let Some(frame) = reader.next().await {
                 match frame.map_err(|e| NetworkError::FailedToReceiveMessage(peer, e)) {
                     Ok(message) => {
-                        if let Err(e) = handler
-                            .dispatch(tx_response.clone().borrow_mut(), message.freeze())
-                            .await
-                        {
-                            warn!("{e}");
-                            return;
-                        }
+                        let accounting_message = AccountingMessage {
+                            receiver_id,
+                            message: message.freeze(),
+                            tx_response: tx_response.clone(),
+                        };
+                        _ = tx_forwarding.send(accounting_message).await;
                     }
                     Err(e) => {
                         warn!("{e}");
@@ -99,8 +92,8 @@ impl<Handler: MessageHandler> Receiver<Handler> {
 
     /// Spawns a new task that will listen for any responses from the accounting layer and
     /// forward them to the tcp writer.
-    async fn spawn_response_writer(
-        mut tr_response: mspcReceiver<Bytes>,
+    pub async fn spawn_response_writer(
+        mut tr_response: Receiver<Bytes>,
         mut tcp_writer: TcpWriter,
     ) {
         tokio::spawn(async move {

--- a/network/src/central_accounting.rs
+++ b/network/src/central_accounting.rs
@@ -1,0 +1,106 @@
+// Copyright (c) 2021, Facebook, Inc. and its affiliates
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use crate::{MessageHandler, Writer};
+use bytes::Bytes;
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use tokio::select;
+use tokio::sync::mpsc::{channel, Receiver as mspcReceiver, Sender};
+use tracing::warn;
+
+#[cfg(test)]
+#[path = "tests/receiver_tests.rs"]
+pub mod receiver_tests;
+
+static COUNTER: AtomicUsize = AtomicUsize::new(1);
+
+fn get_id() -> ReceiverId {
+    COUNTER.fetch_add(1, Ordering::Relaxed)
+}
+
+/// Unique identifier of an Accounting Receiver.
+pub type ReceiverId = usize;
+
+/// CentralAccounting is the centralized layer to put all the logic of what checks to do
+/// on an incoming external request. Based on the output of the checks, it can either dispatch a
+/// message or not.
+pub struct CentralAccounting<Handler: MessageHandler> {
+    /// Sender that gets cloned and provided to each registered accounting receiver.
+    tx_message: Sender<AccountingMessage>,
+
+    /// Receiver of all the messages forwarded from the accounting receivers.
+    tr_message: mspcReceiver<AccountingMessage>,
+
+    /// The handler associated with each registered receiver, by ReceiverID.
+    receiver_info: HashMap<ReceiverId, Handler>,
+}
+
+/// The message with the following metadata: the receiver that sent it, and the Sender for the
+/// TCP Connection on which to send the response.
+pub struct AccountingMessage {
+    /// The Receiver Id of the accounting receiver that sent this message.
+    pub(crate) receiver_id: ReceiverId,
+
+    /// The message Bytes read from TCP connection.
+    pub(crate) message: Bytes,
+
+    /// The channel to forward the response.
+    pub(crate) tx_response: Writer,
+}
+
+impl<Handler: MessageHandler> CentralAccounting<Handler> {
+    /// Create a new CentralAccounting.
+    pub fn new(channel_capacity: usize) -> Self {
+        let (tx_message, tr_message) = channel(channel_capacity);
+        CentralAccounting {
+            tx_message,
+            tr_message,
+            receiver_info: HashMap::new(),
+        }
+    }
+
+    /// Register will register an AccountingReceiver with the CentralAccounting. This function is
+    /// to be called once for each AccountingReceiver, and it will provide the parameters
+    /// necessary to start an AccountingReceiver.
+    pub async fn register(&mut self, handler: Handler) -> (ReceiverId, Sender<AccountingMessage>) {
+        let id = get_id();
+        self.receiver_info.insert(id, handler);
+        (id, self.tx_message.clone())
+    }
+
+    /// Spawn runs the CentralAccounting. This should be called after registration of every
+    /// accounting_receiver.
+    pub async fn spawn(mut self) {
+        tokio::spawn(async move {
+            self.run().await;
+        });
+    }
+
+    /// This contains the main loop for receiving message to inspect and forwards them to the
+    /// respective components using the message handler associated with each receiver.
+    async fn run(&mut self) {
+        loop {
+            select! {
+                Some(mut message) = self.tr_message.recv() => {
+                    // use receiver_id to look up the handler for this receiver
+                    let handler = self.receiver_info.get(&message.receiver_id);
+                    let handler = match handler {
+                        Some(h) => h,
+                        None => {
+                            continue;
+                        }
+                    };
+
+                    // call dispatch
+                    if let Err(e) = handler
+                        .dispatch(&mut message.tx_response, message.message)
+                        .await
+                    {
+                        warn!("{e}");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -7,7 +7,10 @@
     rust_2018_idioms,
     rust_2021_compatibility
 )]
+#![allow(dead_code)]
 
+mod accounting_receiver;
+mod central_accounting;
 mod error;
 mod receiver;
 mod reliable_sender;
@@ -18,6 +21,8 @@ mod simple_sender;
 pub mod common;
 
 pub use crate::{
+    accounting_receiver::AccountingReceiver,
+    central_accounting::CentralAccounting,
     receiver::{MessageHandler, Receiver, Writer},
     reliable_sender::{CancelHandler, ReliableSender},
     simple_sender::SimpleSender,

--- a/network/src/tests/receiver_tests.rs
+++ b/network/src/tests/receiver_tests.rs
@@ -2,7 +2,6 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use super::*;
-use futures::sink::SinkExt as _;
 use tokio::{
     sync::mpsc::{channel, Sender},
     time::{sleep, Duration},

--- a/network/src/tests/receiver_tests.rs
+++ b/network/src/tests/receiver_tests.rs
@@ -27,12 +27,51 @@ impl MessageHandler for TestHandler {
     }
 }
 
+#[derive(Clone)]
+struct TestHandlerNoAck {
+    deliver: Sender<String>,
+}
+
+#[async_trait]
+impl MessageHandler for TestHandlerNoAck {
+    async fn dispatch(&self, _writer: &mut Writer, message: Bytes) -> Result<(), Box<dyn Error>> {
+        // Deserialize the message.
+        let message = bincode::deserialize(&message)?;
+
+        // Deliver the message to the application.
+        self.deliver.send(message).await.unwrap();
+        Ok(())
+    }
+}
+
 #[tokio::test]
 async fn receive() {
     // Make the network receiver.
     let address = "127.0.0.1:4000".parse::<SocketAddr>().unwrap();
     let (tx, mut rx) = channel(1);
     Receiver::spawn(address, TestHandler { deliver: tx });
+    sleep(Duration::from_millis(50)).await;
+
+    // Send a message.
+    let sent = "Hello, world!";
+    let bytes = Bytes::from(bincode::serialize(sent).unwrap());
+    let stream = TcpStream::connect(address).await.unwrap();
+    let mut transport = Framed::new(stream, LengthDelimitedCodec::new());
+    transport.send(bytes.clone()).await.unwrap();
+
+    // Ensure the message gets passed to the channel.
+    let message = rx.recv().await;
+    assert!(message.is_some());
+    let received = message.unwrap();
+    assert_eq!(received, sent);
+}
+
+#[tokio::test]
+async fn receive_no_ack() {
+    // Make the network receiver.
+    let address = "127.0.0.1:4001".parse::<SocketAddr>().unwrap();
+    let (tx, mut rx) = channel(1);
+    Receiver::spawn(address, TestHandlerNoAck { deliver: tx });
     sleep(Duration::from_millis(50)).await;
 
     // Send a message.

--- a/primary/src/primary.rs
+++ b/primary/src/primary.rs
@@ -23,7 +23,6 @@ use crypto::{
     traits::{EncodeDecodeBase64, Signer, VerifyingKey},
     SignatureService,
 };
-use futures::sink::SinkExt as _;
 use network::{MessageHandler, Receiver as NetworkReceiver, SimpleSender, Writer};
 use serde::{Deserialize, Serialize};
 use std::{

--- a/worker/src/worker.rs
+++ b/worker/src/worker.rs
@@ -9,7 +9,6 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use config::{Committee, Parameters, WorkerId};
 use crypto::traits::VerifyingKey;
-use futures::sink::SinkExt as _;
 use network::{MessageHandler, Receiver, Writer};
 use primary::{Batch, BatchDigest, PrimaryWorkerMessage, Transaction};
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
Addresses issue https://github.com/MystenLabs/sui/issues/5216

This creates a Central Accounting Layer along with a new type of network receiver that interfaces with the Central Accounting. The Central Accounting Layer takes over the responsibility for calling `dispatch` on the respective MessageHandler that is associated with the receiver, so that the receiver no longer calls `dispatch`. The accounting receiver  sends external messages it receives, along with some metadata, to the Central Accounting Layer, which will later contain rate-limiting and possibly prioritization logic. For now, it simply calls `dispatch`. 

As a next step, we need to adjust the MessageHandler interface to allow for being able to track and record when each message's processing has completed. Although we forward back responses through the Central Accounting Layer, because "Acks" are either returned immediately or never, the time at which the response is forwarded cannot be used to signal that the message processing is complete.  Another approach might be to implement the Drop for a custom struct witch contains the message Bytes, however, the majority of the components deserialize the message immediately upon reception, which would cause the drop to occur before message processing has completed. We can consider to deserialize the message before forwarding, and using the Drop impl strategy, or, refactor each component to explicitly send notice of message completion.