### PR TITLE
fix: repair benchmarks post #220

### DIFF
--- a/benchmark/benchmark/logs.py
+++ b/benchmark/benchmark/logs.py
@@ -139,7 +139,7 @@ class LogParser:
             )
         }
 
-        ip = search(r'booted on (\d+.\d+.\d+.\d+)', log).group(1)
+        ip = search(r'booted on (/ip4/\d+.\d+.\d+.\d+)', log).group(1)
 
         return proposals, commits, configs, ip
 
@@ -153,7 +153,7 @@ class LogParser:
         tmp = findall(r'Batch ([^ ]+) contains sample tx (\d+)', log)
         samples = {int(s): d for d, s in tmp}
 
-        ip = search(r'booted on (\d+.\d+.\d+.\d+)', log).group(1)
+        ip = search(r'booted on (/ip4/\d+.\d+.\d+.\d+)', log).group(1)
 
         return sizes, samples, ip
 

--- a/benchmark/benchmark/utils.py
+++ b/benchmark/benchmark/utils.py
@@ -1,5 +1,11 @@
-# Copyright(C) Facebook, Inc. and its affiliates.
+# Copyright (c) 2021, Facebook, Inc. and its affiliates.
+# Copyright (c) 2022, Mysten Labs, Inc.
+import multiaddr
+from multiaddr.protocols import (
+    P_DNS, P_DNS4, P_DNS6, P_HTTP, P_HTTPS, P_IP4, P_IP6, P_TCP)
 from os.path import join
+import socket
+import urllib.parse
 
 
 class BenchError(Exception):
@@ -143,3 +149,80 @@ def progress_bar(iterable, prefix='', suffix='', decimals=1, length=30, fill='â–
         yield item
         printProgressBar(i + 1)
     print()
+
+
+class AddressError(Exception, multiaddr.exceptions.Error):
+    """Raised when the provided daemon location Multiaddr does not match any
+    of the supported patterns."""
+    __slots__ = ("addr",)
+
+    def __init__(self, addr) -> None:
+        self.addr = addr
+        Exception.__init__(
+            self, "Unsupported Multiaddr pattern: {0!r}".format(addr))
+
+
+def multiaddr_to_url_data(addr: str):  # noqa: C901
+    try:
+        multi_addr = multiaddr.Multiaddr(addr)
+    except multiaddr.exceptions.ParseError as error:
+        raise AddressError(addr) from error
+
+    addr_iter = iter(multi_addr.items())
+
+    # Parse the `host`, `family`, `port` & `secure` values from the given
+    # multiaddr, raising on unsupported `addr` values
+    try:
+        # Read host value
+        proto, host = next(addr_iter)
+        # TODO: return this
+        family = socket.AF_UNSPEC
+
+        if proto.code in (P_IP4, P_DNS4):
+            family = socket.AF_INET  # noqa: F841
+        elif proto.code in (P_IP6, P_DNS6):
+            family = socket.AF_INET6  # noqa: F841
+        elif proto.code != P_DNS:
+            raise AddressError(addr)
+
+        # Read port value for IP-based transports
+        proto, port = next(addr_iter)
+        if proto.code != P_TCP:
+            raise AddressError(addr)
+
+        # Pre-format network location URL part based on host+port
+        if ":" in host and not host.startswith("["):
+            netloc = "[{0}]:{1}".format(host, port)
+        else:
+            netloc = "{0}:{1}".format(host, port)
+
+        # Read application-level protocol name
+        secure = False
+        try:
+            proto, value = next(addr_iter)
+        except StopIteration:
+            pass
+        else:
+            if proto.code == P_HTTPS:
+                secure = True
+            elif proto.code != P_HTTP:
+                raise AddressError(addr)
+
+        # No further values may follow; this also exhausts the iterator
+        was_final = all(False for _ in addr_iter)
+        if not was_final:
+            raise AddressError(addr)
+    except StopIteration:
+        raise AddressError(addr) from None
+
+    # Convert the parsed `addr` values to a URL base and parameters for the
+    # HTTP library
+    base_url = urllib.parse.SplitResult(
+        scheme="http" if not secure else "https",
+        netloc=netloc,
+        path="/",
+        query="",
+        fragment=""
+    ).geturl()
+
+    return base_url

--- a/benchmark/fabfile.py
+++ b/benchmark/fabfile.py
@@ -34,7 +34,7 @@ def local(ctx, debug=True):
             'payload_availability_timeout': '2_000ms'
         },
         "consensus_api_grpc": {
-            "socket_addr": "127.0.0.1:0",
+            "socket_addr": "/ip4/127.0.0.1/tcp/0/http",
             "get_collections_timeout": "5_000ms"
         },
         'max_concurrent_requests': 2
@@ -126,7 +126,7 @@ def remote(ctx, debug=False):
             'payload_availability_timeout': '2_000ms'
         },
         "consensus_api_grpc": {
-            "socket_addr": "127.0.0.1:0",
+            "socket_addr": "/ip4/127.0.0.1/tcp/0/http",
             "get_collections_timeout": "5_000ms"
         },
         'max_concurrent_requests': 500_000

--- a/benchmark/requirements.txt
+++ b/benchmark/requirements.txt
@@ -1,3 +1,4 @@
 boto3==1.16.0
 fabric==2.6.0
 matplotlib==3.3.4
+multiaddr==0.0.9

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -22,6 +22,7 @@ tokio-util = { version = "0.7.1", features = ["codec"] }
 tracing = { version = "0.1.34", features = ["log"] }
 tracing-log = "0.1.3"
 tracing-subscriber = { version = "0.3.11", features = ["time", "env-filter"] }
+url = "2.2.2"
 
 config = { path = "../config" }
 consensus = { path = "../consensus" }


### PR DESCRIPTION
This switches the benchmarks to use `MultiAddr` (and the benchmark client to use urls).