### PR TITLE
Properly set bool for internal vs external consensus behavior

### DIFF
--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -97,7 +97,7 @@ impl Node {
         // If an external consensus will be used, then this bool will also ensure that the
         // corresponding gRPC server that is used for communication between narwhal and
         // external consensus is also spawned.
-        consensus: bool,
+        internal_consensus: bool,
         // The state used by the client to execute transactions.
         execution_state: Arc<State>,
         // A channel to output transactions execution confirmations.
@@ -125,11 +125,11 @@ impl Node {
             store.payload_store.clone(),
             /* tx_consensus */ tx_new_certificates,
             /* rx_consensus */ rx_feedback,
-            consensus,
+            internal_consensus,
         );
 
-        // Check whether to run consensus.
-        match consensus {
+        // Check whether to run internal consensus.
+        match internal_consensus {
             true => {
                 Self::spawn_consensus(
                     name,

--- a/primary/src/primary.rs
+++ b/primary/src/primary.rs
@@ -88,7 +88,7 @@ impl Primary {
         payload_store: Store<(BatchDigest, WorkerId), PayloadToken>,
         tx_consensus: Sender<Certificate<PublicKey>>,
         rx_consensus: Receiver<Certificate<PublicKey>>,
-        external_consensus: bool,
+        internal_consensus: bool,
     ) {
         let (tx_others_digests, rx_others_digests) = channel(CHANNEL_CAPACITY);
         let (tx_our_digests, rx_our_digests) = channel(CHANNEL_CAPACITY);
@@ -288,7 +288,7 @@ impl Primary {
             rx_helper_requests,
         );
 
-        if external_consensus {
+        if !internal_consensus {
             // Spawn a grpc server to accept requests from external consensus layer.
             ConsensusAPIGrpc::spawn(
                 parameters.consensus_api_grpc.socket_addr,

--- a/primary/tests/integration_tests.rs
+++ b/primary/tests/integration_tests.rs
@@ -102,7 +102,7 @@ async fn test_get_collections() {
         store.payload_store,
         /* tx_consensus */ tx_new_certificates,
         /* rx_consensus */ rx_feedback,
-        /* external_consensus */ true,
+        /* internal_consensus */ false,
     );
 
     // Spawn a `Worker` instance.


### PR DESCRIPTION
Fix issue where consensus api gRPC server was being started despite external consensus being disabled. Renamed variables for clarity