### PR TITLE
wire block synchronizer to block waiter (part 1)

### DIFF
--- a/primary/src/block_synchronizer/mock.rs
+++ b/primary/src/block_synchronizer/mock.rs
@@ -1,0 +1,170 @@
+use crate::block_synchronizer::{BlockHeader, BlockSynchronizeResult, Command};
+use crypto::traits::VerifyingKey;
+use std::collections::HashMap;
+use tokio::sync::{
+    mpsc::{channel, Receiver, Sender},
+    oneshot,
+};
+use types::CertificateDigest;
+
+#[derive(Debug)]
+enum Core<PublicKey: VerifyingKey> {
+    SynchronizeBlockHeaders {
+        block_ids: Vec<CertificateDigest>,
+        times: u32,
+        result: Vec<BlockSynchronizeResult<BlockHeader<PublicKey>>>,
+        ready: oneshot::Sender<()>,
+    },
+    AssertExpectations {
+        ready: oneshot::Sender<()>,
+    },
+}
+
+struct MockBlockSynchronizerCore<PublicKey: VerifyingKey> {
+    block_headers_expected_requests:
+        HashMap<Vec<CertificateDigest>, (u32, Vec<BlockSynchronizeResult<BlockHeader<PublicKey>>>)>,
+    rx_commands: Receiver<Command<PublicKey>>,
+    rx_core: Receiver<Core<PublicKey>>,
+}
+
+impl<PublicKey: VerifyingKey> MockBlockSynchronizerCore<PublicKey> {
+    async fn run(&mut self) {
+        loop {
+            tokio::select! {
+                Some(command) = self.rx_commands.recv() => {
+                    match command {
+                        Command::SynchronizeBlockHeaders { block_ids, respond_to } => {
+                            let (times, results) = self
+                                .block_headers_expected_requests
+                                .remove(&block_ids)
+                                .unwrap_or_else(||panic!("{}", format!("Unexpected call received for SynchronizeBlockHeaders, {:?}", block_ids).as_str()))
+                                .to_owned();
+
+                            if times > 1 {
+                                self.block_headers_expected_requests.insert(block_ids, (times - 1, results.clone()));
+                            }
+
+                            for result in results {
+                                respond_to.send(result).await.expect("Couldn't send message");
+                            }
+                        }
+                        Command::SynchronizeBlockPayload { .. } => {}
+                    }
+                }
+                Some(command) = self.rx_core.recv() => {
+                    match command {
+                        Core::SynchronizeBlockHeaders {
+                            block_ids,
+                            times,
+                            result,
+                            ready,
+                        } => {
+                            self.block_headers_expected_requests.insert(block_ids, (times, result));
+                            ready.send(()).expect("Failed to send ready message");
+                        },
+                        Core::AssertExpectations {ready} => {
+                            self.assert_expectations();
+                            ready.send(()).expect("Failed to send ready message");
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn assert_expectations(&self) {
+        let mut result: String = "".to_string();
+
+        for (ids, results) in &self.block_headers_expected_requests {
+            result.push_str(
+                format!(
+                    "SynchronizeBlockHeaders, ids={:?}, results={:?}",
+                    ids, results
+                )
+                .as_str(),
+            );
+        }
+
+        if !result.is_empty() {
+            panic!(
+                "There are expected calls that haven't been fulfilled \n\n {}",
+                result
+            );
+        }
+    }
+}
+
+/// A mock helper for the BlockSynchronizer to help us mock the responses
+/// eliminating the need to wire in the actual BlockSynchronizer when needed
+/// for other components.
+pub struct MockBlockSynchronizer<PublicKey: VerifyingKey> {
+    tx_core: Sender<Core<PublicKey>>,
+}
+
+impl<PublicKey: VerifyingKey> MockBlockSynchronizer<PublicKey> {
+    pub fn new(rx_commands: Receiver<Command<PublicKey>>) -> Self {
+        let (tx_core, rx_core) = channel(1);
+
+        let mut core = MockBlockSynchronizerCore {
+            block_headers_expected_requests: HashMap::new(),
+            rx_commands,
+            rx_core,
+        };
+
+        tokio::spawn(async move {
+            core.run().await;
+        });
+
+        Self { tx_core }
+    }
+
+    /// A simple method that allow us to mock responses for the
+    /// SynchronizeBlockHeaders requests.
+    /// `block_ids`: The block_ids we expect
+    /// `results`: The results we would like to respond with
+    /// `times`: How many times we should expect to be called.
+    pub async fn expect_synchronize_block_headers(
+        &self,
+        block_ids: Vec<CertificateDigest>,
+        result: Vec<BlockSynchronizeResult<BlockHeader<PublicKey>>>,
+        times: u32,
+    ) {
+        let (tx, rx) = oneshot::channel();
+        self.tx_core
+            .send(Core::SynchronizeBlockHeaders {
+                block_ids,
+                times,
+                result,
+                ready: tx,
+            })
+            .await
+            .expect("Failed to send mock expectation");
+
+        Self::await_channel(rx).await;
+    }
+
+    /// Asserts that all the expectations have been fulfilled and no
+    /// expectation has been left without having been called.
+    pub async fn assert_expectations(&self) {
+        let (tx, rx) = oneshot::channel();
+        self.tx_core
+            .send(Core::AssertExpectations { ready: tx })
+            .await
+            .expect("Failed to assert expectations");
+
+        Self::await_channel(rx).await;
+    }
+
+    /// Helper method to wait on a oneshot receiver channel
+    /// and avoid printing the error. We expect when the
+    /// MockBlockSynchronizerCore panics to violently close
+    /// the provided oneshot channel. To ensure that the
+    /// current thread will panic, we are handling the error
+    /// case and we also print an empty message to avoid
+    /// printing the receive error.
+    async fn await_channel(rx: oneshot::Receiver<()>) {
+        if rx.await.is_err() {
+            panic!("");
+        }
+    }
+}

--- a/primary/src/block_synchronizer/mock.rs
+++ b/primary/src/block_synchronizer/mock.rs
@@ -1,3 +1,5 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
 use crate::block_synchronizer::{BlockHeader, BlockSynchronizeResult, Command};
 use crypto::traits::VerifyingKey;
 use std::collections::HashMap;

--- a/primary/src/block_synchronizer/mod.rs
+++ b/primary/src/block_synchronizer/mod.rs
@@ -45,17 +45,18 @@ const CERTIFICATE_RESPONSES_RATIO_THRESHOLD: f32 = 0.5;
 
 #[derive(Debug, Clone)]
 pub struct BlockHeader<PublicKey: VerifyingKey> {
-    certificate: Certificate<PublicKey>,
+    pub certificate: Certificate<PublicKey>,
     /// It designates whether the requested quantity (either the certificate
     /// or the payload) has been retrieved via the local storage. If true,
     /// the it used the storage. If false, then it has been fetched via
     /// the peers.
-    fetched_from_storage: bool,
+    pub fetched_from_storage: bool,
 }
 
 type ResultSender<T> = Sender<BlockSynchronizeResult<BlockHeader<T>>>;
 type BlockSynchronizeResult<T> = Result<T, SyncError>;
 
+#[derive(Debug)]
 pub enum Command<PublicKey: VerifyingKey> {
     #[allow(dead_code)]
     /// A request to synchronize and output the block headers

--- a/primary/src/block_synchronizer/mod.rs
+++ b/primary/src/block_synchronizer/mod.rs
@@ -34,6 +34,7 @@ use types::{BatchDigest, Certificate, CertificateDigest};
 #[cfg(test)]
 #[path = "tests/block_synchronizer_tests.rs"]
 mod block_synchronizer_tests;
+pub mod mock;
 mod peers;
 pub mod responses;
 

--- a/primary/src/block_waiter.rs
+++ b/primary/src/block_waiter.rs
@@ -26,6 +26,8 @@ use types::{
     CertificateDigest, Header,
 };
 use Result::*;
+use tokio::sync::mpsc::Sender;
+use crate::block_synchronizer::Command;
 
 const BATCH_RETRIEVE_TIMEOUT: Duration = Duration::from_secs(1);
 
@@ -221,6 +223,10 @@ pub struct BlockWaiter<PublicKey: VerifyingKey> {
     /// A map that holds the channels we should notify with the
     /// GetBlocks responses.
     tx_get_blocks_map: HashMap<RequestKey, Vec<oneshot::Sender<BlocksResult>>>,
+
+    /// The sender to use in order to publish messages to the
+    /// block_synchronizer to fetch certificates and synchronize blocks.
+    tx_block_synchronizer: Sender<Command<PublicKey>>,
 }
 
 impl<PublicKey: VerifyingKey> BlockWaiter<PublicKey> {
@@ -369,6 +375,10 @@ impl<PublicKey: VerifyingKey> BlockWaiter<PublicKey> {
         }
 
         None
+    }
+
+    async fn get_certificates(&mut self, ids: Vec<CertificateDigest>) {
+
     }
 
     async fn get_blocks<'a>(

--- a/primary/src/grpc_server/validator.rs
+++ b/primary/src/grpc_server/validator.rs
@@ -2,10 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 use std::time::Duration;
 
-use crate::block_waiter::GetBlockResponse;
-use crate::BlockCommand;
-use tokio::sync::oneshot;
-use tokio::{sync::mpsc::Sender, time::timeout};
+use crate::{block_waiter::GetBlockResponse, BlockCommand};
+use tokio::{
+    sync::{mpsc::Sender, oneshot},
+    time::timeout,
+};
 use tonic::{Request, Response, Status};
 use types::{
     BatchMessageProto, BlockError, CollectionRetrievalResult, GetCollectionsRequest,

--- a/primary/src/lib.rs
+++ b/primary/src/lib.rs
@@ -32,7 +32,11 @@ mod common;
 
 pub use crate::{
     block_remover::{BlockRemover, BlockRemoverCommand, DeleteBatchMessage},
-    block_synchronizer::responses::{CertificatesResponse, PayloadAvailabilityResponse},
+    block_synchronizer::{
+        mock::MockBlockSynchronizer,
+        responses::{CertificatesResponse, PayloadAvailabilityResponse},
+        BlockHeader,
+    },
     block_waiter::{BlockCommand, BlockWaiter},
     primary::{
         PayloadToken, Primary, PrimaryWorkerMessage, WorkerPrimaryError, WorkerPrimaryMessage,

--- a/primary/src/primary.rs
+++ b/primary/src/primary.rs
@@ -203,7 +203,6 @@ impl Primary {
         BlockWaiter::spawn(
             name.clone(),
             committee.clone(),
-            certificate_store.clone(),
             rx_get_block_commands,
             rx_batches,
             tx_block_synchronizer_commands,

--- a/primary/src/primary.rs
+++ b/primary/src/primary.rs
@@ -107,7 +107,7 @@ impl Primary {
         // to remove collections from Narwhal (e.x the remove_collections endpoint).
         let (_tx_block_removal_commands, rx_block_removal_commands) = channel(CHANNEL_CAPACITY);
         let (tx_batch_removal, rx_batch_removal) = channel(CHANNEL_CAPACITY);
-        let (_tx_block_synchronizer_commands, rx_block_synchronizer_commands) =
+        let (tx_block_synchronizer_commands, rx_block_synchronizer_commands) =
             channel(CHANNEL_CAPACITY);
         let (tx_certificate_responses, rx_certificate_responses) = channel(CHANNEL_CAPACITY);
         let (tx_payload_availability_responses, rx_payload_availability_responses) =
@@ -206,6 +206,7 @@ impl Primary {
             certificate_store.clone(),
             rx_get_block_commands,
             rx_batches,
+            tx_block_synchronizer_commands,
         );
 
         // Orchestrates the removal of blocks across the primary and worker nodes.

--- a/primary/tests/integration_tests.rs
+++ b/primary/tests/integration_tests.rs
@@ -2,12 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use config::Parameters;
-use crypto::traits::Signer;
-use crypto::Hash;
-use crypto::{ed25519::Ed25519PublicKey, traits::KeyPair};
+use crypto::{
+    ed25519::Ed25519PublicKey,
+    traits::{KeyPair, Signer},
+    Hash,
+};
 use node::NodeStorage;
-use primary::Primary;
-use primary::CHANNEL_CAPACITY;
+use primary::{Primary, CHANNEL_CAPACITY};
 use std::time::Duration;
 use test_utils::{
     certificate, committee_with_base_port, fixture_batch_with_transactions, fixture_header_builder,

--- a/types/src/primary.rs
+++ b/types/src/primary.rs
@@ -1,8 +1,10 @@
 // Copyright (c) 2021, Facebook, Inc. and its affiliates
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use crate::error::{DagError, DagResult};
-use crate::{BatchDigestProto, CertificateDigestProto};
+use crate::{
+    error::{DagError, DagResult},
+    BatchDigestProto, CertificateDigestProto,
+};
 use blake2::{digest::Update, VarBlake2b};
 use bytes::Bytes;
 use config::{Committee, WorkerId};
@@ -12,10 +14,10 @@ use crypto::{
 };
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
-use std::fmt::Formatter;
 use std::{
     collections::{BTreeMap, BTreeSet, HashSet},
     fmt,
+    fmt::Formatter,
 };
 
 /// The round number.


### PR DESCRIPTION
Ref: https://github.com/MystenLabs/narwhal/issues/183

This PR is wiring in the `block_synchronizer` , via tokio channels, to the `block_waiter` component to ensure that we are able to:
1. synchronize (fetch) missing certificates via peers
2. synchronize (fetch) missing payload (batches) via peers

The case (1) we don't _really_ expect to happen, as via the protocol we'll expect to have the certificates available via the `read_causal` call.

The case (2) is the most probable one which we mostly care.

However, this PR is tackling case (1) and there will be a follow up PR (part 2) to tackle case (2).

So from now on we'll rely 100% to the `block_synchronizer` to fetch the certificates and we don't have the need to query the `certificate_store` ourselfs - `block_synchronizer` is doing that anyways and will serve us fast cached (via rocksdb) results.

Also the `MockBlockSynchronizer` is introduced as a way to mock the synchronizer's responses without having the need to use the actual component and going through the fuzz of setting up etc. The mock will be extended for the `payload` cases as well