### PR TITLE
Introduce block_synchronizer_handler and wire to block waiter (part 1) #214

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -39,7 +39,8 @@ node_params = {
     'block_synchronizer': {
         'certificates_synchronize_timeout': '2000ms',
         'payload_synchronize_timeout': '2000ms',
-        'payload_availability_timeout': '2000ms'
+        'payload_availability_timeout': '2000ms',
+        'handler_certificate_deliver_timeout': '2_000ms'
     },
     "consensus_api_grpc": {
         "socket_addr": "/ip4/127.0.0.1/tcp/0/http",
@@ -63,6 +64,9 @@ They are defined as follows:
 * `socket_addr`: The socket address the consensus api gRPC server should be listening to.
 * `get_collections_timeout`: The timeout configuration when requesting batches from workers.
 * `remove_collections_timeout`: The timeout configuration when removing batches from workers.
+* `handler_certificate_deliver_timeout`: When a certificate is fetched on the fly from peers, it is submitted from the block synchronizer handler for further processing to core 
+to validate and ensure parents are available and history is causal complete. This property is the timeout while we wait for core to perform this processes and the certificate to become 
+available to the handler to consume.
 * `max_concurrent_requests`: The maximum number of concurrent requests for primary-to-primary and worker-to-worker messages.
 
 ### Run the benchmark

--- a/benchmark/fabfile.py
+++ b/benchmark/fabfile.py
@@ -31,7 +31,8 @@ def local(ctx, debug=True):
         'block_synchronizer': {
             'certificates_synchronize_timeout': '2_000ms',
             'payload_synchronize_timeout': '2_000ms',
-            'payload_availability_timeout': '2_000ms'
+            'payload_availability_timeout': '2_000ms',
+            'handler_certificate_deliver_timeout': '2_000ms'
         },
         "consensus_api_grpc": {
             "socket_addr": "/ip4/127.0.0.1/tcp/0/http",
@@ -124,7 +125,8 @@ def remote(ctx, debug=False):
         'block_synchronizer': {
             'certificates_synchronize_timeout': '2_000ms',
             'payload_synchronize_timeout': '2_000ms',
-            'payload_availability_timeout': '2_000ms'
+            'payload_availability_timeout': '2_000ms',
+            'handler_certificate_deliver_timeout': '2_000ms'
         },
         "consensus_api_grpc": {
             "socket_addr": "/ip4/127.0.0.1/tcp/0/http",

--- a/primary/Cargo.toml
+++ b/primary/Cargo.toml
@@ -31,7 +31,6 @@ tower = "0.4.12"
 crypto = { path = "../crypto" }
 network = { path = "../network" }
 types = { path = "../types" }
-
 store = { git = "https://github.com/mystenlabs/mysten-infra.git", package = "typed-store", rev = "3b7daedf91fd8937dde26e905b8114cac459b866" }
 mysten-network = { git = "https://github.com/mystenlabs/mysten-infra.git", rev = "3b7daedf91fd8937dde26e905b8114cac459b866" }
 
@@ -42,6 +41,7 @@ tempfile = "3.3.0"
 test_utils = { path = "../test_utils"}
 tracing-test = { version = "0.2.1" }
 worker = { path = "../worker" }
+mockall = "0.11.0"
 
 [features]
 benchmark = []

--- a/primary/src/block_synchronizer/handler.rs
+++ b/primary/src/block_synchronizer/handler.rs
@@ -1,0 +1,250 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use crate::{
+    block_synchronizer::{
+        handler::Error::{BlockDeliveryTimeout, BlockNotFound, Internal},
+        BlockSynchronizeResult, Command,
+    },
+    BlockHeader,
+};
+use async_trait::async_trait;
+use crypto::{traits::VerifyingKey, Hash};
+use futures::future::join_all;
+#[cfg(test)]
+use mockall::*;
+use std::time::Duration;
+use store::Store;
+use thiserror::Error;
+use tokio::{
+    sync::mpsc::{channel, Sender},
+    time::timeout,
+};
+use tracing::{debug, error, instrument};
+use types::{Certificate, CertificateDigest, PrimaryMessage};
+
+#[cfg(test)]
+#[path = "tests/handler_tests.rs"]
+mod handler_tests;
+
+/// The errors returned by the Handler. It translates
+/// also the errors returned from the block_synchronizer.
+#[derive(Debug, Error, Copy, Clone)]
+pub enum Error {
+    #[error("Block with id {block_id} not found")]
+    BlockNotFound { block_id: CertificateDigest },
+
+    #[error("Block with id {block_id} couldn't be retrieved, internal error occurred")]
+    Internal { block_id: CertificateDigest },
+
+    #[error("Timed out while waiting for {block_id} to become available after submitting for processing")]
+    BlockDeliveryTimeout { block_id: CertificateDigest },
+}
+
+impl Error {
+    pub fn block_id(&self) -> CertificateDigest {
+        match *self {
+            BlockNotFound { block_id }
+            | Internal { block_id }
+            | BlockDeliveryTimeout { block_id } => block_id,
+        }
+    }
+}
+
+/// Handler defines an interface to allow us access the BlockSycnhronizer's
+/// functionality in a synchronous way without having to deal with message
+/// emission. The BlockSynchronizer on its own for the certificates that
+/// fetches on the fly from peers doesn't care/deal about any other validation
+/// checks than the basic verification offered via the certificate entity
+/// it self. For that reason the Handler offers methods to submit the fetched
+/// from peers certificates for further validation & processing (e.x ensure
+/// parents history is causally complete) to the core and wait until the
+/// certificate has been processed, before it returns it back as result.
+#[cfg_attr(test, automock)]
+#[async_trait]
+pub trait Handler<PublicKey: VerifyingKey> {
+    /// It retrieves the requested blocks via the block_synchronizer making
+    /// sure though that they are fully validated. The certificates will only
+    /// be returned when they have properly processed via the core module
+    /// and made sure all the requirements have been fulfilled.
+    async fn get_and_synchronize_block_headers(
+        &self,
+        block_ids: Vec<CertificateDigest>,
+    ) -> Vec<Result<Certificate<PublicKey>, Error>>;
+
+    /// It retrieves the requested blocks via the block_synchronizer, but it
+    /// doesn't synchronize the fetched headers, meaning that no processing
+    /// will take place (causal completion etc).
+    async fn get_block_headers(
+        &self,
+        block_ids: Vec<CertificateDigest>,
+    ) -> Vec<BlockSynchronizeResult<BlockHeader<PublicKey>>>;
+}
+
+/// A helper struct to allow us access the block_synchronizer in a synchronous
+/// way. It also offers methods to both fetch the certificates and way to
+/// process them and causally complete their history.
+pub struct BlockSynchronizerHandler<PublicKey: VerifyingKey> {
+    /// Channel to send commands to the block_synchronizer.
+    tx_block_synchronizer: Sender<Command<PublicKey>>,
+
+    /// Channel to send the fetched certificates to Core for
+    /// further processing, validation and possibly causal
+    /// completion.
+    tx_core: Sender<PrimaryMessage<PublicKey>>,
+
+    /// The store that holds the certificates.
+    certificate_store: Store<CertificateDigest, Certificate<PublicKey>>,
+
+    /// The timeout while waiting for a certificate to become available
+    /// after submitting for processing to core.
+    certificate_deliver_timeout: Duration,
+}
+
+impl<PublicKey: VerifyingKey> BlockSynchronizerHandler<PublicKey> {
+    pub fn new(
+        tx_block_synchronizer: Sender<Command<PublicKey>>,
+        tx_core: Sender<PrimaryMessage<PublicKey>>,
+        certificate_store: Store<CertificateDigest, Certificate<PublicKey>>,
+        certificate_deliver_timeout: Duration,
+    ) -> Self {
+        Self {
+            tx_block_synchronizer,
+            tx_core,
+            certificate_store,
+            certificate_deliver_timeout,
+        }
+    }
+
+    #[instrument(level = "debug", skip_all)]
+    async fn wait_all(
+        &self,
+        certificates: Vec<Certificate<PublicKey>>,
+    ) -> Vec<Result<Certificate<PublicKey>, Error>> {
+        let futures: Vec<_> = certificates
+            .into_iter()
+            .map(|c| self.wait(c.digest()))
+            .collect();
+
+        join_all(futures).await
+    }
+
+    #[instrument(level = "debug", skip_all, err)]
+    async fn wait(&self, block_id: CertificateDigest) -> Result<Certificate<PublicKey>, Error> {
+        if let Ok(result) = timeout(
+            self.certificate_deliver_timeout,
+            self.certificate_store.notify_read(block_id),
+        )
+        .await
+        {
+            result
+                .map_err(|_| Error::Internal { block_id })?
+                .ok_or(Error::BlockNotFound { block_id })
+        } else {
+            Err(Error::BlockDeliveryTimeout { block_id })
+        }
+    }
+}
+
+#[async_trait]
+impl<PublicKey: VerifyingKey> Handler<PublicKey> for BlockSynchronizerHandler<PublicKey> {
+    /// The method will return a separate result for each requested block id.
+    /// If a certificate has been successfully retrieved (and processed via core
+    /// if has been fetched from peers) then an OK result will be returned with the
+    /// certificate value.
+    /// In case of error, the following outcomes are possible:
+    /// * BlockNotFound: Failed to retrieve the certificate either via the store or via the peers
+    /// * Internal: An internal error caused
+    /// * BlockDeliveryTimeout: Timed out while waiting for the certificate to become available
+    /// after submitting it for processing to core
+    #[instrument(level="debug", skip_all, fields(block_ids = ?block_ids))]
+    async fn get_and_synchronize_block_headers(
+        &self,
+        block_ids: Vec<CertificateDigest>,
+    ) -> Vec<Result<Certificate<PublicKey>, Error>> {
+        let sync_results = self.get_block_headers(block_ids).await;
+        let mut results: Vec<Result<Certificate<PublicKey>, Error>> = Vec::new();
+
+        // send certificates to core for processing and potential
+        // causal completion
+        let mut wait_for = Vec::new();
+
+        for result in sync_results {
+            match result {
+                Ok(block_header) => {
+                    if !block_header.fetched_from_storage {
+                        // we need to perform causal completion since this
+                        // entity has not been fetched from storage.
+                        self.tx_core
+                            .send(PrimaryMessage::Certificate(
+                                block_header.certificate.clone(),
+                            ))
+                            .await
+                            .expect("Couldn't send certificate to core");
+                        wait_for.push(block_header.certificate.clone());
+
+                        debug!(
+                            "Need to causally complete {}",
+                            block_header.certificate.digest()
+                        );
+                    } else {
+                        // Otherwise, if certificate fetched from storage, just
+                        // add directly the certificate to the results - no need
+                        // for further processing, validation, causal completion
+                        // as all that have already happened.
+                        results.push(Ok(block_header.certificate));
+                    }
+                }
+                Err(err) => {
+                    error!(
+                        "Error occurred while synchronizing requested certificate {:?}",
+                        err
+                    );
+                    results.push(Err(BlockNotFound {
+                        block_id: err.block_id(),
+                    }));
+                }
+            }
+        }
+
+        // now wait for the certificates to become available - timeout so we can
+        // serve requests.
+        let mut wait_results = self.wait_all(wait_for).await;
+
+        // append the results we were waiting for
+        results.append(&mut wait_results);
+
+        results
+    }
+
+    #[instrument(level="debug", skip_all, fields(block_ids = ?block_ids))]
+    async fn get_block_headers(
+        &self,
+        block_ids: Vec<CertificateDigest>,
+    ) -> Vec<BlockSynchronizeResult<BlockHeader<PublicKey>>> {
+        let (tx, mut rx) = channel(block_ids.len());
+
+        self.tx_block_synchronizer
+            .send(Command::SynchronizeBlockHeaders {
+                block_ids,
+                respond_to: tx,
+            })
+            .await
+            .expect("Couldn't send message to block synchronizer");
+
+        // now wait to retrieve all the results
+        let mut results = Vec::new();
+
+        // We want to block and wait until we get all the results back.
+        loop {
+            match rx.recv().await {
+                None => {
+                    debug!("Channel closed when getting certificates, no more messages to get");
+                    break;
+                }
+                Some(result) => results.push(result),
+            }
+        }
+
+        results
+    }
+}

--- a/primary/src/block_synchronizer/mock.rs
+++ b/primary/src/block_synchronizer/mock.rs
@@ -1,0 +1,172 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use crate::block_synchronizer::{BlockHeader, BlockSynchronizeResult, Command};
+use crypto::traits::VerifyingKey;
+use std::collections::HashMap;
+use tokio::sync::{
+    mpsc::{channel, Receiver, Sender},
+    oneshot,
+};
+use types::CertificateDigest;
+
+#[derive(Debug)]
+enum Core<PublicKey: VerifyingKey> {
+    SynchronizeBlockHeaders {
+        block_ids: Vec<CertificateDigest>,
+        times: u32,
+        result: Vec<BlockSynchronizeResult<BlockHeader<PublicKey>>>,
+        ready: oneshot::Sender<()>,
+    },
+    AssertExpectations {
+        ready: oneshot::Sender<()>,
+    },
+}
+
+struct MockBlockSynchronizerCore<PublicKey: VerifyingKey> {
+    block_headers_expected_requests:
+        HashMap<Vec<CertificateDigest>, (u32, Vec<BlockSynchronizeResult<BlockHeader<PublicKey>>>)>,
+    rx_commands: Receiver<Command<PublicKey>>,
+    rx_core: Receiver<Core<PublicKey>>,
+}
+
+impl<PublicKey: VerifyingKey> MockBlockSynchronizerCore<PublicKey> {
+    async fn run(&mut self) {
+        loop {
+            tokio::select! {
+                Some(command) = self.rx_commands.recv() => {
+                    match command {
+                        Command::SynchronizeBlockHeaders { block_ids, respond_to } => {
+                            let (times, results) = self
+                                .block_headers_expected_requests
+                                .remove(&block_ids)
+                                .unwrap_or_else(||panic!("{}", format!("Unexpected call received for SynchronizeBlockHeaders, {:?}", block_ids).as_str()))
+                                .to_owned();
+
+                            if times > 1 {
+                                self.block_headers_expected_requests.insert(block_ids, (times - 1, results.clone()));
+                            }
+
+                            for result in results {
+                                respond_to.send(result).await.expect("Couldn't send message");
+                            }
+                        }
+                        Command::SynchronizeBlockPayload { .. } => {}
+                    }
+                }
+                Some(command) = self.rx_core.recv() => {
+                    match command {
+                        Core::SynchronizeBlockHeaders {
+                            block_ids,
+                            times,
+                            result,
+                            ready,
+                        } => {
+                            self.block_headers_expected_requests.insert(block_ids, (times, result));
+                            ready.send(()).expect("Failed to send ready message");
+                        },
+                        Core::AssertExpectations {ready} => {
+                            self.assert_expectations();
+                            ready.send(()).expect("Failed to send ready message");
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn assert_expectations(&self) {
+        let mut result: String = "".to_string();
+
+        for (ids, results) in &self.block_headers_expected_requests {
+            result.push_str(
+                format!(
+                    "SynchronizeBlockHeaders, ids={:?}, results={:?}",
+                    ids, results
+                )
+                .as_str(),
+            );
+        }
+
+        if !result.is_empty() {
+            panic!(
+                "There are expected calls that haven't been fulfilled \n\n {}",
+                result
+            );
+        }
+    }
+}
+
+/// A mock helper for the BlockSynchronizer to help us mock the responses
+/// eliminating the need to wire in the actual BlockSynchronizer when needed
+/// for other components.
+pub struct MockBlockSynchronizer<PublicKey: VerifyingKey> {
+    tx_core: Sender<Core<PublicKey>>,
+}
+
+impl<PublicKey: VerifyingKey> MockBlockSynchronizer<PublicKey> {
+    pub fn new(rx_commands: Receiver<Command<PublicKey>>) -> Self {
+        let (tx_core, rx_core) = channel(1);
+
+        let mut core = MockBlockSynchronizerCore {
+            block_headers_expected_requests: HashMap::new(),
+            rx_commands,
+            rx_core,
+        };
+
+        tokio::spawn(async move {
+            core.run().await;
+        });
+
+        Self { tx_core }
+    }
+
+    /// A simple method that allow us to mock responses for the
+    /// SynchronizeBlockHeaders requests.
+    /// `block_ids`: The block_ids we expect
+    /// `results`: The results we would like to respond with
+    /// `times`: How many times we should expect to be called.
+    pub async fn expect_synchronize_block_headers(
+        &self,
+        block_ids: Vec<CertificateDigest>,
+        result: Vec<BlockSynchronizeResult<BlockHeader<PublicKey>>>,
+        times: u32,
+    ) {
+        let (tx, rx) = oneshot::channel();
+        self.tx_core
+            .send(Core::SynchronizeBlockHeaders {
+                block_ids,
+                times,
+                result,
+                ready: tx,
+            })
+            .await
+            .expect("Failed to send mock expectation");
+
+        Self::await_channel(rx).await;
+    }
+
+    /// Asserts that all the expectations have been fulfilled and no
+    /// expectation has been left without having been called.
+    pub async fn assert_expectations(&self) {
+        let (tx, rx) = oneshot::channel();
+        self.tx_core
+            .send(Core::AssertExpectations { ready: tx })
+            .await
+            .expect("Failed to assert expectations");
+
+        Self::await_channel(rx).await;
+    }
+
+    /// Helper method to wait on a oneshot receiver channel
+    /// and avoid printing the error. We expect when the
+    /// MockBlockSynchronizerCore panics to violently close
+    /// the provided oneshot channel. To ensure that the
+    /// current thread will panic, we are handling the error
+    /// case and we also print an empty message to avoid
+    /// printing the receive error.
+    async fn await_channel(rx: oneshot::Receiver<()>) {
+        if rx.await.is_err() {
+            panic!("");
+        }
+    }
+}

--- a/primary/src/block_synchronizer/mod.rs
+++ b/primary/src/block_synchronizer/mod.rs
@@ -34,6 +34,8 @@ use types::{BatchDigest, Certificate, CertificateDigest};
 #[cfg(test)]
 #[path = "tests/block_synchronizer_tests.rs"]
 mod block_synchronizer_tests;
+pub mod handler;
+pub mod mock;
 mod peers;
 pub mod responses;
 
@@ -45,17 +47,18 @@ const CERTIFICATE_RESPONSES_RATIO_THRESHOLD: f32 = 0.5;
 
 #[derive(Debug, Clone)]
 pub struct BlockHeader<PublicKey: VerifyingKey> {
-    certificate: Certificate<PublicKey>,
+    pub certificate: Certificate<PublicKey>,
     /// It designates whether the requested quantity (either the certificate
     /// or the payload) has been retrieved via the local storage. If true,
     /// the it used the storage. If false, then it has been fetched via
     /// the peers.
-    fetched_from_storage: bool,
+    pub fetched_from_storage: bool,
 }
 
 type ResultSender<T> = Sender<BlockSynchronizeResult<BlockHeader<T>>>;
 type BlockSynchronizeResult<T> = Result<T, SyncError>;
 
+#[derive(Debug)]
 pub enum Command<PublicKey: VerifyingKey> {
     #[allow(dead_code)]
     /// A request to synchronize and output the block headers
@@ -107,8 +110,8 @@ enum State<PublicKey: VerifyingKey> {
 
 #[derive(Debug, Error, Copy, Clone)]
 pub enum SyncError {
-    #[error("Block with id {block_id} could not be retrieved")]
-    Error { block_id: CertificateDigest },
+    #[error("Block with id {block_id} was not returned in any peer response")]
+    NoResponse { block_id: CertificateDigest },
 
     #[error("Block with id {block_id} could not be retrieved, timeout while retrieving result")]
     Timeout { block_id: CertificateDigest },
@@ -118,7 +121,7 @@ impl SyncError {
     #[allow(dead_code)]
     pub fn block_id(&self) -> CertificateDigest {
         match *self {
-            SyncError::Error { block_id } | SyncError::Timeout { block_id } => block_id,
+            SyncError::NoResponse { block_id } | SyncError::Timeout { block_id } => block_id,
         }
     }
 }
@@ -429,7 +432,7 @@ impl<PublicKey: VerifyingKey> BlockSynchronizer<PublicKey> {
         let key = RequestID::from_iter(to_sync.iter());
 
         let message = PrimaryMessage::<PublicKey>::CertificatesBatchRequest {
-            certificate_ids: block_ids,
+            certificate_ids: to_sync.clone(),
             requestor: self.name.clone(),
         };
 
@@ -732,6 +735,7 @@ impl<PublicKey: VerifyingKey> BlockSynchronizer<PublicKey> {
                     // responses we get are filtered by the request id, but still
                     // worth double checking
                     if !primaries_sent_requests_to.iter().any(|p|p.eq(&response.from)) {
+                        warn!("Not expected reply from this peer, will skip response");
                         continue;
                     }
 
@@ -743,6 +747,7 @@ impl<PublicKey: VerifyingKey> BlockSynchronizer<PublicKey> {
                             // Even if we have found one certificate that doesn't match
                             // we reject the payload - it shouldn't happen.
                             if certificates.iter().any(|c|!block_ids.contains(&c.digest())) {
+                                warn!("Will not process certificates, found at least one that we haven't asked for");
                                 continue;
                             }
 
@@ -906,7 +911,7 @@ impl<PublicKey: VerifyingKey> BlockSynchronizer<PublicKey> {
             } else if timeout {
                 result.insert(block_id, Err(SyncError::Timeout { block_id }));
             } else {
-                result.insert(block_id, Err(SyncError::Error { block_id }));
+                result.insert(block_id, Err(SyncError::NoResponse { block_id }));
             }
         }
 

--- a/primary/src/block_synchronizer/mod.rs
+++ b/primary/src/block_synchronizer/mod.rs
@@ -56,7 +56,7 @@ pub struct BlockHeader<PublicKey: VerifyingKey> {
 }
 
 type ResultSender<T> = Sender<BlockSynchronizeResult<BlockHeader<T>>>;
-type BlockSynchronizeResult<T> = Result<T, SyncError>;
+pub type BlockSynchronizeResult<T> = Result<T, SyncError>;
 
 #[derive(Debug)]
 pub enum Command<PublicKey: VerifyingKey> {

--- a/primary/src/block_synchronizer/tests/handler_tests.rs
+++ b/primary/src/block_synchronizer/tests/handler_tests.rs
@@ -1,0 +1,217 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use crate::{
+    block_synchronizer::handler::{BlockSynchronizerHandler, Error, Handler},
+    common::create_db_stores,
+    BlockHeader, MockBlockSynchronizer,
+};
+use crypto::Hash;
+use std::{collections::HashSet, time::Duration};
+use test_utils::{certificate, fixture_header_with_payload};
+use tokio::sync::mpsc::channel;
+use types::{CertificateDigest, PrimaryMessage};
+
+#[tokio::test]
+async fn test_get_and_synchronize_block_headers_when_fetched_from_storage() {
+    // GIVEN
+    let (_, certificate_store, _) = create_db_stores();
+    let (tx_block_synchronizer, rx_block_synchronizer) = channel(1);
+    let (tx_core, _rx_core) = channel(1);
+
+    let synchronizer = BlockSynchronizerHandler {
+        tx_block_synchronizer,
+        tx_core,
+        certificate_store: certificate_store.clone(),
+        certificate_deliver_timeout: Duration::from_millis(2_000),
+    };
+
+    // AND dummy certificate
+    let certificate = certificate(&fixture_header_with_payload(1));
+
+    // AND
+    let block_ids = vec![CertificateDigest::default()];
+
+    // AND mock the block_synchronizer
+    let mock_synchronizer = MockBlockSynchronizer::new(rx_block_synchronizer);
+    let expected_result = vec![Ok(BlockHeader {
+        certificate: certificate.clone(),
+        fetched_from_storage: true,
+    })];
+    mock_synchronizer
+        .expect_synchronize_block_headers(block_ids.clone(), expected_result, 1)
+        .await;
+
+    // WHEN
+    let result = synchronizer
+        .get_and_synchronize_block_headers(block_ids)
+        .await;
+
+    // THEN
+    assert_eq!(result.len(), 1);
+
+    // AND
+    if let Ok(result_certificate) = result.first().unwrap().to_owned() {
+        assert_eq!(result_certificate, certificate, "Certificates do not match");
+    } else {
+        panic!("Should have received the certificate successfully");
+    }
+
+    // AND
+    mock_synchronizer.assert_expectations().await;
+}
+
+#[tokio::test]
+async fn test_get_and_synchronize_block_headers_when_fetched_from_peers() {
+    // GIVEN
+    let (_, certificate_store, _) = create_db_stores();
+    let (tx_block_synchronizer, rx_block_synchronizer) = channel(1);
+    let (tx_core, mut rx_core) = channel(1);
+
+    let synchronizer = BlockSynchronizerHandler {
+        tx_block_synchronizer,
+        tx_core,
+        certificate_store: certificate_store.clone(),
+        certificate_deliver_timeout: Duration::from_millis(2_000),
+    };
+
+    // AND a certificate stored
+    let cert_stored = certificate(&fixture_header_with_payload(1));
+    certificate_store
+        .write(cert_stored.digest(), cert_stored.clone())
+        .await;
+
+    // AND a certificate NOT stored
+    let cert_missing = certificate(&fixture_header_with_payload(2));
+
+    // AND
+    let mut block_ids = HashSet::new();
+    block_ids.insert(cert_stored.digest());
+    block_ids.insert(cert_missing.digest());
+
+    // AND mock the block_synchronizer where the certificate is fetched
+    // from peers (fetched_from_storage = false)
+    let mock_synchronizer = MockBlockSynchronizer::new(rx_block_synchronizer);
+    let expected_result = vec![
+        Ok(BlockHeader {
+            certificate: cert_stored.clone(),
+            fetched_from_storage: true,
+        }),
+        Ok(BlockHeader {
+            certificate: cert_missing.clone(),
+            fetched_from_storage: false,
+        }),
+    ];
+    mock_synchronizer
+        .expect_synchronize_block_headers(
+            block_ids
+                .clone()
+                .into_iter()
+                .collect::<Vec<CertificateDigest>>(),
+            expected_result,
+            1,
+        )
+        .await;
+
+    // AND mock the "core" module. We assume that the certificate will be
+    // stored after validated and causally complete the history.
+    tokio::spawn(async move {
+        match rx_core.recv().await {
+            Some(PrimaryMessage::Certificate(c)) => {
+                assert_eq!(c.digest(), cert_missing.digest());
+                certificate_store.write(c.digest(), c).await;
+            }
+            _ => panic!("Didn't receive certificate message"),
+        }
+    });
+
+    // WHEN
+    let result = synchronizer
+        .get_and_synchronize_block_headers(
+            block_ids
+                .clone()
+                .into_iter()
+                .collect::<Vec<CertificateDigest>>(),
+        )
+        .await;
+
+    // THEN
+    assert_eq!(result.len(), 2);
+
+    // AND
+    for r in result {
+        assert!(r.is_ok());
+        assert!(block_ids.contains(&r.unwrap().digest()))
+    }
+
+    // AND
+    mock_synchronizer.assert_expectations().await;
+}
+
+#[tokio::test]
+async fn test_get_and_synchronize_block_headers_timeout_on_causal_completion() {
+    // GIVEN
+    let (_, certificate_store, _) = create_db_stores();
+    let (tx_block_synchronizer, rx_block_synchronizer) = channel(1);
+    let (tx_core, _rx_core) = channel(1);
+
+    let synchronizer = BlockSynchronizerHandler {
+        tx_block_synchronizer,
+        tx_core,
+        certificate_store: certificate_store.clone(),
+        certificate_deliver_timeout: Duration::from_millis(2_000),
+    };
+
+    // AND a certificate stored
+    let cert_stored = certificate(&fixture_header_with_payload(1));
+    certificate_store
+        .write(cert_stored.digest(), cert_stored.clone())
+        .await;
+
+    // AND a certificate NOT stored
+    let cert_missing = certificate(&fixture_header_with_payload(2));
+
+    // AND
+    let block_ids = vec![cert_stored.digest(), cert_missing.digest()];
+
+    // AND mock the block_synchronizer where the certificate is fetched
+    // from peers (fetched_from_storage = false)
+    let mock_synchronizer = MockBlockSynchronizer::new(rx_block_synchronizer);
+    let expected_result = vec![
+        Ok(BlockHeader {
+            certificate: cert_stored.clone(),
+            fetched_from_storage: true,
+        }),
+        Ok(BlockHeader {
+            certificate: cert_missing.clone(),
+            fetched_from_storage: false,
+        }),
+    ];
+    mock_synchronizer
+        .expect_synchronize_block_headers(block_ids.clone(), expected_result, 1)
+        .await;
+
+    // WHEN
+    let result = synchronizer
+        .get_and_synchronize_block_headers(block_ids)
+        .await;
+
+    // THEN
+    assert_eq!(result.len(), 2);
+
+    // AND
+    for r in result {
+        if let Ok(cert) = r {
+            assert_eq!(cert_stored.digest(), cert.digest());
+        } else {
+            match r.err().unwrap() {
+                Error::BlockDeliveryTimeout { block_id } => {
+                    assert_eq!(cert_missing.digest(), block_id)
+                }
+                _ => panic!("Unexpected error returned"),
+            }
+        }
+    }
+
+    // AND
+    mock_synchronizer.assert_expectations().await;
+}

--- a/primary/src/block_waiter.rs
+++ b/primary/src/block_waiter.rs
@@ -1,8 +1,8 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use crate::PrimaryWorkerMessage;
+use crate::{block_synchronizer::handler::Handler, PrimaryWorkerMessage};
 use config::Committee;
-use crypto::{traits::VerifyingKey, Digest};
+use crypto::{traits::VerifyingKey, Digest, Hash};
 use futures::{
     future::{try_join_all, BoxFuture},
     stream::{futures_unordered::FuturesUnordered, StreamExt as _},
@@ -15,12 +15,11 @@ use std::{
     fmt::Formatter,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
-use store::Store;
 use tokio::{
     sync::{mpsc::Receiver, oneshot},
     time::timeout,
 };
-use tracing::{error, log::debug};
+use tracing::{error, instrument, log::debug, warn};
 use types::{
     BatchDigest, BatchMessage, BlockError, BlockErrorKind, BlockResult, Certificate,
     CertificateDigest, Header,
@@ -112,7 +111,6 @@ type RequestKey = Vec<u8>;
 /// the result of it.
 ///
 /// ```rust
-/// # use store::{reopen, rocks, rocks::DBMap, Store};
 /// # use tokio::sync::mpsc::{channel};
 /// # use tokio::sync::oneshot;
 /// # use crypto::Hash;
@@ -121,41 +119,40 @@ type RequestKey = Vec<u8>;
 /// # use config::Committee;
 /// # use std::collections::BTreeMap;
 /// # use types::Certificate;
-/// # use tempfile::tempdir;
 /// # use primary::{BlockWaiter, BlockCommand};
 /// # use types::{BatchMessage, BatchDigest, CertificateDigest, Batch};
+/// # use mockall::*;
+/// # use primary::MockHandler;
 ///
 /// #[tokio::main(flavor = "current_thread")]
 /// # async fn main() {
-///     const CERTIFICATES_CF: &str = "certificates";
-///
-///     let temp_dir = tempdir().expect("Failed to open temporary directory").into_path();
-///
-///     // Basic setup: datastore, channels & BlockWaiter
-///     let rocksdb = rocks::open_cf(temp_dir, None, &[CERTIFICATES_CF])
-///         .expect("Failed creating database");
-///
-///     let (certificate_map) = reopen!(&rocksdb,
-///             CERTIFICATES_CF;<CertificateDigest, Certificate<Ed25519PublicKey>>);
-///     let certificate_store = Store::new(certificate_map);
-///
-///     let (tx_commands, rx_commands) = channel(1);
+///     use primary::{BlockHeader, MockBlockSynchronizer};
+/// let (tx_commands, rx_commands) = channel(1);
 ///     let (tx_batches, rx_batches) = channel(1);
 ///     let (tx_get_block, mut rx_get_block) = oneshot::channel();
 ///
 ///     let name = Ed25519PublicKey::default();
 ///     let committee = Committee{ authorities: BTreeMap::new() };
 ///
+///     // A dummy certificate
+///     let certificate = Certificate::<Ed25519PublicKey>::default();
+///
+///     // Dummy - we expect the BlockSynchronizer to actually respond, here
+///     // we are using a mock
+///     let mut mock_handler = MockHandler::<Ed25519PublicKey>::new();
+///     mock_handler
+///         .expect_get_and_synchronize_block_headers()
+///         .with(predicate::eq(vec![certificate.digest()]))
+///         .times(1)
+///         .return_const(vec![Ok(certificate.clone())]);
+///
 ///     BlockWaiter::spawn(
 ///         name,
 ///         committee,
-///         certificate_store.clone(),
 ///         rx_commands,
 ///         rx_batches,
+///         mock_handler,
 ///     );
-///
-///     // A dummy certificate
-///     let certificate = Certificate::<Ed25519PublicKey>::default();
 ///
 ///     // Send a command to receive a block
 ///     tx_commands
@@ -180,15 +177,15 @@ type RequestKey = Vec<u8>;
 ///     }
 /// # }
 /// ```
-pub struct BlockWaiter<PublicKey: VerifyingKey> {
+pub struct BlockWaiter<
+    PublicKey: VerifyingKey,
+    SynchronizerHandler: Handler<PublicKey> + Send + Sync + 'static,
+> {
     /// The public key of this primary.
     name: PublicKey,
 
     /// The committee information.
     committee: Committee<PublicKey>,
-
-    /// Storage that keeps the Certificates by their digest id.
-    certificate_store: Store<CertificateDigest, Certificate<PublicKey>>,
 
     /// Receive all the requests to get a block
     rx_commands: Receiver<BlockCommand>,
@@ -221,23 +218,28 @@ pub struct BlockWaiter<PublicKey: VerifyingKey> {
     /// A map that holds the channels we should notify with the
     /// GetBlocks responses.
     tx_get_blocks_map: HashMap<RequestKey, Vec<oneshot::Sender<BlocksResult>>>,
+
+    /// We use the handler of the block synchronizer to interact with the
+    /// block synchronizer in a synchronous way.
+    block_synchronizer_handler: SynchronizerHandler,
 }
 
-impl<PublicKey: VerifyingKey> BlockWaiter<PublicKey> {
+impl<PublicKey: VerifyingKey, SynchronizerHandler: Handler<PublicKey> + Send + Sync + 'static>
+    BlockWaiter<PublicKey, SynchronizerHandler>
+{
     // Create a new waiter and start listening on incoming
     // commands to fetch a block
     pub fn spawn(
         name: PublicKey,
         committee: Committee<PublicKey>,
-        certificate_store: Store<CertificateDigest, Certificate<PublicKey>>,
         rx_commands: Receiver<BlockCommand>,
         batch_receiver: Receiver<BatchResult>,
+        block_synchronizer_handler: SynchronizerHandler,
     ) {
         tokio::spawn(async move {
             Self {
                 name,
                 committee,
-                certificate_store,
                 rx_commands,
                 pending_get_block: HashMap::new(),
                 worker_network: PrimaryToWorkerNetwork::default(),
@@ -245,6 +247,7 @@ impl<PublicKey: VerifyingKey> BlockWaiter<PublicKey> {
                 tx_pending_batch: HashMap::new(),
                 tx_get_block_map: HashMap::new(),
                 tx_get_blocks_map: HashMap::new(),
+                block_synchronizer_handler,
             }
             .run()
             .await;
@@ -325,6 +328,7 @@ impl<PublicKey: VerifyingKey> BlockWaiter<PublicKey> {
         }
     }
 
+    #[instrument(level="debug", skip_all, fields(block_ids = ?ids))]
     async fn handle_get_blocks_command<'a>(
         &mut self,
         ids: Vec<CertificateDigest>,
@@ -350,45 +354,80 @@ impl<PublicKey: VerifyingKey> BlockWaiter<PublicKey> {
             return None;
         }
 
-        match self.certificate_store.read_all(ids.clone()).await {
-            Ok(certificates) => {
-                let (get_block_futures, get_blocks_future) =
-                    self.get_blocks(ids, certificates).await;
+        // fetch the certificates
+        let certificates = self.get_certificates(ids.clone()).await;
 
-                // mark the request as pending
-                self.tx_get_blocks_map
-                    .entry(key)
-                    .or_insert_with(Vec::new)
-                    .push(sender);
+        let (get_block_futures, get_blocks_future) = self.get_blocks(certificates).await;
 
-                return Some((get_block_futures, get_blocks_future));
-            }
-            Err(err) => {
-                error!("{err}");
-            }
+        // mark the request as pending
+        self.tx_get_blocks_map
+            .entry(key)
+            .or_insert_with(Vec::new)
+            .push(sender);
+
+        Some((get_block_futures, get_blocks_future))
+    }
+
+    /// Helper method to retrieve a single certificate.
+    #[instrument(level = "debug", skip_all, fields(certificate_id = ?id))]
+    async fn get_certificate(&mut self, id: CertificateDigest) -> Option<Certificate<PublicKey>> {
+        if let Some((_, c)) = self.get_certificates(vec![id]).await.first() {
+            return c.to_owned();
         }
-
         None
     }
 
-    async fn get_blocks<'a>(
+    /// Will fetch the certificates via the block_synchronizer. If the
+    /// certificate is missing then we expect the synchronizer to
+    /// fetch it via the peers. Otherwise if available on the storage
+    /// should return the result immediately. The method is blocking to
+    /// retrieve all the results.
+    #[instrument(level = "debug", skip_all, fields(certificate_ids = ?ids))]
+    async fn get_certificates(
         &mut self,
         ids: Vec<CertificateDigest>,
-        certificates: Vec<Option<Certificate<PublicKey>>>,
+    ) -> Vec<(CertificateDigest, Option<Certificate<PublicKey>>)> {
+        let mut results = Vec::new();
+
+        let block_header_results = self
+            .block_synchronizer_handler
+            .get_and_synchronize_block_headers(ids)
+            .await;
+
+        for result in block_header_results {
+            if let Ok(certificate) = result {
+                results.push((certificate.digest(), Some(certificate)));
+            } else {
+                results.push((result.err().unwrap().block_id(), None));
+            }
+        }
+
+        results
+    }
+
+    /// It triggers fetching the blocks for each provided certificate. The
+    /// method receives the `certificates` vector which is a tuple of the
+    /// certificate id and an Optional with the certificate. If the certificate
+    /// doesn't exist then the Optional will be empty (None) which means that
+    /// we haven't managed to retrieve/find the certificate an error result
+    /// will immediately be sent to the consumer.
+    async fn get_blocks<'a>(
+        &mut self,
+        certificates: Vec<(CertificateDigest, Option<Certificate<PublicKey>>)>,
     ) -> (
         Vec<BoxFuture<'a, BlockResult<GetBlockResponse>>>,
         BoxFuture<'a, BlocksResult>,
     ) {
         let mut get_block_receivers = Vec::new();
         let mut futures = Vec::new();
+        let mut ids = Vec::new();
 
-        for (i, c) in certificates.into_iter().enumerate() {
+        for (id, c) in certificates {
             let (get_block_sender, get_block_receiver) = oneshot::channel();
-            let id = *ids.get(i).unwrap();
+            ids.push(id);
 
             // certificate has been found
-            if c.is_some() {
-                let certificate = c.unwrap();
+            if let Some(certificate) = c {
                 let fut = self.get_block(id, certificate, get_block_sender).await;
 
                 if fut.is_some() {
@@ -401,7 +440,7 @@ impl<PublicKey: VerifyingKey> BlockWaiter<PublicKey> {
                         id,
                         error: BlockErrorKind::BlockNotFound,
                     }))
-                    .expect("Couldn't send BlockNotFound error for a GetBlock request");
+                    .expect("Couldn't send BlockNotFound error for a GetBlocks request");
             }
 
             get_block_receivers.push(get_block_receiver);
@@ -416,14 +455,15 @@ impl<PublicKey: VerifyingKey> BlockWaiter<PublicKey> {
     // handles received commands and returns back a future if needs to
     // wait for further results. Otherwise, an empty option is returned
     // if no further waiting on processing is needed.
+    #[instrument(level="debug", skip_all, fields(block_ids = ?id))]
     async fn handle_get_block_command<'a>(
         &mut self,
         id: CertificateDigest,
         sender: oneshot::Sender<BlockResult<GetBlockResponse>>,
     ) -> Option<BoxFuture<'a, BlockResult<GetBlockResponse>>> {
-        return match self.certificate_store.read(id).await {
-            Ok(Some(certificate)) => self.get_block(id, certificate, sender).await,
-            _ => {
+        match self.get_certificate(id).await {
+            Some(certificate) => self.get_block(id, certificate, sender).await,
+            None => {
                 sender
                     .send(Err(BlockError {
                         id,
@@ -433,7 +473,7 @@ impl<PublicKey: VerifyingKey> BlockWaiter<PublicKey> {
 
                 None
             }
-        };
+        }
     }
 
     async fn get_block<'a>(
@@ -589,7 +629,7 @@ impl<PublicKey: VerifyingKey> BlockWaiter<PublicKey> {
                     .expect("Couldn't send BatchResult for pending batch");
             }
             None => {
-                println!("Couldn't find pending batch with id {}", &batch_id);
+                warn!("Couldn't find pending batch with id {}", &batch_id);
             }
         }
     }

--- a/primary/src/grpc_server/validator.rs
+++ b/primary/src/grpc_server/validator.rs
@@ -4,7 +4,10 @@ use std::time::Duration;
 
 use crate::{block_waiter::GetBlockResponse, BlockCommand, BlockRemoverCommand};
 use tokio::{
-    sync::{mpsc::channel, mpsc::Sender, oneshot},
+    sync::{
+        mpsc::{channel, Sender},
+        oneshot,
+    },
     time::timeout,
 };
 use tonic::{Request, Response, Status};

--- a/primary/src/lib.rs
+++ b/primary/src/lib.rs
@@ -32,7 +32,11 @@ mod common;
 
 pub use crate::{
     block_remover::{BlockRemover, BlockRemoverCommand, DeleteBatchMessage},
-    block_synchronizer::responses::{CertificatesResponse, PayloadAvailabilityResponse},
+    block_synchronizer::{
+        mock::MockBlockSynchronizer,
+        responses::{CertificatesResponse, PayloadAvailabilityResponse},
+        BlockHeader,
+    },
     block_waiter::{BlockCommand, BlockWaiter},
     primary::{
         PayloadToken, Primary, PrimaryWorkerMessage, WorkerPrimaryError, WorkerPrimaryMessage,

--- a/primary/src/lib.rs
+++ b/primary/src/lib.rs
@@ -12,7 +12,7 @@ mod aggregators;
 mod block_remover;
 // TODO [#175][#127]: re-plug the blocksynchronzier
 #[allow(dead_code)]
-mod block_synchronizer;
+pub mod block_synchronizer;
 mod block_waiter;
 mod certificate_waiter;
 mod core;


### PR DESCRIPTION
Ref: https://github.com/MystenLabs/narwhal/issues/183

This PR is introducing the following:
* a `handler` to allow us access the `block_synchronizer` functionality in a synchronous way
* a `MockBlockSynchronizer` to allow us test more easily the `handler`. This will be used for follow up work around batch sync as well
* the `mockall` library to allow us easily mock traits and structs
* wire in to the `block_waiter` the `handler` to allow us seamlessly retrieve certificates and wait for causal completion (via `core`) for certificates that have been fetched on the fly from peers.

The `handler` will also be re-used during the `read_causal` calls when we detect missing certificates on the DAG and we need to fetch them (from peers) and ensure that are validated and history has been causally completed.

There is also a separate PR opened against this one which is testing end to end the `get_collections` when missing certificates. 

This is `part 1` . There is follow up work https://github.com/MystenLabs/narwhal/issues/223 to add more functionality to `handler` so we can also seamlessly synchronize the missing `payload` when we request them on `block_waiter`. 