### PR TITLE
[block_synchronizer] do not synchronise existing in store headers & payload

### DIFF
--- a/primary/src/block_synchronizer/mod.rs
+++ b/primary/src/block_synchronizer/mod.rs
@@ -488,8 +488,8 @@ impl<PublicKey: VerifyingKey> BlockSynchronizer<PublicKey> {
                     .collect();
 
                 for r in join_all(futures).await {
-                    if r.is_err() {
-                        error!("Couldn't send message to channel [{:?}]", r.err().unwrap());
+                    if let Err(err) = r {
+                        error!("Couldn't send message to channel [{:?}]", err);
                     }
                 }
 

--- a/primary/src/block_synchronizer/mod.rs
+++ b/primary/src/block_synchronizer/mod.rs
@@ -46,9 +46,10 @@ const CERTIFICATE_RESPONSES_RATIO_THRESHOLD: f32 = 0.5;
 #[derive(Debug, Clone)]
 pub struct BlockHeader<PublicKey: VerifyingKey> {
     certificate: Certificate<PublicKey>,
-    /// When the certificate is found in the local storage and is fetched
-    /// from it (instead via the primary peers), then this value will
-    /// be true, false otherwise.
+    /// It designates whether the requested quantity (either the certificate
+    /// or the payload) has been retrieved via the local storage. If true,
+    /// the it used the storage. If false, then it has been fetched via
+    /// the peers.
     fetched_from_storage: bool,
 }
 

--- a/primary/src/block_synchronizer/tests/block_synchronizer_tests.rs
+++ b/primary/src/block_synchronizer/tests/block_synchronizer_tests.rs
@@ -37,7 +37,7 @@ use types::{Certificate, CertificateDigest};
 #[tokio::test]
 async fn test_successful_headers_synchronization() {
     // GIVEN
-    let (_, _, payload_store) = create_db_stores();
+    let (_, certificate_store, payload_store) = create_db_stores();
 
     // AND the necessary keys
     let (name, committee) = resolve_name_and_committee(13600);
@@ -78,6 +78,7 @@ async fn test_successful_headers_synchronization() {
         rx_payload_availability_responses,
         PrimaryNetwork::default(),
         payload_store.clone(),
+        certificate_store.clone(),
         BlockSynchronizerParameters::default(),
     );
 
@@ -166,11 +167,13 @@ async fn test_successful_headers_synchronization() {
                 assert!(result.is_ok(), "Error result received: {:?}", result.err().unwrap());
 
                 if result.is_ok() {
-                    let certificate = result.ok().unwrap();
+                    let block_header = result.ok().unwrap();
+                    let certificate = block_header.certificate;
 
                     println!("Received certificate result: {:?}", certificate.clone());
 
                     assert!(certificates.contains_key(&certificate.digest()));
+                    assert!(!block_header.fetched_from_storage, "Didn't expect to have fetched certificate from storage");
 
                     total_results_received += 1;
                 }
@@ -189,7 +192,7 @@ async fn test_successful_headers_synchronization() {
 #[tokio::test]
 async fn test_successful_payload_synchronization() {
     // GIVEN
-    let (_, _, payload_store) = create_db_stores();
+    let (_, certificate_store, payload_store) = create_db_stores();
 
     // AND the necessary keys
     let (name, committee) = resolve_name_and_committee(13500);
@@ -230,6 +233,7 @@ async fn test_successful_payload_synchronization() {
         rx_payload_availability_responses,
         PrimaryNetwork::default(),
         payload_store.clone(),
+        certificate_store.clone(),
         BlockSynchronizerParameters::default(),
     );
 
@@ -362,11 +366,13 @@ async fn test_successful_payload_synchronization() {
                 assert!(result.is_ok(), "Error result received: {:?}", result.err().unwrap());
 
                 if result.is_ok() {
-                    let certificate = result.ok().unwrap();
+                    let block_header = result.ok().unwrap();
+                    let certificate = block_header.certificate;
 
                     println!("Received certificate result: {:?}", certificate.clone());
 
                     assert!(certificates.contains_key(&certificate.digest()));
+                    assert!(!block_header.fetched_from_storage, "Didn't expect to have fetched certificate from storage");
 
                     total_results_received += 1;
                 }
@@ -385,7 +391,7 @@ async fn test_successful_payload_synchronization() {
 #[tokio::test]
 async fn test_multiple_overlapping_requests() {
     // GIVEN
-    let (_, _, payload_store) = create_db_stores();
+    let (_, certificate_store, payload_store) = create_db_stores();
     let (name, committee) = resolve_name_and_committee(13001);
 
     let (_, rx_commands) = channel(10);
@@ -423,6 +429,7 @@ async fn test_multiple_overlapping_requests() {
         primary_network: PrimaryNetwork::default(),
         worker_network: PrimaryToWorkerNetwork::default(),
         payload_store,
+        certificate_store,
         certificates_synchronize_timeout: Duration::from_millis(2_000),
         payload_synchronize_timeout: Duration::from_millis(2_000),
         payload_availability_timeout: Duration::from_millis(2_000),
@@ -497,7 +504,7 @@ async fn test_multiple_overlapping_requests() {
 #[tokio::test]
 async fn test_timeout_while_waiting_for_certificates() {
     // GIVEN
-    let (_, _, payload_store) = create_db_stores();
+    let (_, certificate_store, payload_store) = create_db_stores();
 
     // AND the necessary keys
     let (name, committee) = resolve_name_and_committee(13001);
@@ -528,6 +535,7 @@ async fn test_timeout_while_waiting_for_certificates() {
         rx_payload_availability_responses,
         PrimaryNetwork::default(),
         payload_store.clone(),
+        certificate_store.clone(),
         BlockSynchronizerParameters::default(),
     );
 
@@ -577,6 +585,97 @@ async fn test_timeout_while_waiting_for_certificates() {
                 panic!("Timeout, no result has been received in time")
             }
         }
+    }
+}
+
+#[tokio::test]
+async fn test_reply_with_certificates_already_in_storage() {
+    // GIVEN
+    let (_, certificate_store, payload_store) = create_db_stores();
+
+    // AND the necessary keys
+    let (name, committee) = resolve_name_and_committee(13001);
+    let key = keys().pop().unwrap();
+
+    let (_, rx_commands) = channel(10);
+    let (_, rx_certificate_responses) = channel(10);
+    let (_, rx_payload_availability_responses) = channel(10);
+
+    let synchronizer = BlockSynchronizer {
+        name,
+        committee,
+        rx_commands,
+        rx_certificate_responses,
+        rx_payload_availability_responses,
+        pending_requests: Default::default(),
+        map_certificate_responses_senders: Default::default(),
+        map_payload_availability_responses_senders: Default::default(),
+        primary_network: Default::default(),
+        worker_network: Default::default(),
+        certificate_store: certificate_store.clone(),
+        payload_store,
+        certificates_synchronize_timeout: Default::default(),
+        payload_synchronize_timeout: Default::default(),
+        payload_availability_timeout: Default::default(),
+    };
+
+    let mut certificates: HashMap<CertificateDigest, Certificate<Ed25519PublicKey>> =
+        HashMap::new();
+    let mut block_ids = Vec::new();
+    const NUM_OF_MISSING_CERTIFICATES: u32 = 5;
+
+    // AND storing some certificates
+    for i in 1..=8 {
+        let batch = fixture_batch_with_transactions(10);
+
+        let header = fixture_header_builder()
+            .with_payload_batch(batch.clone(), 0)
+            .build(|payload| key.sign(payload));
+
+        let certificate = certificate(&header);
+
+        block_ids.push(certificate.digest());
+        certificates.insert(certificate.clone().digest(), certificate.clone());
+
+        if i > NUM_OF_MISSING_CERTIFICATES {
+            certificate_store
+                .write(certificate.digest(), certificate)
+                .await;
+        }
+    }
+
+    // AND create a dummy sender/receiver
+    let (tx, mut rx) = channel(10);
+
+    // WHEN
+    let missing_certificates = synchronizer
+        .reply_with_certificates_already_in_storage(block_ids, tx)
+        .await;
+
+    // THEN some missing certificates exist
+    assert_eq!(
+        missing_certificates.len() as u32,
+        NUM_OF_MISSING_CERTIFICATES,
+        "Number of expected missing certificates differ."
+    );
+
+    // AND should have received all the block headers
+    for _ in 0..8 - NUM_OF_MISSING_CERTIFICATES {
+        let result = timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+
+        let block_header = result.unwrap();
+
+        assert!(
+            block_header.fetched_from_storage,
+            "Should have been fetched from storage"
+        );
+        assert!(
+            certificates.contains_key(&block_header.certificate.digest()),
+            "Not found expected certificate"
+        );
     }
 }
 

--- a/primary/src/block_synchronizer/tests/block_synchronizer_tests.rs
+++ b/primary/src/block_synchronizer/tests/block_synchronizer_tests.rs
@@ -679,6 +679,101 @@ async fn test_reply_with_certificates_already_in_storage() {
     }
 }
 
+#[tokio::test]
+async fn test_reply_with_payload_already_in_storage() {
+    // GIVEN
+    let (_, certificate_store, payload_store) = create_db_stores();
+
+    // AND the necessary keys
+    let (name, committee) = resolve_name_and_committee(13001);
+    let key = keys().pop().unwrap();
+
+    let (_, rx_commands) = channel(10);
+    let (_, rx_certificate_responses) = channel(10);
+    let (_, rx_payload_availability_responses) = channel(10);
+
+    let synchronizer = BlockSynchronizer {
+        name,
+        committee,
+        rx_commands,
+        rx_certificate_responses,
+        rx_payload_availability_responses,
+        pending_requests: Default::default(),
+        map_certificate_responses_senders: Default::default(),
+        map_payload_availability_responses_senders: Default::default(),
+        primary_network: Default::default(),
+        worker_network: Default::default(),
+        certificate_store: certificate_store.clone(),
+        payload_store: payload_store.clone(),
+        certificates_synchronize_timeout: Default::default(),
+        payload_synchronize_timeout: Default::default(),
+        payload_availability_timeout: Default::default(),
+    };
+
+    let mut certificates_map: HashMap<CertificateDigest, Certificate<Ed25519PublicKey>> =
+        HashMap::new();
+    let mut certificates = Vec::new();
+    const NUM_OF_CERTIFICATES_WITH_MISSING_PAYLOAD: u32 = 5;
+
+    // AND storing some certificates
+    for i in 1..=8 {
+        let batch = fixture_batch_with_transactions(10);
+
+        let header = fixture_header_builder()
+            .with_payload_batch(batch.clone(), 0)
+            .build(|payload| key.sign(payload));
+
+        let certificate: Certificate<Ed25519PublicKey> = certificate(&header);
+
+        certificates.push(certificate.clone());
+        certificates_map.insert(certificate.clone().digest(), certificate.clone());
+
+        if i > NUM_OF_CERTIFICATES_WITH_MISSING_PAYLOAD {
+            certificate_store
+                .write(certificate.digest(), certificate.clone())
+                .await;
+
+            for entry in certificate.header.payload {
+                payload_store.write(entry, 1).await;
+            }
+        }
+    }
+
+    // AND create a dummy sender/receiver
+    let (tx, mut rx) = channel(10);
+
+    // WHEN
+    let missing_certificates = synchronizer
+        .reply_with_payload_already_in_storage(certificates, tx)
+        .await;
+
+    // THEN some certificates with missing payload exist
+    assert_eq!(
+        missing_certificates.len() as u32,
+        NUM_OF_CERTIFICATES_WITH_MISSING_PAYLOAD,
+        "Number of expected missing certificates differ."
+    );
+
+    // AND should have received all the block headers
+    for _ in 0..8 - NUM_OF_CERTIFICATES_WITH_MISSING_PAYLOAD {
+        let result = timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+
+        let block_header = result.unwrap();
+
+        assert!(
+            block_header.fetched_from_storage,
+            "Should have been fetched from storage"
+        );
+        assert!(
+            certificates_map.contains_key(&block_header.certificate.digest()),
+            "Not found expected certificate"
+        );
+    }
+}
+
 pub fn primary_listener<T>(
     num_of_expected_responses: i32,
     address: SocketAddr,

--- a/primary/src/grpc_server/validator.rs
+++ b/primary/src/grpc_server/validator.rs
@@ -2,10 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 use std::time::Duration;
 
-use crate::block_waiter::GetBlockResponse;
-use crate::BlockCommand;
-use tokio::sync::oneshot;
-use tokio::{sync::mpsc::Sender, time::timeout};
+use crate::{block_waiter::GetBlockResponse, BlockCommand};
+use tokio::{
+    sync::{mpsc::Sender, oneshot},
+    time::timeout,
+};
 use tonic::{Request, Response, Status};
 use types::{
     BatchMessageProto, BlockError, CollectionRetrievalResult, GetCollectionsRequest,

--- a/primary/src/primary.rs
+++ b/primary/src/primary.rs
@@ -230,6 +230,7 @@ impl Primary {
             rx_payload_availability_responses,
             PrimaryNetwork::default(),
             payload_store.clone(),
+            certificate_store.clone(),
             parameters.block_synchronizer,
         );
 

--- a/primary/tests/integration_tests.rs
+++ b/primary/tests/integration_tests.rs
@@ -2,12 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use config::Parameters;
-use crypto::traits::Signer;
-use crypto::Hash;
-use crypto::{ed25519::Ed25519PublicKey, traits::KeyPair};
+use crypto::{
+    ed25519::Ed25519PublicKey,
+    traits::{KeyPair, Signer},
+    Hash,
+};
 use node::NodeStorage;
-use primary::Primary;
-use primary::CHANNEL_CAPACITY;
+use primary::{Primary, CHANNEL_CAPACITY};
 use std::time::Duration;
 use test_utils::{
     certificate, committee_with_base_port, fixture_batch_with_transactions, fixture_header_builder,

--- a/types/src/primary.rs
+++ b/types/src/primary.rs
@@ -1,8 +1,10 @@
 // Copyright (c) 2021, Facebook, Inc. and its affiliates
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use crate::error::{DagError, DagResult};
-use crate::{BatchDigestProto, CertificateDigestProto};
+use crate::{
+    error::{DagError, DagResult},
+    BatchDigestProto, CertificateDigestProto,
+};
 use blake2::{digest::Update, VarBlake2b};
 use bytes::Bytes;
 use config::{Committee, WorkerId};
@@ -12,10 +14,10 @@ use crypto::{
 };
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
-use std::fmt::Formatter;
 use std::{
     collections::{BTreeMap, BTreeSet, HashSet},
     fmt,
+    fmt::Formatter,
 };
 
 /// The round number.


### PR DESCRIPTION
Resolves: https://github.com/MystenLabs/narwhal/issues/163

This PR is introducing some extra logic on the `block_synchronizer` to first query in the storage for availability before synchronizing either a `certificate` or a `payload`.

**Command::SynchronizeBlockHeaders**
If a certificate is found in local storage, then the response is immediately sent to the consumer and is excluded from synching. If there is any certificate left to synchronize, then the rest of the process will be followed. If all can be served via the local storage, then no synching process will be triggered.

**Command::SynchronizeBlockPayload**
Similar to the `Command::SynchronizeBlockHeaders` case, the `payload_store` will be queried in order to figure out whether the payload is available. The assumption is that if a certificate's payload batches can all be found to the `payload_store` , then the batch should be available to the workers - that's how the rest of the codebase treats the `payload_store`