### PR TITLE
network: use 'multiaddr' everywhere

### DIFF
--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -10,10 +10,10 @@ serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
 thiserror = "1.0.30"
 tracing = { version = "0.1.34", features = ["log"] }
+multiaddr = "0.14.0"
 
 crypto = { path = "../crypto" }
 
 [dev-dependencies]
 tempfile = "3.3.0"
 tracing-test = { version = "0.2.1" }
-

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -14,7 +14,7 @@ rand = { version = "0.7.3", optional = true }
 rocksdb = { version = "0.18.0", features = ["snappy", "lz4", "zstd", "zlib"], default-features = false }
 serde = { version = "1.0.136", features = ["derive"] }
 serde_bytes = "0.11.5"
-store = { git = "https://github.com/mystenlabs/mysten-infra.git", package = "typed-store", rev = "808de09203d147b43d59114b8afd9e51cbcf5778" }
+store = { git = "https://github.com/mystenlabs/mysten-infra.git", package = "typed-store", rev = "3b7daedf91fd8937dde26e905b8114cac459b866" }
 tokio = { version = "1.17.0", features = ["sync"] }
 tracing = "0.1.34"
 

--- a/consensus/src/tests/consensus_tests.rs
+++ b/consensus/src/tests/consensus_tests.rs
@@ -24,8 +24,8 @@ pub fn mock_committee(keys: &[Ed25519PublicKey]) -> Committee<Ed25519PublicKey> 
                     Authority {
                         stake: 1,
                         primary: PrimaryAddresses {
-                            primary_to_primary: "0.0.0.0:0".parse().unwrap(),
-                            worker_to_primary: "0.0.0.0:0".parse().unwrap(),
+                            primary_to_primary: "/ip4/0.0.0.0/tcp/0/http".parse().unwrap(),
+                            worker_to_primary: "/ip4/0.0.0.0/tcp/0/http".parse().unwrap(),
                         },
                         workers: HashMap::default(),
                     },

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -23,7 +23,7 @@ crypto = { path = "../crypto" }
 primary = { path = "../primary" }
 tonic = "0.7"
 
-store = { git = "https://github.com/mystenlabs/mysten-infra.git", package = "typed-store", rev = "808de09203d147b43d59114b8afd9e51cbcf5778" }
+store = { git = "https://github.com/mystenlabs/mysten-infra.git", package = "typed-store", rev = "3b7daedf91fd8937dde26e905b8114cac459b866" }
 types = { path = "../types" }
 
 worker = { path = "../worker" }

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -22,11 +22,13 @@ consensus = { path = "../consensus" }
 crypto = { path = "../crypto" }
 primary = { path = "../primary" }
 tonic = "0.7"
+multiaddr = "0.14.0"
+
+types = { path = "../types" }
+worker = { path = "../worker" }
 
 store = { git = "https://github.com/mystenlabs/mysten-infra.git", package = "typed-store", rev = "3b7daedf91fd8937dde26e905b8114cac459b866" }
-types = { path = "../types" }
-
-worker = { path = "../worker" }
+mysten-network = { git = "https://github.com/mystenlabs/mysten-infra.git", rev = "3b7daedf91fd8937dde26e905b8114cac459b866" }
 
 [dev-dependencies]
 rand = "0.7.3"

