### PR TITLE
wire the CertificatesBatchResponse to the primary

### DIFF
--- a/primary/src/lib.rs
+++ b/primary/src/lib.rs
@@ -31,7 +31,7 @@ mod common;
 
 pub use crate::{
     block_remover::{BlockRemover, BlockRemoverCommand, DeleteBatchMessage},
-    block_synchronizer::responses::PayloadAvailabilityResponse,
+    block_synchronizer::responses::{CertificatesResponse, PayloadAvailabilityResponse},
     block_waiter::{BatchMessage, BlockCommand, BlockWaiter},
     primary::{
         PayloadToken, Primary, PrimaryWorkerMessage, WorkerPrimaryError, WorkerPrimaryMessage,

--- a/primary/src/tests/helper_tests.rs
+++ b/primary/src/tests/helper_tests.rs
@@ -151,7 +151,7 @@ async fn test_process_certificates_batch_mode() {
         .unwrap();
     let message: PrimaryMessage<Ed25519PublicKey> = received.deserialize().unwrap();
     let result_certificates = match message {
-        PrimaryMessage::CertificatesBatchResponse { certificates } => certificates,
+        PrimaryMessage::CertificatesBatchResponse { certificates, .. } => certificates,
         msg => {
             panic!("Didn't expect message {:?}", msg);
         }

--- a/types/src/primary.rs
+++ b/types/src/primary.rs
@@ -460,6 +460,7 @@ pub enum PrimaryMessage<PublicKey: VerifyingKey> {
     },
     CertificatesBatchResponse {
         certificates: Vec<(CertificateDigest, Option<Certificate<PublicKey>>)>,
+        from: PublicKey,
     },
 
     PayloadAvailabilityRequest {


### PR DESCRIPTION
Following the https://github.com/MystenLabs/narwhal/pull/186 , this PR is wiring in the `CertificatesBatchResponse` responses to the primary in order to be sent to the `block_synchronizer` . Also some small refactoring was done to the `helper` component in order to:
* not process requests with empty block_ids
* respond back for the `CertificatesBatchResponse` with a negative response (certificates not found) when an error in storage is raised (once we have proper erroring response mechanism can convert to that)