### PR TITLE
fix: rename header_store to certificate_store

### DIFF
--- a/primary/src/grpc_server/validator.rs
+++ b/primary/src/grpc_server/validator.rs
@@ -2,10 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 use std::time::Duration;
 
-use crate::block_waiter::GetBlockResponse;
-use crate::BlockCommand;
-use tokio::sync::oneshot;
-use tokio::{sync::mpsc::Sender, time::timeout};
+use crate::{block_waiter::GetBlockResponse, BlockCommand};
+use tokio::{
+    sync::{mpsc::Sender, oneshot},
+    time::timeout,
+};
 use tonic::{Request, Response, Status};
 use types::{
     BatchMessageProto, BlockError, CollectionRetrievalResult, GetCollectionsRequest,

--- a/primary/src/header_waiter.rs
+++ b/primary/src/header_waiter.rs
@@ -47,7 +47,7 @@ pub struct HeaderWaiter<PublicKey: VerifyingKey> {
     /// The committee information.
     committee: Committee<PublicKey>,
     /// The persistent storage for parent Certificates.
-    header_store: Store<CertificateDigest, Certificate<PublicKey>>,
+    certificate_store: Store<CertificateDigest, Certificate<PublicKey>>,
     /// The persistent storage for payload markers from workers.
     payload_store: Store<(BatchDigest, WorkerId), PayloadToken>,
     /// The current consensus round (used for cleanup).
@@ -82,7 +82,7 @@ impl<PublicKey: VerifyingKey> HeaderWaiter<PublicKey> {
     pub fn spawn(
         name: PublicKey,
         committee: Committee<PublicKey>,
-        header_store: Store<CertificateDigest, Certificate<PublicKey>>,
+        certificate_store: Store<CertificateDigest, Certificate<PublicKey>>,
         payload_store: Store<(BatchDigest, WorkerId), PayloadToken>,
         consensus_round: Arc<AtomicU64>,
         gc_depth: Round,
@@ -95,7 +95,7 @@ impl<PublicKey: VerifyingKey> HeaderWaiter<PublicKey> {
             Self {
                 name,
                 committee,
-                header_store,
+                certificate_store,
                 payload_store,
                 consensus_round,
                 gc_depth,
@@ -202,7 +202,7 @@ impl<PublicKey: VerifyingKey> HeaderWaiter<PublicKey> {
                             let wait_for = missing.clone();
                             let (tx_cancel, rx_cancel) = channel(1);
                             self.pending.insert(header_id, (round, tx_cancel));
-                            let fut = Self::waiter(wait_for, self.header_store.clone(), header, rx_cancel);
+                            let fut = Self::waiter(wait_for, self.certificate_store.clone(), header, rx_cancel);
                             // pointer-size allocation, bounded by the # of blocks (may eventually go away, see rust RFC #1909)
                             waiting.push(Box::pin(fut));
 

--- a/primary/tests/integration_tests.rs
+++ b/primary/tests/integration_tests.rs
@@ -2,12 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use config::Parameters;
-use crypto::traits::Signer;
-use crypto::Hash;
-use crypto::{ed25519::Ed25519PublicKey, traits::KeyPair};
+use crypto::{
+    ed25519::Ed25519PublicKey,
+    traits::{KeyPair, Signer},
+    Hash,
+};
 use node::NodeStorage;
-use primary::Primary;
-use primary::CHANNEL_CAPACITY;
+use primary::{Primary, CHANNEL_CAPACITY};
 use std::time::Duration;
 use test_utils::{
     certificate, committee_with_base_port, fixture_batch_with_transactions, fixture_header_builder,

--- a/types/src/primary.rs
+++ b/types/src/primary.rs
@@ -1,8 +1,10 @@
 // Copyright (c) 2021, Facebook, Inc. and its affiliates
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use crate::error::{DagError, DagResult};
-use crate::{BatchDigestProto, CertificateDigestProto};
+use crate::{
+    error::{DagError, DagResult},
+    BatchDigestProto, CertificateDigestProto,
+};
 use blake2::{digest::Update, VarBlake2b};
 use bytes::Bytes;
 use config::{Committee, WorkerId};
@@ -12,10 +14,10 @@ use crypto::{
 };
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
-use std::fmt::Formatter;
 use std::{
     collections::{BTreeMap, BTreeSet, HashSet},
     fmt,
+    fmt::Formatter,
 };
 
 /// The round number.


### PR DESCRIPTION
While going through the code in `header_waiter` I came across the `header_store` which is in fact the `certificate_store`. The naming compared to the expected functionality is quite confusing (@huitseeker I saw that you actually fixed this as a bug where the `header_store` was erroneously passed in the past). If it wasn't intentional to leave this as `header_store` let's do the renaming as it makes the semantics clearer (waiting on the `certificate_store` doesn't require syncing the `headers`/ `batches` as well). 