--- a/executor/src/lib.rs
+++ b/executor/src/lib.rs
@@ -137,7 +137,7 @@ impl Executor {
             .expect("Our public key is not in the committee")
             .workers
             .iter()
-            .map(|(id, x)| (*id, x.worker_to_worker))
+            .map(|(id, x)| (*id, x.worker_to_worker.clone()))
             .collect();
         let batch_loader_handle = BatchLoader::spawn(store, rx_batch_loader, worker_addresses);
 

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -19,6 +19,9 @@ types = { path = "../types" }
 crypto = { path = "../crypto" }
 tonic = { version = "0.7", features = ["tls"] }
 backoff = { version = "0.4.0", features = ["tokio"] }
+multiaddr = "0.14.0"
+
+mysten-network = { git = "https://github.com/mystenlabs/mysten-infra.git", rev = "3b7daedf91fd8937dde26e905b8114cac459b866" }
 
 [dev-dependencies]
 bincode = "1.3.3"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -14,7 +14,7 @@ cfg-if = "1.0.0"
 clap = "2.34"
 futures = "0.3.21"
 rand = "0.7.3"
-store = { git = "https://github.com/mystenlabs/mysten-infra.git", package = "typed-store", rev = "808de09203d147b43d59114b8afd9e51cbcf5778" }
+store = { git = "https://github.com/mystenlabs/mysten-infra.git", package = "typed-store", rev = "3b7daedf91fd8937dde26e905b8114cac459b866" }
 thiserror = "1.0.30"
 tokio = { version = "1.17.0", features = ["full"] }
 tokio-stream = "0.1.8"

--- a/node/src/generate_format.rs
+++ b/node/src/generate_format.rs
@@ -43,15 +43,25 @@ fn get_registry() -> Result<Registry> {
             .map(|(i, kp)| {
                 let id = kp.public();
                 let primary = PrimaryAddresses {
-                    primary_to_primary: format!("127.0.0.1:{}", 100 + i).parse().unwrap(),
-                    worker_to_primary: format!("127.0.0.1:{}", 200 + i).parse().unwrap(),
+                    primary_to_primary: format!("/ip4/127.0.0.1/tcp/{}/http", 100 + i)
+                        .parse()
+                        .unwrap(),
+                    worker_to_primary: format!("/ip4/127.0.0.1/tcp/{}/http", 200 + i)
+                        .parse()
+                        .unwrap(),
                 };
                 let workers = vec![(
                     0,
                     WorkerAddresses {
-                        primary_to_worker: format!("127.0.0.1:{}", 300 + i).parse().unwrap(),
-                        transactions: format!("127.0.0.1:{}", 400 + i).parse().unwrap(),
-                        worker_to_worker: format!("127.0.0.1:{}", 500 + i).parse().unwrap(),
+                        primary_to_worker: format!("/ip4/127.0.0.1/tcp/{}/http", 300 + i)
+                            .parse()
+                            .unwrap(),
+                        transactions: format!("/ip4/127.0.0.1/tcp/{}/http", 400 + i)
+                            .parse()
+                            .unwrap(),
+                        worker_to_worker: format!("/ip4/127.0.0.1/tcp/{}/http", 500 + i)
+                            .parse()
+                            .unwrap(),
                     },
                 )]
                 .into_iter()

--- a/primary/Cargo.toml
+++ b/primary/Cargo.toml
@@ -18,7 +18,6 @@ derive_builder = "0.11.2"
 ed25519-dalek = "1.0.1"
 futures = "0.3.21"
 serde = { version = "1.0.136", features = ["derive"] }
-store = { git = "https://github.com/mystenlabs/mysten-infra.git", package = "typed-store", rev = "3b7daedf91fd8937dde26e905b8114cac459b866" }
 thiserror = "1.0.30"
 tokio = { version = "1.17.0", features = ["sync", "rt", "macros"] }
 tokio-util = { version = "0.7.1", features = ["codec"] }
@@ -26,12 +25,15 @@ tracing = { version = "0.1.34", features = ["log"] }
 tonic = "0.7"
 prost = "0.10.1"
 rand = { version = "0.7.3", features = ["small_rng"] }
+multiaddr = "0.14.0"
+tower = "0.4.12"
 
 crypto = { path = "../crypto" }
 network = { path = "../network" }
 types = { path = "../types" }
-tower = "0.4.12"
 
+store = { git = "https://github.com/mystenlabs/mysten-infra.git", package = "typed-store", rev = "3b7daedf91fd8937dde26e905b8114cac459b866" }
+mysten-network = { git = "https://github.com/mystenlabs/mysten-infra.git", rev = "3b7daedf91fd8937dde26e905b8114cac459b866" }
 
 [dev-dependencies]
 itertools = "0.10.3"

--- a/primary/Cargo.toml
+++ b/primary/Cargo.toml
@@ -18,7 +18,7 @@ derive_builder = "0.11.2"
 ed25519-dalek = "1.0.1"
 futures = "0.3.21"
 serde = { version = "1.0.136", features = ["derive"] }
-store = { git = "https://github.com/mystenlabs/mysten-infra.git", package = "typed-store", rev = "808de09203d147b43d59114b8afd9e51cbcf5778" }
+store = { git = "https://github.com/mystenlabs/mysten-infra.git", package = "typed-store", rev = "3b7daedf91fd8937dde26e905b8114cac459b866" }
 thiserror = "1.0.30"
 tokio = { version = "1.17.0", features = ["sync", "rt", "macros"] }
 tokio-util = { version = "0.7.1", features = ["codec"] }

--- a/primary/src/core.rs
+++ b/primary/src/core.rs
@@ -135,7 +135,7 @@ impl<PublicKey: VerifyingKey> Core<PublicKey> {
         let addresses = self
             .committee
             .others_primaries(&self.name)
-            .iter()
+            .into_iter()
             .map(|(_, x)| x.primary_to_primary)
             .collect();
         let message = PrimaryMessage::Header(header.clone());
@@ -248,7 +248,7 @@ impl<PublicKey: VerifyingKey> Core<PublicKey> {
             let addresses = self
                 .committee
                 .others_primaries(&self.name)
-                .iter()
+                .into_iter()
                 .map(|(_, x)| x.primary_to_primary)
                 .collect();
             let message = PrimaryMessage::Certificate(certificate.clone());

--- a/primary/src/garbage_collector.rs
+++ b/primary/src/garbage_collector.rs
@@ -4,13 +4,11 @@
 use crate::primary::PrimaryWorkerMessage;
 use config::Committee;
 use crypto::traits::VerifyingKey;
+use multiaddr::Multiaddr;
 use network::PrimaryToWorkerNetwork;
-use std::{
-    net::SocketAddr,
-    sync::{
-        atomic::{AtomicU64, Ordering},
-        Arc,
-    },
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc,
 };
 use tokio::sync::mpsc::Receiver;
 use types::Certificate;
@@ -22,7 +20,7 @@ pub struct GarbageCollector<PublicKey: VerifyingKey> {
     /// Receives the ordered certificates from consensus.
     rx_consensus: Receiver<Certificate<PublicKey>>,
     /// The network addresses of our workers.
-    addresses: Vec<SocketAddr>,
+    addresses: Vec<Multiaddr>,
     /// A network sender to notify our workers of cleanup events.
     worker_network: PrimaryToWorkerNetwork,
 }
@@ -37,7 +35,7 @@ impl<PublicKey: VerifyingKey> GarbageCollector<PublicKey> {
         let addresses = committee
             .our_workers(name)
             .expect("Our public key or worker id is not in the committee")
-            .iter()
+            .into_iter()
             .map(|x| x.primary_to_worker)
             .collect();
 

--- a/primary/src/grpc_server/mod.rs
+++ b/primary/src/grpc_server/mod.rs
@@ -1,25 +1,25 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use std::time::Duration;
 
 use self::validator::NarwhalValidator;
 use crate::BlockCommand;
+use multiaddr::Multiaddr;
+use std::time::Duration;
 use tokio::sync::mpsc::Sender;
-use tonic::transport::Server;
 use tracing::error;
 use types::ValidatorServer;
 
 mod validator;
 
 pub struct ConsensusAPIGrpc {
-    socket_addr: String,
+    socket_addr: Multiaddr,
     tx_get_block_commands: Sender<BlockCommand>,
     get_collections_timeout: Duration,
 }
 
 impl ConsensusAPIGrpc {
     pub fn spawn(
-        socket_addr: String,
+        socket_addr: Multiaddr,
         tx_get_block_commands: Sender<BlockCommand>,
         get_collections_timeout: Duration,
     ) {
@@ -36,15 +36,18 @@ impl ConsensusAPIGrpc {
     }
 
     async fn run(&mut self) -> Result<(), Box<dyn std::error::Error>> {
-        let addr = self.socket_addr.parse()?;
         let narwhal = NarwhalValidator::new(
             self.tx_get_block_commands.to_owned(),
             self.get_collections_timeout,
         );
 
-        Server::builder()
+        let config = mysten_network::config::Config::default();
+        config
+            .server_builder()
             .add_service(ValidatorServer::new(narwhal))
-            .serve(addr)
+            .bind(&self.socket_addr)
+            .await?
+            .serve()
             .await?;
 
         Ok(())

--- a/primary/src/header_waiter.rs
+++ b/primary/src/header_waiter.rs
@@ -272,7 +272,7 @@ impl<PublicKey: VerifyingKey> HeaderWaiter<PublicKey> {
                     if !retry.is_empty() {
                         let addresses = self.committee
                             .others_primaries(&self.name)
-                            .iter()
+                            .into_iter()
                             .map(|(_, x)| x.primary_to_primary)
                             .collect();
                         let message = PrimaryMessage::CertificatesRequest(retry, self.name.clone());

--- a/primary/src/helper.rs
+++ b/primary/src/helper.rs
@@ -231,14 +231,14 @@ impl<PublicKey: VerifyingKey> Helper<PublicKey> {
             };
 
             self.primary_network
-                .unreliable_send(address, &message)
+                .unreliable_send(address.clone(), &message)
                 .await;
         } else {
             for certificate in certificates.into_iter().flatten() {
                 // TODO: Remove this deserialization-serialization in the critical path.
                 let message = PrimaryMessage::Certificate(certificate);
                 self.primary_network
-                    .unreliable_send(address, &message)
+                    .unreliable_send(address.clone(), &message)
                     .await;
             }
         }

--- a/primary/src/tests/block_remover_tests.rs
+++ b/primary/src/tests/block_remover_tests.rs
@@ -17,7 +17,7 @@ use crypto::{
 };
 use futures::{future::try_join_all, stream::FuturesUnordered};
 use network::PrimaryToWorkerNetwork;
-use std::{collections::HashMap, net::SocketAddr, time::Duration};
+use std::{collections::HashMap, time::Duration};
 use test_utils::{
     certificate, fixture_batch_with_transactions, fixture_header_builder, keys,
     resolve_name_and_committee, PrimaryToWorkerMockServer,
@@ -38,7 +38,7 @@ async fn test_successful_blocks_delete() {
     let (tx_delete_batches, rx_delete_batches) = channel(10);
 
     // AND the necessary keys
-    let (name, committee) = resolve_name_and_committee(14000);
+    let (name, committee) = resolve_name_and_committee();
 
     BlockRemover::spawn(
         name.clone(),
@@ -181,7 +181,7 @@ async fn test_timeout() {
     let (tx_delete_batches, rx_delete_batches) = channel(10);
 
     // AND the necessary keys
-    let (name, committee) = resolve_name_and_committee(14001);
+    let (name, committee) = resolve_name_and_committee();
 
     BlockRemover::spawn(
         name.clone(),
@@ -305,7 +305,7 @@ async fn test_unlocking_pending_requests() {
     let (tx_delete_batches, rx_delete_batches) = channel(10);
 
     // AND the necessary keys
-    let (name, committee) = resolve_name_and_committee(14001);
+    let (name, committee) = resolve_name_and_committee();
 
     let mut remover = BlockRemover {
         name,
@@ -402,12 +402,12 @@ async fn test_unlocking_pending_requests() {
 }
 
 pub fn worker_listener<PublicKey: VerifyingKey>(
-    address: SocketAddr,
+    address: multiaddr::Multiaddr,
     expected_batch_ids: Vec<BatchDigest>,
     tx_delete_batches: Sender<DeleteBatchResult>,
 ) -> JoinHandle<()> {
     println!("[{}] Setting up server", &address);
-    let mut recv = PrimaryToWorkerMockServer::spawn(address);
+    let mut recv = PrimaryToWorkerMockServer::spawn(address.clone());
     tokio::spawn(async move {
         let message = recv.recv().await.unwrap();
         match deserialize(&message.payload) {

--- a/primary/src/tests/block_waiter_tests.rs
+++ b/primary/src/tests/block_waiter_tests.rs
@@ -12,7 +12,7 @@ use bincode::deserialize;
 use crypto::{ed25519::Ed25519PublicKey, traits::VerifyingKey, Hash};
 use ed25519_dalek::Signer;
 use network::PrimaryToWorkerNetwork;
-use std::{collections::HashMap, net::SocketAddr};
+use std::collections::HashMap;
 use test_utils::{
     certificate, fixture_batch_with_transactions, fixture_header_builder,
     fixture_header_with_payload, keys, resolve_name_and_committee, PrimaryToWorkerMockServer,
@@ -33,7 +33,7 @@ async fn test_successfully_retrieve_block() {
     let (_, certificate_store, _) = create_db_stores();
 
     // AND the necessary keys
-    let (name, committee) = resolve_name_and_committee(12000);
+    let (name, committee) = resolve_name_and_committee();
 
     // AND store certificate
     let header = fixture_header_with_payload(2);
@@ -127,7 +127,7 @@ async fn test_successfully_retrieve_multiple_blocks() {
     let (_, certificate_store, _) = create_db_stores();
 
     // AND the necessary keys
-    let (name, committee) = resolve_name_and_committee(14001);
+    let (name, committee) = resolve_name_and_committee();
 
     let key = keys().pop().unwrap();
     let mut block_ids = Vec::new();
@@ -263,7 +263,7 @@ async fn test_one_pending_request_for_block_at_time() {
     let (_, certificate_store, _) = create_db_stores();
 
     // AND the necessary keys
-    let (name, committee) = resolve_name_and_committee(13002);
+    let (name, committee) = resolve_name_and_committee();
 
     // AND store certificate
     let header = fixture_header_with_payload(2);
@@ -331,7 +331,7 @@ async fn test_unlocking_pending_get_block_request_after_response() {
     let (_, certificate_store, _) = create_db_stores();
 
     // AND the necessary keys
-    let (name, committee) = resolve_name_and_committee(13003);
+    let (name, committee) = resolve_name_and_committee();
 
     // AND store certificate
     let header = fixture_header_with_payload(2);
@@ -390,7 +390,7 @@ async fn test_batch_timeout() {
     let (_, certificate_store, _) = create_db_stores();
 
     // AND the necessary keys
-    let (name, committee) = resolve_name_and_committee(13004);
+    let (name, committee) = resolve_name_and_committee();
 
     // AND store certificate
     let header = fixture_header_with_payload(2);
@@ -446,7 +446,7 @@ async fn test_batch_timeout() {
 async fn test_return_error_when_certificate_is_missing() {
     // GIVEN
     let (_, certificate_store, _) = create_db_stores();
-    let (name, committee) = resolve_name_and_committee(13005);
+    let (name, committee) = resolve_name_and_committee();
 
     // AND create a certificate but don't store it
     let certificate = Certificate::<Ed25519PublicKey>::default();
@@ -496,7 +496,7 @@ async fn test_return_error_when_certificate_is_missing() {
 // worker_listener listens to TCP requests. The worker responds to the
 // RequestBatch requests for the provided expected_batches.
 pub fn worker_listener<PublicKey: VerifyingKey>(
-    address: SocketAddr,
+    address: multiaddr::Multiaddr,
     expected_batches: HashMap<BatchDigest, BatchMessage>,
     tx_batch_messages: Sender<BatchResult>,
 ) -> JoinHandle<()> {

--- a/primary/src/tests/core_tests.rs
+++ b/primary/src/tests/core_tests.rs
@@ -5,8 +5,7 @@ use super::*;
 use crate::common::create_db_stores;
 use crypto::traits::KeyPair;
 use test_utils::{
-    certificate, committee, committee_with_base_port, header, headers, keys, votes,
-    PrimaryToPrimaryMockServer,
+    certificate, committee, header, headers, keys, votes, PrimaryToPrimaryMockServer,
 };
 use tokio::sync::mpsc::channel;
 use types::{BatchDigest, Header, Vote};
@@ -19,7 +18,7 @@ async fn process_header() {
     let name = kp.public().clone();
     let mut signature_service = SignatureService::new(kp);
 
-    let committee = committee_with_base_port(13_000);
+    let committee = committee();
 
     let (tx_sync_headers, _rx_sync_headers) = channel(1);
     let (tx_sync_certificates, _rx_sync_certificates) = channel(1);
@@ -217,7 +216,7 @@ async fn process_votes() {
     let name = kp.public().clone();
     let signature_service = SignatureService::new(kp);
 
-    let committee = committee_with_base_port(13_100);
+    let committee = committee();
 
     let (tx_sync_headers, _rx_sync_headers) = channel(1);
     let (tx_sync_certificates, _rx_sync_certificates) = channel(1);
@@ -265,7 +264,7 @@ async fn process_votes() {
     // Spawn all listeners to receive our newly formed certificate.
     let mut handles: Vec<_> = committee
         .others_primaries(&name)
-        .iter()
+        .into_iter()
         .map(|(_, address)| PrimaryToPrimaryMockServer::spawn(address.primary_to_primary))
         .collect();
 

--- a/primary/src/tests/helper_tests.rs
+++ b/primary/src/tests/helper_tests.rs
@@ -25,7 +25,7 @@ async fn test_process_certificates_stream_mode() {
     // GIVEN
     let (_, certificate_store, payload_store) = create_db_stores();
     let key = keys().pop().unwrap();
-    let (name, committee) = resolve_name_and_committee(13080);
+    let (name, committee) = resolve_name_and_committee();
     let (tx_primaries, rx_primaries) = channel(10);
 
     // AND a helper
@@ -95,7 +95,7 @@ async fn test_process_certificates_batch_mode() {
     // GIVEN
     let (_, certificate_store, payload_store) = create_db_stores();
     let key = keys().pop().unwrap();
-    let (name, committee) = resolve_name_and_committee(13020);
+    let (name, committee) = resolve_name_and_committee();
     let (tx_primaries, rx_primaries) = channel(10);
 
     // AND a helper
@@ -186,7 +186,7 @@ async fn test_process_payload_availability_success() {
     // GIVEN
     let (_, certificate_store, payload_store) = create_db_stores();
     let key = keys().pop().unwrap();
-    let (name, committee) = resolve_name_and_committee(13710);
+    let (name, committee) = resolve_name_and_committee();
     let (tx_primaries, rx_primaries) = channel(10);
 
     // AND a helper
@@ -297,7 +297,7 @@ async fn test_process_payload_availability_when_failures() {
         Store::new(payload_map);
 
     let key = keys().pop().unwrap();
-    let (name, committee) = resolve_name_and_committee(11340);
+    let (name, committee) = resolve_name_and_committee();
     let (tx_primaries, rx_primaries) = channel(10);
 
     // AND a helper

--- a/test_utils/Cargo.toml
+++ b/test_utils/Cargo.toml
@@ -16,7 +16,7 @@ ed25519-dalek = "1.0.1"
 futures = "0.3.21"
 rand = "0.7.3"
 serde = { version = "1.0.136", features = ["derive"] }
-store = { git = "https://github.com/mystenlabs/mysten-infra.git", package = "typed-store", rev = "808de09203d147b43d59114b8afd9e51cbcf5778" }
+store = { git = "https://github.com/mystenlabs/mysten-infra.git", package = "typed-store", rev = "3b7daedf91fd8937dde26e905b8114cac459b866" }
 tempfile = "3.3.0"
 thiserror = "1.0.30"
 tokio = { version = "1.17.0", features = ["sync", "rt", "macros"] }

--- a/test_utils/Cargo.toml
+++ b/test_utils/Cargo.toml
@@ -16,15 +16,18 @@ ed25519-dalek = "1.0.1"
 futures = "0.3.21"
 rand = "0.7.3"
 serde = { version = "1.0.136", features = ["derive"] }
-store = { git = "https://github.com/mystenlabs/mysten-infra.git", package = "typed-store", rev = "3b7daedf91fd8937dde26e905b8114cac459b866" }
 tempfile = "3.3.0"
 thiserror = "1.0.30"
 tokio = { version = "1.17.0", features = ["sync", "rt", "macros"] }
 tokio-util = { version = "0.7.1", features = ["codec"] }
 tonic = "0.7"
+multiaddr = "0.14.0"
+hex = "0.4.3"
 
 config = { path = "../config" }
 crypto = { path = "../crypto" }
 types = { path = "../types" }
 worker = { path = "../worker"}
-hex = "0.4.3"
+
+store = { git = "https://github.com/mystenlabs/mysten-infra.git", package = "typed-store", rev = "3b7daedf91fd8937dde26e905b8114cac459b866" }
+mysten-network = { git = "https://github.com/mystenlabs/mysten-infra.git", rev = "3b7daedf91fd8937dde26e905b8114cac459b866" }

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -15,7 +15,7 @@ derive_builder = "0.11.2"
 ed25519-dalek = "1.0.1"
 rand = "0.7.3"
 serde = { version = "1.0.136", features = ["derive"] }
-store = { git = "https://github.com/mystenlabs/mysten-infra.git", package = "typed-store", rev = "808de09203d147b43d59114b8afd9e51cbcf5778" }
+store = { git = "https://github.com/mystenlabs/mysten-infra.git", package = "typed-store", rev = "3b7daedf91fd8937dde26e905b8114cac459b866" }
 thiserror = "1.0.30"
 tokio = { version = "1.17.0", features = ["sync", "rt", "macros"] }
 tokio-util = { version = "0.7.1", features = ["codec"] }

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -14,7 +14,7 @@ bytes = "1.1.0"
 ed25519-dalek = "1.0.1"
 futures = "0.3.21"
 serde = { version = "1.0.136", features = ["derive"] }
-store = { git = "https://github.com/mystenlabs/mysten-infra.git", package = "typed-store", rev = "808de09203d147b43d59114b8afd9e51cbcf5778" }
+store = { git = "https://github.com/mystenlabs/mysten-infra.git", package = "typed-store", rev = "3b7daedf91fd8937dde26e905b8114cac459b866" }
 tokio = { version = "1.17.0", features = ["sync", "rt", "macros"] }
 tokio-util = { version = "0.7.1", features = ["codec"] }
 tracing = { version = "0.1.34", features = ["log"] }

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -14,19 +14,22 @@ bytes = "1.1.0"
 ed25519-dalek = "1.0.1"
 futures = "0.3.21"
 serde = { version = "1.0.136", features = ["derive"] }
-store = { git = "https://github.com/mystenlabs/mysten-infra.git", package = "typed-store", rev = "3b7daedf91fd8937dde26e905b8114cac459b866" }
 tokio = { version = "1.17.0", features = ["sync", "rt", "macros"] }
 tokio-util = { version = "0.7.1", features = ["codec"] }
 tracing = { version = "0.1.34", features = ["log"] }
 tonic = "0.7"
 tokio-stream = "0.1.8"
+tower = "0.4.12"
+multiaddr = "0.14.0"
 
 config = { path = "../config" }
 crypto = { path = "../crypto" }
 network = { path = "../network" }
 primary = { path = "../primary" }
 types = { path = "../types" }
-tower = "0.4.12"
+
+store = { git = "https://github.com/mystenlabs/mysten-infra.git", package = "typed-store", rev = "3b7daedf91fd8937dde26e905b8114cac459b866" }
+mysten-network = { git = "https://github.com/mystenlabs/mysten-infra.git", rev = "3b7daedf91fd8937dde26e905b8114cac459b866" }
 
 [dev-dependencies]
 rand = "0.7.3"

--- a/worker/src/batch_maker.rs
+++ b/worker/src/batch_maker.rs
@@ -6,10 +6,10 @@ use crypto::traits::VerifyingKey;
 
 #[cfg(feature = "benchmark")]
 use blake2::digest::Update;
+use multiaddr::Multiaddr;
 use network::WorkerNetwork;
 #[cfg(feature = "benchmark")]
 use std::convert::TryInto as _;
-use std::net::SocketAddr;
 use tokio::{
     sync::mpsc::{Receiver, Sender},
     time::{sleep, Duration, Instant},
@@ -35,7 +35,7 @@ pub struct BatchMaker<PublicKey> {
     /// Output channel to deliver sealed batches to the `QuorumWaiter`.
     tx_message: Sender<QuorumWaiterMessage<PublicKey>>,
     /// The network addresses of the other workers that share our worker id.
-    workers_addresses: Vec<(PublicKey, SocketAddr)>,
+    workers_addresses: Vec<(PublicKey, Multiaddr)>,
     /// Holds the current batch.
     current_batch: Batch,
     /// Holds the size of the current batch (in bytes).
@@ -50,7 +50,7 @@ impl<PublicKey: VerifyingKey> BatchMaker<PublicKey> {
         max_batch_delay: Duration,
         rx_transaction: Receiver<Transaction>,
         tx_message: Sender<QuorumWaiterMessage<PublicKey>>,
-        workers_addresses: Vec<(PublicKey, SocketAddr)>,
+        workers_addresses: Vec<(PublicKey, Multiaddr)>,
     ) {
         tokio::spawn(async move {
             Self {

--- a/worker/src/helper.rs
+++ b/worker/src/helper.rs
@@ -72,7 +72,7 @@ impl<PublicKey: VerifyingKey> Helper<PublicKey> {
                     for digest in digests {
                         match self.store.read(digest).await {
                             Ok(Some(data)) => {
-                                let _ = self.network.unreliable_send_message(address, Bytes::from(data)).await;
+                                let _ = self.network.unreliable_send_message(address.clone(), Bytes::from(data)).await;
                             }
                             Ok(None) => (),
                             Err(e) => error!("{e}"),

--- a/worker/src/primary_connector.rs
+++ b/worker/src/primary_connector.rs
@@ -1,8 +1,8 @@
 // Copyright (c) 2021, Facebook, Inc. and its affiliates
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
+use multiaddr::Multiaddr;
 use primary::WorkerPrimaryMessage;
-use std::net::SocketAddr;
 use tokio::sync::mpsc::Receiver;
 use tonic::transport::Channel;
 use types::{BincodeEncodedPayload, WorkerToPrimaryClient};
@@ -10,7 +10,7 @@ use types::{BincodeEncodedPayload, WorkerToPrimaryClient};
 // Send batches' digests to the primary.
 pub struct PrimaryConnector {
     /// The primary network address.
-    _primary_address: SocketAddr,
+    _primary_address: Multiaddr,
     /// Input channel to receive the messages to send to the primary.
     rx_digest: Receiver<WorkerPrimaryMessage>,
     /// A network sender to send the batches' digests to the primary.
@@ -18,10 +18,10 @@ pub struct PrimaryConnector {
 }
 
 impl PrimaryConnector {
-    pub fn spawn(primary_address: SocketAddr, rx_digest: Receiver<WorkerPrimaryMessage>) {
+    pub fn spawn(primary_address: Multiaddr, rx_digest: Receiver<WorkerPrimaryMessage>) {
         tokio::spawn(async move {
             Self {
-                _primary_address: primary_address,
+                _primary_address: primary_address.clone(),
                 rx_digest,
                 primary_client: PrimaryClient::new(primary_address),
             }
@@ -42,17 +42,15 @@ impl PrimaryConnector {
 #[derive(Clone)]
 pub struct PrimaryClient {
     /// The primary network address.
-    _primary_address: SocketAddr,
+    _primary_address: Multiaddr,
     client: WorkerToPrimaryClient<Channel>,
 }
 
 impl PrimaryClient {
-    pub fn new(address: SocketAddr) -> Self {
-        // TODO maybe use TLS
-        let url = format!("http://{}", address);
-        let channel = Channel::from_shared(url)
-            .expect("URI should be valid")
-            .connect_lazy();
+    pub fn new(address: Multiaddr) -> Self {
+        //TODO don't panic here if address isn't supported
+        let config = mysten_network::config::Config::new();
+        let channel = config.connect_lazy(&address).unwrap();
         let client = WorkerToPrimaryClient::new(channel);
 
         Self {

--- a/worker/src/synchronizer.rs
+++ b/worker/src/synchronizer.rs
@@ -221,7 +221,8 @@ impl<PublicKey: VerifyingKey> Synchronizer<PublicKey> {
                     if !retry.is_empty() {
                         let addresses = self.committee
                             .others_workers(&self.name, &self.id)
-                            .iter().map(|(_, address)| address.worker_to_worker)
+                            .into_iter()
+                            .map(|(_, address)| address.worker_to_worker)
                             .collect();
                         let message = WorkerMessage::BatchRequest(retry, self.name.clone());
                         self.network

--- a/worker/src/tests/batch_maker_tests.rs
+++ b/worker/src/tests/batch_maker_tests.rs
@@ -10,7 +10,10 @@ use tokio::sync::mpsc::channel;
 async fn make_batch() {
     let (tx_transaction, rx_transaction) = channel(1);
     let (tx_message, mut rx_message) = channel(1);
-    let dummy_addresses = vec![(Ed25519PublicKey::default(), "127.0.0.1:0".parse().unwrap())];
+    let dummy_addresses = vec![(
+        Ed25519PublicKey::default(),
+        "/ip4/127.0.0.1/tcp/0/http".parse().unwrap(),
+    )];
 
     // Spawn a `BatchMaker` instance.
     BatchMaker::spawn(
@@ -40,7 +43,10 @@ async fn make_batch() {
 async fn batch_timeout() {
     let (tx_transaction, rx_transaction) = channel(1);
     let (tx_message, mut rx_message) = channel(1);
-    let dummy_addresses = vec![(Ed25519PublicKey::default(), "127.0.0.1:0".parse().unwrap())];
+    let dummy_addresses = vec![(
+        Ed25519PublicKey::default(),
+        "/ip4/127.0.0.1/tcp/0/http".parse().unwrap(),
+    )];
 
     // Spawn a `BatchMaker` instance.
     BatchMaker::spawn(

--- a/worker/src/tests/helper_tests.rs
+++ b/worker/src/tests/helper_tests.rs
@@ -5,7 +5,7 @@ use super::*;
 use crypto::traits::KeyPair;
 use store::rocks;
 use test_utils::{
-    batch, committee_with_base_port, digest_batch, keys, serialize_batch_message, temp_dir,
+    batch, committee, digest_batch, keys, serialize_batch_message, temp_dir,
     WorkerToWorkerMockServer,
 };
 use tokio::sync::mpsc::channel;
@@ -17,7 +17,7 @@ async fn worker_batch_reply() {
     let (_tx_client_request, rx_client_request) = channel(1);
     let requestor = keys().pop().unwrap().public().clone();
     let id = 0;
-    let committee = committee_with_base_port(8_000);
+    let committee = committee();
 
     // Create a new test store.
     let db = rocks::DBMap::<BatchDigest, SerializedBatchMessage>::open(
@@ -61,7 +61,7 @@ async fn client_batch_reply() {
     let (_tx_worker_request, rx_worker_request) = channel(1);
     let (tx_client_request, rx_client_request) = channel(1);
     let id = 0;
-    let committee = committee_with_base_port(8_001);
+    let committee = committee();
 
     // Create a new test store.
     let db = rocks::DBMap::<BatchDigest, SerializedBatchMessage>::open(

--- a/worker/src/tests/quorum_waiter_tests.rs
+++ b/worker/src/tests/quorum_waiter_tests.rs
@@ -6,7 +6,7 @@ use crate::worker::WorkerMessage;
 use bytes::Bytes;
 use crypto::{ed25519::Ed25519PublicKey, traits::KeyPair};
 use network::WorkerNetwork;
-use test_utils::{batch, committee_with_base_port, keys, WorkerToWorkerMockServer};
+use test_utils::{batch, committee, keys, WorkerToWorkerMockServer};
 use tokio::sync::mpsc::channel;
 
 #[tokio::test]
@@ -14,7 +14,7 @@ async fn wait_for_quorum() {
     let (tx_message, rx_message) = channel(1);
     let (tx_batch, mut rx_batch) = channel(1);
     let myself = keys().pop().unwrap().public().clone();
-    let committee = committee_with_base_port(7_000);
+    let committee = committee();
 
     // Spawn a `QuorumWaiter` instance.
     QuorumWaiter::spawn(committee.clone(), /* stake */ 1, rx_message, tx_batch);
@@ -30,7 +30,7 @@ async fn wait_for_quorum() {
     let mut listener_handles = Vec::new();
     for (name, address) in committee.others_workers(&myself, /* id */ &0) {
         let address = address.worker_to_worker;
-        let handle = WorkerToWorkerMockServer::spawn(address);
+        let handle = WorkerToWorkerMockServer::spawn(address.clone());
         names.push(name);
         addresses.push(address);
         listener_handles.push(handle);

--- a/worker/src/tests/synchronizer_tests.rs
+++ b/worker/src/tests/synchronizer_tests.rs
@@ -4,8 +4,8 @@
 use super::*;
 use crypto::{ed25519::Ed25519PublicKey, traits::KeyPair};
 use test_utils::{
-    batch, batch_digest, batches, committee_with_base_port, keys, open_batch_store,
-    resolve_batch_digest, serialize_batch_message, WorkerToWorkerMockServer,
+    batch, batch_digest, batches, committee, keys, open_batch_store, resolve_batch_digest,
+    serialize_batch_message, WorkerToWorkerMockServer,
 };
 use tokio::{sync::mpsc::channel, time::timeout};
 
@@ -17,7 +17,7 @@ async fn synchronize() {
     let mut keys = keys();
     let name = keys.pop().unwrap().public().clone();
     let id = 0;
-    let committee = committee_with_base_port(9_000);
+    let committee = committee();
 
     // Create a new test store.
     let store = open_batch_store();
@@ -60,7 +60,7 @@ async fn test_successful_request_batch() {
     let mut keys = keys();
     let name = keys.pop().unwrap().public().clone();
     let id = 0;
-    let committee = committee_with_base_port(9_000);
+    let committee = committee();
 
     // Create a new test store.
     let store = open_batch_store();
@@ -115,7 +115,7 @@ async fn test_request_batch_not_found() {
     let mut keys = keys();
     let name = keys.pop().unwrap().public().clone();
     let id = 0;
-    let committee = committee_with_base_port(9_000);
+    let committee = committee();
 
     // Create a new test store.
     let store = open_batch_store();
@@ -169,7 +169,7 @@ async fn test_successful_batch_delete() {
     let mut keys = keys();
     let name = keys.pop().unwrap().public().clone();
     let id = 0;
-    let committee = committee_with_base_port(9_000);
+    let committee = committee();
 
     // Create a new test store.
     let store = open_batch_store();


### PR DESCRIPTION
This patch converts all uses of `SocketAddr` for identifiying the
network address of a node to `Multiaddr`.

In addition this patch leverages the `config::utils::get_available_port`
utility function to improve port allocation in tests.