### PR TITLE
Introduce block_synchronizer_handler and wire to block waiter (part 2)

### DIFF
--- a/primary/src/grpc_server/mod.rs
+++ b/primary/src/grpc_server/mod.rs
@@ -1,8 +1,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use self::configuration::NarwhalConfiguration;
-use self::validator::NarwhalValidator;
+use self::{configuration::NarwhalConfiguration, validator::NarwhalValidator};
 use crate::{BlockCommand, BlockRemoverCommand};
 use multiaddr::Multiaddr;
 use std::time::Duration;

--- a/primary/src/tests/block_waiter_tests.rs
+++ b/primary/src/tests/block_waiter_tests.rs
@@ -73,6 +73,12 @@ async fn test_successfully_retrieve_block() {
         .expect_get_and_synchronize_block_headers()
         .with(predicate::eq(vec![block_id]))
         .times(1)
+        .return_const(vec![Ok(certificate.clone())]);
+
+    mock_handler
+        .expect_synchronize_block_payloads()
+        .with(predicate::eq(vec![certificate.clone()]))
+        .times(1)
         .return_const(vec![Ok(certificate)]);
 
     BlockWaiter::spawn(
@@ -217,7 +223,7 @@ async fn test_successfully_retrieve_multiple_blocks() {
 
     // AND mock the responses from the BlockSynchronizer
     let mut expected_result: Vec<Result<Certificate<Ed25519PublicKey>, handler::Error>> =
-        certificates.into_iter().map(Ok).collect();
+        certificates.clone().into_iter().map(Ok).collect();
 
     expected_result.push(Err(handler::Error::BlockNotFound {
         block_id: missing_block_id,
@@ -227,6 +233,12 @@ async fn test_successfully_retrieve_multiple_blocks() {
     mock_handler
         .expect_get_and_synchronize_block_headers()
         .with(predicate::eq(block_ids.clone()))
+        .times(1)
+        .return_const(expected_result.clone());
+
+    mock_handler
+        .expect_synchronize_block_payloads()
+        .with(predicate::eq(certificates))
         .times(1)
         .return_const(expected_result);
 
@@ -294,6 +306,12 @@ async fn test_one_pending_request_for_block_at_time() {
         .expect_get_and_synchronize_block_headers()
         .with(predicate::eq(vec![block_id]))
         .times(4)
+        .return_const(vec![Ok(certificate.clone())]);
+
+    mock_handler
+        .expect_synchronize_block_payloads()
+        .with(predicate::eq(vec![certificate.clone()]))
+        .times(4)
         .return_const(vec![Ok(certificate)]);
 
     let mut waiter = BlockWaiter {
@@ -358,6 +376,12 @@ async fn test_unlocking_pending_get_block_request_after_response() {
         .expect_get_and_synchronize_block_headers()
         .with(predicate::eq(vec![block_id]))
         .times(3)
+        .return_const(vec![Ok(certificate.clone())]);
+
+    mock_handler
+        .expect_synchronize_block_payloads()
+        .with(predicate::eq(vec![certificate.clone()]))
+        .times(3)
         .return_const(vec![Ok(certificate)]);
 
     let mut waiter = BlockWaiter {
@@ -418,6 +442,12 @@ async fn test_batch_timeout() {
     mock_handler
         .expect_get_and_synchronize_block_headers()
         .with(predicate::eq(vec![block_id]))
+        .times(1)
+        .return_const(vec![Ok(certificate.clone())]);
+
+    mock_handler
+        .expect_synchronize_block_payloads()
+        .with(predicate::eq(vec![certificate.clone()]))
         .times(1)
         .return_const(vec![Ok(certificate)]);
 

--- a/primary/tests/integration_tests.rs
+++ b/primary/tests/integration_tests.rs
@@ -1,5 +1,6 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
+use blake2::digest::Update;
 use config::{Parameters, WorkerId};
 use consensus::dag::Dag;
 use crypto::{
@@ -10,7 +11,11 @@ use crypto::{
 use futures::future::join_all;
 use node::NodeStorage;
 use primary::{PayloadToken, Primary, CHANNEL_CAPACITY};
-use std::{sync::Arc, time::Duration};
+use std::{
+    collections::{BTreeMap, HashMap},
+    sync::Arc,
+    time::Duration,
+};
 use store::Store;
 use test_utils::{
     certificate, committee, fixture_batch_with_transactions, fixture_header_builder, keys, temp_dir,
@@ -18,7 +23,7 @@ use test_utils::{
 use tokio::sync::mpsc::channel;
 use tonic::transport::Channel;
 use types::{
-    BatchDigest, Certificate, CertificateDigest, CertificateDigestProto, CollectionErrorType,
+    Batch, BatchDigest, Certificate, CertificateDigest, CertificateDigestProto,
     CollectionRetrievalResult, ConfigurationClient, Empty, GetCollectionsRequest, Header,
     HeaderDigest, MultiAddrProto, NewNetworkInfoRequest, PublicKeyProto, RemoveCollectionsRequest,
     RetrievalResult, ValidatorClient, ValidatorData,
@@ -445,11 +450,10 @@ async fn test_new_network_info() {
 /// collections for both certificates. Since primary 1 knows only about the
 /// certificate 1 we expect to sync with primary 2 to fetch the unknown
 /// certificate 2 after it has been processed for causal completion & validation.
-///
-/// TODO: the code will not successfully fetch the batches for certificate 2
-/// since we don't block on waiting to sync the batches. That will be included
-/// in a follow up PR (see https://github.com/MystenLabs/narwhal/issues/223).
-/// Then this test will be refactored to test only for successful responses.
+/// We also expect to synchronize the missing batches of the missing certificate
+/// from primary 2. All in all the end goal is to:
+/// * Primary 1 be able to retrieve both certificates 1 & 2 successfully
+/// * Primary 1 be able to fetch the payload for certificates 1 & 2
 #[tokio::test]
 async fn test_get_collections_with_missing_certificates() {
     // GIVEN keys for two primary nodes
@@ -477,7 +481,7 @@ async fn test_get_collections_with_missing_certificates() {
     let signer_1 = keys().remove(0);
 
     // The certificate_1 will be stored in primary 1
-    let certificate_1 = fixture_certificate(
+    let (certificate_1, batch_digest_1, batch_1) = fixture_certificate(
         signer_1,
         store_primary_1.header_store.clone(),
         store_primary_1.certificate_store.clone(),
@@ -490,7 +494,7 @@ async fn test_get_collections_with_missing_certificates() {
     let signer_2 = keys().remove(1);
 
     // The certificate_2 will be stored in primary 2
-    let certificate_2 = fixture_certificate(
+    let (certificate_2, batch_digest_2, batch_2) = fixture_certificate(
         signer_2,
         store_primary_2.header_store.clone(),
         store_primary_2.certificate_store.clone(),
@@ -498,6 +502,11 @@ async fn test_get_collections_with_missing_certificates() {
         store_primary_2.batch_store.clone(),
     )
     .await;
+
+    // AND keep a map of batches and payload
+    let mut batches_map = HashMap::new();
+    batches_map.insert(batch_digest_1, batch_1);
+    batches_map.insert(batch_digest_2, batch_2);
 
     let block_ids = vec![certificate_1.digest(), certificate_2.digest()];
 
@@ -572,34 +581,28 @@ async fn test_get_collections_with_missing_certificates() {
 
     // We expect to get successfully the batches only for the one collection
     assert_eq!(
-        1,
+        2,
         actual_result
             .iter()
             .filter(|&r| matches!(r.retrieval_result, Some(types::RetrievalResult::Batch(_))))
             .count()
     );
 
-    // The second certificate, which was missing from the primary 1, we expect
-    // to have fetched it but not be able to fetch its payload. So the expected
-    // error would be CollectionError.
-    // TODO: once we plugin the block_synchronizer to sync missing payload as well
-    // then this error shouldn't be thrown anymore
-    // (see https://github.com/MystenLabs/narwhal/issues/223)
-    let error: &CollectionRetrievalResult = actual_result
-        .iter()
-        .find(|&r| matches!(r.retrieval_result, Some(types::RetrievalResult::Error(_))))
-        .unwrap();
+    for result in actual_result {
+        match result.retrieval_result.unwrap() {
+            RetrievalResult::Batch(batch) => {
+                let id: BatchDigest = batch.id.unwrap().into();
+                let result_batch: Batch = batch.transactions.unwrap().into();
 
-    match error.retrieval_result.as_ref().unwrap() {
-        RetrievalResult::Error(err) => {
-            assert_eq!(err.error, CollectionErrorType::CollectionError as i32);
-            assert_eq!(
-                err.id.as_ref().unwrap(),
-                &CertificateDigestProto::from(certificate_2.digest())
-            );
-        }
-        _ => {
-            panic!("Error was expected");
+                if let Some(expected_batch) = batches_map.get(&id) {
+                    assert_eq!(result_batch, *expected_batch, "Batch payload doesn't match");
+                } else {
+                    panic!("Unexpected batch!");
+                }
+            }
+            _ => {
+                panic!("Expected to have received a batch response");
+            }
         }
     }
 }
@@ -610,9 +613,22 @@ async fn fixture_certificate(
     certificate_store: Store<CertificateDigest, Certificate<Ed25519PublicKey>>,
     payload_store: Store<(BatchDigest, WorkerId), PayloadToken>,
     batch_store: Store<BatchDigest, SerializedBatchMessage>,
-) -> Certificate<Ed25519PublicKey> {
+) -> (Certificate<Ed25519PublicKey>, BatchDigest, Batch) {
     let batch = fixture_batch_with_transactions(10);
     let worker_id = 0;
+
+    // We need to make sure that we calculate the batch digest based on the
+    // serialised message rather than the batch it self.
+    // See more info https://github.com/MystenLabs/narwhal/issues/188
+    // TODO: refactor this when the above is changed/fixed.
+    let message = WorkerMessage::<Ed25519PublicKey>::Batch(batch.clone());
+    let serialized_batch = bincode::serialize(&message).unwrap();
+    let batch_digest = BatchDigest::new(crypto::blake2b_256(|hasher| {
+        hasher.update(&serialized_batch)
+    }));
+
+    let mut payload = BTreeMap::new();
+    payload.insert(batch_digest, worker_id);
 
     let builder = types::HeaderBuilder::<Ed25519PublicKey>::default();
     let header = builder
@@ -624,8 +640,8 @@ async fn fixture_certificate(
                 .map(|x| x.digest())
                 .collect(),
         )
-        .with_payload_batch(batch.clone(), worker_id)
-        .build(|payload| key.sign(payload));
+        .payload(payload)
+        .build(|p| key.sign(p));
 
     let certificate = certificate(&header);
 
@@ -639,16 +655,14 @@ async fn fixture_certificate(
 
     // Write the batches to payload store
     payload_store
-        .write_all(vec![((batch.clone().digest(), worker_id), 0)])
+        .write_all(vec![((batch_digest, worker_id), 0)])
         .await
         .expect("couldn't store batches");
 
     // Add a batch to the workers store
-    let message = WorkerMessage::<Ed25519PublicKey>::Batch(batch.clone());
-    let serialized_batch = bincode::serialize(&message).unwrap();
-    batch_store.write(batch.digest(), serialized_batch).await;
+    batch_store.write(batch_digest, serialized_batch).await;
 
-    certificate
+    (certificate, batch_digest, batch)
 }
 
 fn connect_to_validator_client(parameters: Parameters) -> ValidatorClient<Channel> {

--- a/worker/src/tests/processor_tests.rs
+++ b/worker/src/tests/processor_tests.rs
@@ -3,8 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use super::*;
 use crate::worker::WorkerMessage;
-use crypto::ed25519::Ed25519PublicKey;
-use crypto::Hash;
+use crypto::{ed25519::Ed25519PublicKey, Hash};
 use store::rocks;
 use test_utils::{batch, temp_dir};
 use tokio::sync::mpsc::channel;


### PR DESCRIPTION
Resolves: MystenLabs/narwhal#183 

This the second part of the MystenLabs/narwhal#183  and follow up of MystenLabs/narwhal#227 .

It extends the block synchronizer handler in order to synchronize missing payloads. Also, the functionality is wired into the `block_waiter` so we make sure that if we are missing the payload (batches) for a certificate we can sync on the fly from other peers and serve it back. 