### PR TITLE
adds max concurrent requests with towers

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -40,7 +40,8 @@ node_params = {
         'certificates_synchronize_timeout': '2000ms',
         'payload_synchronize_timeout': '2000ms',
         'payload_availability_timeout': '2000ms'
-    }
+    },
+    'max_concurrent_requests': 500_000
 }
 ```
 They are defined as follows:
@@ -54,6 +55,7 @@ They are defined as follows:
 * `certificates_synchronize_timeout`: The timeout configuration when requesting certificates from peers.
 * `payload_synchronize_timeout`: Timeout when has requested the payload for a certificate and is waiting to receive them.
 * `payload_availability_timeout`: The timeout configuration when for when we ask the other peers to discover who has the payload available for the dictated certificates.
+* `max_concurrent_requests`: The maximum number of concurrent requests for primary-to-primary and worker-to-worker messages.
 
 ### Run the benchmark
 Once you specified both `bench_params` and `node_params` as desired, run:

--- a/benchmark/benchmark/config.py
+++ b/benchmark/benchmark/config.py
@@ -172,6 +172,7 @@ class NodeParameters:
             inputs += [json['sync_retry_nodes']]
             inputs += [json['batch_size']]
             inputs += [json['max_batch_delay']]
+            inputs += [json['max_concurrent_requests']]
         except KeyError as e:
             raise ConfigError(f'Malformed parameters: missing key {e}')
 

--- a/benchmark/benchmark/logs.py
+++ b/benchmark/benchmark/logs.py
@@ -134,6 +134,9 @@ class LogParser:
             'max_batch_delay': int(
                 search(r'Max batch delay .* (\d+)', log).group(1)
             ),
+            'max_concurrent_requests': int(
+                search(r'Max concurrent requests .* (\d+)', log).group(1)
+            )
         }
 
         ip = search(r'booted on (\d+.\d+.\d+.\d+)', log).group(1)
@@ -201,6 +204,7 @@ class LogParser:
         sync_retry_nodes = self.configs[0]['sync_retry_nodes']
         batch_size = self.configs[0]['batch_size']
         max_batch_delay = self.configs[0]['max_batch_delay']
+        max_concurrent_requests = self.configs[0]['max_concurrent_requests']
 
         consensus_latency = self._consensus_latency() * 1_000
         consensus_tps, consensus_bps, _ = self._consensus_throughput()
@@ -228,6 +232,7 @@ class LogParser:
             f' Sync retry nodes: {sync_retry_nodes:,} node(s)\n'
             f' batch size: {batch_size:,} B\n'
             f' Max batch delay: {max_batch_delay:,} ms\n'
+            f' Max concurrent requests: {max_concurrent_requests:,} \n'
             '\n'
             ' + RESULTS:\n'
             f' Consensus TPS: {round(consensus_tps):,} tx/s\n'

--- a/benchmark/fabfile.py
+++ b/benchmark/fabfile.py
@@ -32,7 +32,8 @@ def local(ctx, debug=True):
             'certificates_synchronize_timeout': '2_000ms',
             'payload_synchronize_timeout': '2_000ms',
             'payload_availability_timeout': '2_000ms'
-        }
+        },
+        'max_concurrent_requests': 2
     }
     try:
         ret = LocalBench(bench_params, node_params).run(debug)
@@ -119,7 +120,8 @@ def remote(ctx, debug=False):
             'certificates_synchronize_timeout': '2_000ms',
             'payload_synchronize_timeout': '2_000ms',
             'payload_availability_timeout': '2_000ms'
-        }
+        },
+        'max_concurrent_requests': 500_000
     }
     try:
         Bench(ctx).run(bench_params, node_params, debug)

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -105,6 +105,8 @@ pub struct Parameters {
     pub max_batch_delay: Duration,
     /// The parameters for the block synchronizer
     pub block_synchronizer: BlockSynchronizerParameters,
+    /// The maximum number of concurrent requests for messages accepted from an un-trusted entity
+    pub max_concurrent_requests: usize,
 }
 
 #[derive(Deserialize, Clone)]
@@ -143,6 +145,7 @@ impl Default for Parameters {
             batch_size: 500_000,
             max_batch_delay: Duration::from_millis(100),
             block_synchronizer: BlockSynchronizerParameters::default(),
+            max_concurrent_requests: 500_000,
         }
     }
 }
@@ -183,6 +186,10 @@ impl Parameters {
                 .payload_synchronize_timeout
                 .as_millis()
         );
+        info!(
+            "Max concurrent requests set to {}",
+            self.max_concurrent_requests
+        )
     }
 }
 
@@ -350,7 +357,8 @@ mod tests {
                  "certificates_synchronize_timeout": "2s",
                  "payload_synchronize_timeout": "3_000ms",
                  "payload_availability_timeout": "4_000ms"
-             }
+             },
+             "max_concurrent_requests": 500000
           }"#;
 
         // AND temporary file
@@ -416,5 +424,6 @@ mod tests {
         assert!(logs_contain(
             "Synchronize payload (batches) timeout set to 2000 ms"
         ));
+        assert!(logs_contain("Max concurrent requests set to 500000"))
     }
 }

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -143,7 +143,8 @@ async fn run(matches: &ArgMatches<'_>) -> Result<()> {
                 .context("The worker id must be a positive integer")?;
 
             Node::spawn_workers(
-                /* name */ keypair.public().clone(),
+                /* name */
+                keypair.public().clone(),
                 vec![id],
                 committee,
                 &store,

--- a/primary/Cargo.toml
+++ b/primary/Cargo.toml
@@ -29,6 +29,7 @@ tonic = "0.7"
 crypto = { path = "../crypto" }
 network = { path = "../network" }
 types = { path = "../types" }
+tower = "0.4.12"
 
 [dev-dependencies]
 tempfile = "3.3.0"

--- a/primary/src/primary.rs
+++ b/primary/src/primary.rs
@@ -295,9 +295,8 @@ struct PrimaryReceiverHandler<PublicKey: VerifyingKey> {
 
 impl<PublicKey: VerifyingKey> PrimaryReceiverHandler<PublicKey> {
     fn spawn(self, address: SocketAddr, max_concurrent_requests: usize) {
-        let concurrent_limit = tower::limit::ConcurrencyLimitLayer::new(max_concurrent_requests);
         let service = tonic::transport::Server::builder()
-            .layer(concurrent_limit)
+            .concurrency_limit_per_connection(max_concurrent_requests)
             .add_service(PrimaryToPrimaryServer::new(self))
             .serve(address);
         tokio::spawn(service);

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -26,6 +26,7 @@ crypto = { path = "../crypto" }
 network = { path = "../network" }
 primary = { path = "../primary" }
 types = { path = "../types" }
+tower = "0.4.12"
 
 [dev-dependencies]
 rand = "0.7.3"

--- a/worker/src/worker.rs
+++ b/worker/src/worker.rs
@@ -209,7 +209,7 @@ impl<PublicKey: VerifyingKey> Worker<PublicKey> {
             tx_client_helper,
             tx_processor,
         }
-        .spawn(address);
+        .spawn(address, self.parameters.max_concurrent_requests);
 
         // The `Helper` is dedicated to reply to batch requests from other workers.
         Helper::spawn(
@@ -294,8 +294,10 @@ struct WorkerReceiverHandler<PublicKey: VerifyingKey> {
 }
 
 impl<PublicKey: VerifyingKey> WorkerReceiverHandler<PublicKey> {
-    fn spawn(self, address: SocketAddr) {
+    fn spawn(self, address: SocketAddr, max_concurrent_requests: usize) {
+        let concurrent_limit = tower::limit::ConcurrencyLimitLayer::new(max_concurrent_requests);
         let service = tonic::transport::Server::builder()
+            .layer(concurrent_limit)
             .add_service(WorkerToWorkerServer::new(self))
             .serve(address);
         tokio::spawn(service);

--- a/worker/src/worker.rs
+++ b/worker/src/worker.rs
@@ -295,9 +295,8 @@ struct WorkerReceiverHandler<PublicKey: VerifyingKey> {
 
 impl<PublicKey: VerifyingKey> WorkerReceiverHandler<PublicKey> {
     fn spawn(self, address: SocketAddr, max_concurrent_requests: usize) {
-        let concurrent_limit = tower::limit::ConcurrencyLimitLayer::new(max_concurrent_requests);
         let service = tonic::transport::Server::builder()
-            .layer(concurrent_limit)
+            .concurrency_limit_per_connection(max_concurrent_requests)
             .add_service(WorkerToWorkerServer::new(self))
             .serve(address);
         tokio::spawn(service);


### PR DESCRIPTION
Addresses https://github.com/MystenLabs/sui/issues/5216 with our new GRPC network.

This creates a new config parameter for setting maximum concurrent requests, and applies a limit to the worker to worker and primary to primary servers, which are the untrusted communications. Based on my understanding from reading the code, it seems like one instance of narwhal is either a primary *or* a worker, so whichever it is, it will instantiate only one of these servers, and so the limits don't need to be coordinated. Let me know if this is not accurate. 
Advice is welcome on what to set as the default value.

Upon running the benchmarks with setting the concurrency limit of 500,000 I see this result on my laptop:
```
-----------------------------------------
 SUMMARY:
-----------------------------------------
 + CONFIG:
 Faults: 0 node(s)
 Committee size: 4 node(s)
 Worker(s) per node: 1 worker(s)
 Collocate primary and workers: True
 Input rate: 50,000 tx/s
 Transaction size: 512 B
 Execution time: 7 s

 Header size: 1,000 B
 Max header delay: 200 ms
 GC depth: 50 round(s)
 Sync retry delay: 10,000 ms
 Sync retry nodes: 3 node(s)
 batch size: 500,000 B
 Max batch delay: 200 ms
 Max concurrent requests: 500,000 <---- *new!*

 + RESULTS:
 Consensus TPS: 40,447 tx/s
 Consensus BPS: 20,708,609 B/s
 Consensus latency: 893 ms

 End-to-end TPS: 39,706 tx/s
 End-to-end BPS: 20,329,690 B/s
 End-to-end latency: 1,030 ms
```

then when setting the concurrency limit to 2:
```-----------------------------------------
 SUMMARY:
-----------------------------------------
 + CONFIG:
 Faults: 0 node(s)
 Committee size: 4 node(s)
 Worker(s) per node: 1 worker(s)
 Collocate primary and workers: True
 Input rate: 50,000 tx/s
 Transaction size: 512 B
 Execution time: 1 s

 Header size: 1,000 B
 Max header delay: 200 ms
 GC depth: 50 round(s)
 Sync retry delay: 10,000 ms
 Sync retry nodes: 3 node(s)
 batch size: 500,000 B
 Max batch delay: 200 ms
 Max concurrent requests: 2

 + RESULTS:
 Consensus TPS: 9,267 tx/s
 Consensus BPS: 4,744,495 B/s
 Consensus latency: 525 ms

 End-to-end TPS: 7,636 tx/s
 End-to-end BPS: 3,909,456 B/s
 End-to-end latency: 661 ms
 ```
The performance noticeably decreases when the concurrency limit is very low.