### PR TITLE
Smoke test node startup

### DIFF
--- a/consensus/benches/process_certificates.rs
+++ b/consensus/benches/process_certificates.rs
@@ -24,7 +24,10 @@ pub fn process_certificates(c: &mut Criterion) {
         let rounds: Round = *size;
 
         // process certificates for rounds, check we don't grow the dag too much
-        let keys: Vec<_> = keys().into_iter().map(|kp| kp.public().clone()).collect();
+        let keys: Vec<_> = keys(None)
+            .into_iter()
+            .map(|kp| kp.public().clone())
+            .collect();
         let genesis = Certificate::genesis(&mock_committee(&keys[..]))
             .iter()
             .map(|x| x.digest())

--- a/consensus/src/tests/consensus_tests.rs
+++ b/consensus/src/tests/consensus_tests.rs
@@ -157,7 +157,7 @@ pub fn make_certificate_store(
 #[tokio::test]
 async fn commit_one() {
     // Make certificates for rounds 1 to 4.
-    let keys: Vec<_> = test_utils::keys()
+    let keys: Vec<_> = test_utils::keys(None)
         .into_iter()
         .map(|kp| kp.public().clone())
         .collect();
@@ -207,7 +207,7 @@ async fn commit_one() {
 #[tokio::test]
 async fn dead_node() {
     // Make the certificates.
-    let mut keys: Vec<_> = test_utils::keys()
+    let mut keys: Vec<_> = test_utils::keys(None)
         .into_iter()
         .map(|kp| kp.public().clone())
         .collect();
@@ -257,7 +257,7 @@ async fn dead_node() {
 // round 4 does. The leader of rounds 2 and 4 should thus be committed upon entering round 6.
 #[tokio::test]
 async fn not_enough_support() {
-    let mut keys: Vec<_> = test_utils::keys()
+    let mut keys: Vec<_> = test_utils::keys(None)
         .into_iter()
         .map(|kp| kp.public().clone())
         .collect();
@@ -356,7 +356,7 @@ async fn not_enough_support() {
 // and reapers from round 3.
 #[tokio::test]
 async fn missing_leader() {
-    let mut keys: Vec<_> = test_utils::keys()
+    let mut keys: Vec<_> = test_utils::keys(None)
         .into_iter()
         .map(|kp| kp.public().clone())
         .collect();

--- a/consensus/src/tests/dag_tests.rs
+++ b/consensus/src/tests/dag_tests.rs
@@ -15,7 +15,7 @@ use super::{Dag, ValidatorDagError};
 #[tokio::test]
 async fn inner_dag_insert_one() {
     // Make certificates for rounds 1 to 4.
-    let keys: Vec<_> = test_utils::keys()
+    let keys: Vec<_> = test_utils::keys(None)
         .into_iter()
         .map(|kp| kp.public().clone())
         .collect();
@@ -42,7 +42,7 @@ async fn inner_dag_insert_one() {
 #[tokio::test]
 async fn dag_mutation_failures() {
     // Make certificates for rounds 1 to 4.
-    let keys: Vec<_> = test_utils::keys()
+    let keys: Vec<_> = test_utils::keys(None)
         .into_iter()
         .map(|kp| kp.public().clone())
         .collect();
@@ -113,7 +113,7 @@ async fn dag_mutation_failures() {
 #[tokio::test]
 async fn dag_insert_one_and_rounds_node_read() {
     // Make certificates for rounds 1 to 4.
-    let keys: Vec<_> = test_utils::keys()
+    let keys: Vec<_> = test_utils::keys(None)
         .into_iter()
         .map(|kp| kp.public().clone())
         .collect();
@@ -161,7 +161,7 @@ async fn dag_insert_one_and_rounds_node_read() {
 #[tokio::test]
 async fn dag_insert_and_remove_reads() {
     // Make certificates for rounds 1 to 4.
-    let keys: Vec<_> = test_utils::keys()
+    let keys: Vec<_> = test_utils::keys(None)
         .into_iter()
         .map(|kp| kp.public().clone())
         .collect();

--- a/consensus/src/tests/subscriber_tests.rs
+++ b/consensus/src/tests/subscriber_tests.rs
@@ -12,7 +12,10 @@ use tokio::sync::mpsc::{channel, Receiver, Sender};
 /// Make enough certificates to commit a leader.
 pub fn commit_certificates() -> VecDeque<Certificate<Ed25519PublicKey>> {
     // Make certificates for rounds 1 to 4.
-    let keys: Vec<_> = keys().into_iter().map(|kp| kp.public().clone()).collect();
+    let keys: Vec<_> = keys(None)
+        .into_iter()
+        .map(|kp| kp.public().clone())
+        .collect();
     let genesis = Certificate::genesis(&mock_committee(&keys[..]))
         .iter()
         .map(|x| x.digest())
@@ -36,7 +39,10 @@ pub async fn spawn_node(
     let certificates = commit_certificates();
 
     // Make the committee.
-    let keys: Vec<_> = keys().into_iter().map(|kp| kp.public().clone()).collect();
+    let keys: Vec<_> = keys(None)
+        .into_iter()
+        .map(|kp| kp.public().clone())
+        .collect();
     let committee = mock_committee(&keys[..]);
 
     // Create the storages.

--- a/consensus/src/tusk.rs
+++ b/consensus/src/tusk.rs
@@ -408,7 +408,7 @@ mod tests {
         let rounds: Round = rand::thread_rng().gen_range(10, 100);
 
         // process certificates for rounds, check we don't grow the dag too much
-        let keys: Vec<_> = test_utils::keys()
+        let keys: Vec<_> = test_utils::keys(None)
             .into_iter()
             .map(|kp| kp.public().clone())
             .collect();
@@ -457,7 +457,7 @@ mod tests {
         let rounds: Round = rand::thread_rng().gen_range(10, 100);
 
         // process certificates for rounds, check we don't grow the dag too much
-        let keys: Vec<_> = test_utils::keys()
+        let keys: Vec<_> = test_utils::keys(None)
             .into_iter()
             .map(|kp| kp.public().clone())
             .collect();

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -39,6 +39,7 @@ pretty_assertions = "1.2.1"
 serde-reflection = "0.3.5"
 serde_yaml = "0.8.23"
 structopt = "0.3.26"
+test_utils = { path = "../test_utils" }
 
 [features]
 benchmark = ["worker/benchmark", "primary/benchmark", "consensus/benchmark"]

--- a/node/tests/node_smoke_test.rs
+++ b/node/tests/node_smoke_test.rs
@@ -1,0 +1,106 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::time::{Duration, Instant};
+
+use config::Export;
+use test_utils::{committee, keys, temp_dir};
+
+#[test]
+fn test_primary_no_consensus() {
+    let db_path = temp_dir().into_os_string().into_string().unwrap();
+    let config_path = temp_dir().into_os_string().into_string().unwrap();
+    let now = Instant::now();
+    let duration = Duration::from_secs(5);
+
+    let keys = keys(None);
+    let keys_file_path = format!("{config_path}/smoke_test_keys.json");
+    keys[0].export(&keys_file_path).unwrap();
+
+    let committee = committee(None);
+    let committee_file_path = format!("{config_path}/smoke_test_committee.json");
+    committee.export(&committee_file_path).unwrap();
+
+    let mut child = std::process::Command::new("cargo")
+        .current_dir("..")
+        .args(&["run", "--bin", "node", "--"])
+        .args(&[
+            "run",
+            "--committee",
+            &committee_file_path,
+            "--keys",
+            &keys_file_path,
+            "--store",
+            &db_path,
+            "primary",
+            "--consensus-disabled",
+        ])
+        .spawn()
+        .expect("failed to launch primary process w/o consensus");
+
+    while now.elapsed() < duration {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                if !status.success() {
+                    panic!("node panicked with: {:?}", child.stderr.take().unwrap());
+                }
+                assert!(status.success());
+                break;
+            }
+            Ok(None) => continue,
+            Err(e) => {
+                panic!("error waiting for child process: {}", e);
+            }
+        }
+    }
+}
+
+#[test]
+fn test_primary_with_consensus() {
+    let db_path = temp_dir().into_os_string().into_string().unwrap();
+    let config_path = temp_dir().into_os_string().into_string().unwrap();
+    let now = Instant::now();
+    let duration = Duration::from_secs(5);
+
+    let keys = keys(None);
+    let keys_file_path = format!("{config_path}/smoke_test_keys.json");
+    keys[0].export(&keys_file_path).unwrap();
+
+    let committee = committee(None);
+    let committee_file_path = format!("{config_path}/smoke_test_committee.json");
+    committee.export(&committee_file_path).unwrap();
+
+    let mut child = std::process::Command::new("cargo")
+        .current_dir("..")
+        .args(&["run", "--bin", "node", "--"])
+        .args(&[
+            "run",
+            "--committee",
+            &committee_file_path,
+            "--keys",
+            &keys_file_path,
+            "--store",
+            &db_path,
+            "primary",
+            //no arg : default of with_consensus
+        ])
+        .spawn()
+        .expect("failed to launch primary process w/o consensus");
+
+    while now.elapsed() < duration {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                if !status.success() {
+                    panic!("node panicked with: {:?}", child.stderr.take().unwrap());
+                }
+                assert!(status.success());
+                break;
+            }
+            // This is expected to run indefinitely => will hit the timeout
+            Ok(None) => continue,
+            Err(e) => {
+                panic!("error waiting for child process: {}", e);
+            }
+        }
+    }
+}

--- a/node/tests/node_smoke_test.rs
+++ b/node/tests/node_smoke_test.rs
@@ -54,6 +54,7 @@ fn test_primary_no_consensus() {
             }
         }
     }
+    let _ = child.kill();
 }
 
 #[test]
@@ -104,4 +105,5 @@ fn test_primary_with_consensus() {
             }
         }
     }
+    let _ = child.kill();
 }

--- a/node/tests/node_smoke_test.rs
+++ b/node/tests/node_smoke_test.rs
@@ -1,17 +1,18 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::time::{Duration, Instant};
-
 use config::Export;
+use std::time::{Duration, Instant};
 use test_utils::{committee, keys, temp_dir};
+
+const TEST_DURATION: Duration = Duration::from_secs(3);
 
 #[test]
 fn test_primary_no_consensus() {
     let db_path = temp_dir().into_os_string().into_string().unwrap();
     let config_path = temp_dir().into_os_string().into_string().unwrap();
     let now = Instant::now();
-    let duration = Duration::from_secs(5);
+    let duration = TEST_DURATION;
 
     let keys = keys(None);
     let keys_file_path = format!("{config_path}/smoke_test_keys.json");
@@ -60,7 +61,7 @@ fn test_primary_with_consensus() {
     let db_path = temp_dir().into_os_string().into_string().unwrap();
     let config_path = temp_dir().into_os_string().into_string().unwrap();
     let now = Instant::now();
-    let duration = Duration::from_secs(5);
+    let duration = TEST_DURATION;
 
     let keys = keys(None);
     let keys_file_path = format!("{config_path}/smoke_test_keys.json");

--- a/primary/src/block_synchronizer/tests/block_synchronizer_tests.rs
+++ b/primary/src/block_synchronizer/tests/block_synchronizer_tests.rs
@@ -49,7 +49,7 @@ async fn test_successful_headers_synchronization() {
     let mut certificates: HashMap<CertificateDigest, Certificate<Ed25519PublicKey>> =
         HashMap::new();
 
-    let key = keys().pop().unwrap();
+    let key = keys(None).pop().unwrap();
     let worker_id_0 = 0;
     let worker_id_1 = 1;
 
@@ -204,7 +204,7 @@ async fn test_successful_payload_synchronization() {
     let mut certificates: HashMap<CertificateDigest, Certificate<Ed25519PublicKey>> =
         HashMap::new();
 
-    let key = keys().pop().unwrap();
+    let key = keys(None).pop().unwrap();
     let worker_id_0: u32 = 0;
     let worker_id_1: u32 = 1;
 
@@ -401,7 +401,7 @@ async fn test_multiple_overlapping_requests() {
     let mut certificates: HashMap<CertificateDigest, Certificate<Ed25519PublicKey>> =
         HashMap::new();
 
-    let key = keys().pop().unwrap();
+    let key = keys(None).pop().unwrap();
 
     // AND generate headers with distributed batches between 2 workers (0 and 1)
     for _ in 0..5 {
@@ -507,7 +507,7 @@ async fn test_timeout_while_waiting_for_certificates() {
 
     // AND the necessary keys
     let (name, committee) = resolve_name_and_committee();
-    let key = keys().pop().unwrap();
+    let key = keys(None).pop().unwrap();
 
     let (tx_commands, rx_commands) = channel(10);
     let (_, rx_certificate_responses) = channel(10);
@@ -594,7 +594,7 @@ async fn test_reply_with_certificates_already_in_storage() {
 
     // AND the necessary keys
     let (name, committee) = resolve_name_and_committee();
-    let key = keys().pop().unwrap();
+    let key = keys(None).pop().unwrap();
 
     let (_, rx_commands) = channel(10);
     let (_, rx_certificate_responses) = channel(10);
@@ -685,7 +685,7 @@ async fn test_reply_with_payload_already_in_storage() {
 
     // AND the necessary keys
     let (name, committee) = resolve_name_and_committee();
-    let key = keys().pop().unwrap();
+    let key = keys(None).pop().unwrap();
 
     let (_, rx_commands) = channel(10);
     let (_, rx_certificate_responses) = channel(10);

--- a/primary/src/core.rs
+++ b/primary/src/core.rs
@@ -18,7 +18,10 @@ use std::{
     },
 };
 use store::Store;
-use tokio::sync::mpsc::{Receiver, Sender};
+use tokio::{
+    sync::mpsc::{Receiver, Sender},
+    task::JoinHandle,
+};
 use tracing::{debug, error, warn};
 use types::{
     ensure,
@@ -95,7 +98,7 @@ impl<PublicKey: VerifyingKey> Core<PublicKey> {
         rx_proposer: Receiver<Header<PublicKey>>,
         tx_consensus: Sender<Certificate<PublicKey>>,
         tx_proposer: Sender<(Vec<CertificateDigest>, Round)>,
-    ) {
+    ) -> JoinHandle<()> {
         tokio::spawn(async move {
             Self {
                 name,
@@ -123,7 +126,7 @@ impl<PublicKey: VerifyingKey> Core<PublicKey> {
             }
             .run()
             .await;
-        });
+        })
     }
 
     async fn process_own_header(&mut self, header: Header<PublicKey>) -> DagResult<()> {

--- a/primary/src/tests/block_remover_tests.rs
+++ b/primary/src/tests/block_remover_tests.rs
@@ -64,7 +64,7 @@ async fn test_successful_blocks_delete() {
     let mut header_ids = Vec::new();
     let handlers = FuturesUnordered::new();
 
-    let key = keys().pop().unwrap();
+    let key = keys(None).pop().unwrap();
 
     let mut worker_batches: HashMap<WorkerId, Vec<BatchDigest>> = HashMap::new();
 
@@ -212,7 +212,7 @@ async fn test_timeout() {
     let mut block_ids = Vec::new();
     let mut header_ids = Vec::new();
 
-    let key = keys().pop().unwrap();
+    let key = keys(None).pop().unwrap();
 
     let mut worker_batches: HashMap<WorkerId, Vec<BatchDigest>> = HashMap::new();
 
@@ -345,7 +345,7 @@ async fn test_unlocking_pending_requests() {
     let mut block_ids = Vec::new();
     let mut header_ids = Vec::new();
 
-    let key = keys().pop().unwrap();
+    let key = keys(None).pop().unwrap();
 
     let worker_id_0 = 0;
 

--- a/primary/src/tests/block_waiter_tests.rs
+++ b/primary/src/tests/block_waiter_tests.rs
@@ -127,7 +127,7 @@ async fn test_successfully_retrieve_multiple_blocks() {
     // GIVEN
     let (name, committee) = resolve_name_and_committee();
 
-    let key = keys().pop().unwrap();
+    let key = keys(None).pop().unwrap();
     let mut block_ids = Vec::new();
     let mut expected_batch_messages = HashMap::new();
     let worker_id = 0;

--- a/primary/src/tests/core_tests.rs
+++ b/primary/src/tests/core_tests.rs
@@ -12,13 +12,13 @@ use types::{BatchDigest, Header, Vote};
 
 #[tokio::test]
 async fn process_header() {
-    let mut keys = keys();
+    let mut keys = keys(None);
     let _ = keys.pop().unwrap(); // Skip the header' author.
     let kp = keys.pop().unwrap();
     let name = kp.public().clone();
     let mut signature_service = SignatureService::new(kp);
 
-    let committee = committee();
+    let committee = committee(None);
 
     let (tx_sync_headers, _rx_sync_headers) = channel(1);
     let (tx_sync_certificates, _rx_sync_certificates) = channel(1);
@@ -90,7 +90,7 @@ async fn process_header() {
 
 #[tokio::test]
 async fn process_header_missing_parent() {
-    let kp = keys().pop().unwrap();
+    let kp = keys(None).pop().unwrap();
     let name = kp.public().clone();
     let signature_service = SignatureService::new(kp);
 
@@ -109,7 +109,7 @@ async fn process_header_missing_parent() {
     // Make a synchronizer for the core.
     let synchronizer = Synchronizer::new(
         name.clone(),
-        &committee(),
+        &committee(None),
         certificates_store.clone(),
         payload_store.clone(),
         /* tx_header_waiter */ tx_sync_headers,
@@ -119,7 +119,7 @@ async fn process_header_missing_parent() {
     // Spawn the core.
     Core::spawn(
         name,
-        committee(),
+        committee(None),
         header_store.clone(),
         certificates_store.clone(),
         synchronizer,
@@ -151,7 +151,7 @@ async fn process_header_missing_parent() {
 
 #[tokio::test]
 async fn process_header_missing_payload() {
-    let kp = keys().pop().unwrap();
+    let kp = keys(None).pop().unwrap();
     let name = kp.public().clone();
     let signature_service = SignatureService::new(kp);
 
@@ -170,7 +170,7 @@ async fn process_header_missing_payload() {
     // Make a synchronizer for the core.
     let synchronizer = Synchronizer::new(
         name.clone(),
-        &committee(),
+        &committee(None),
         certificates_store.clone(),
         payload_store.clone(),
         /* tx_header_waiter */ tx_sync_headers,
@@ -180,7 +180,7 @@ async fn process_header_missing_payload() {
     // Spawn the core.
     Core::spawn(
         name,
-        committee(),
+        committee(None),
         header_store.clone(),
         certificates_store.clone(),
         synchronizer,
@@ -212,11 +212,11 @@ async fn process_header_missing_payload() {
 
 #[tokio::test]
 async fn process_votes() {
-    let kp = keys().pop().unwrap();
+    let kp = keys(None).pop().unwrap();
     let name = kp.public().clone();
     let signature_service = SignatureService::new(kp);
 
-    let committee = committee();
+    let committee = committee(None);
 
     let (tx_sync_headers, _rx_sync_headers) = channel(1);
     let (tx_sync_certificates, _rx_sync_certificates) = channel(1);
@@ -288,7 +288,7 @@ async fn process_votes() {
 
 #[tokio::test]
 async fn process_certificates() {
-    let kp = keys().pop().unwrap();
+    let kp = keys(None).pop().unwrap();
     let name = kp.public().clone();
     let signature_service = SignatureService::new(kp);
 
@@ -307,7 +307,7 @@ async fn process_certificates() {
     // Make a synchronizer for the core.
     let synchronizer = Synchronizer::new(
         name.clone(),
-        &committee(),
+        &committee(None),
         certificates_store.clone(),
         payload_store.clone(),
         /* tx_header_waiter */ tx_sync_headers,
@@ -317,7 +317,7 @@ async fn process_certificates() {
     // Spawn the core.
     Core::spawn(
         name,
-        committee(),
+        committee(None),
         header_store.clone(),
         certificates_store.clone(),
         synchronizer,

--- a/primary/src/tests/helper_tests.rs
+++ b/primary/src/tests/helper_tests.rs
@@ -24,7 +24,7 @@ use types::{BatchDigest, Certificate, CertificateDigest};
 async fn test_process_certificates_stream_mode() {
     // GIVEN
     let (_, certificate_store, payload_store) = create_db_stores();
-    let key = keys().pop().unwrap();
+    let key = keys(None).pop().unwrap();
     let (name, committee) = resolve_name_and_committee();
     let (tx_primaries, rx_primaries) = channel(10);
 
@@ -94,7 +94,7 @@ async fn test_process_certificates_stream_mode() {
 async fn test_process_certificates_batch_mode() {
     // GIVEN
     let (_, certificate_store, payload_store) = create_db_stores();
-    let key = keys().pop().unwrap();
+    let key = keys(None).pop().unwrap();
     let (name, committee) = resolve_name_and_committee();
     let (tx_primaries, rx_primaries) = channel(10);
 
@@ -185,7 +185,7 @@ async fn test_process_certificates_batch_mode() {
 async fn test_process_payload_availability_success() {
     // GIVEN
     let (_, certificate_store, payload_store) = create_db_stores();
-    let key = keys().pop().unwrap();
+    let key = keys(None).pop().unwrap();
     let (name, committee) = resolve_name_and_committee();
     let (tx_primaries, rx_primaries) = channel(10);
 
@@ -296,7 +296,7 @@ async fn test_process_payload_availability_when_failures() {
     let payload_store: Store<(types::BatchDigest, WorkerId), PayloadToken> =
         Store::new(payload_map);
 
-    let key = keys().pop().unwrap();
+    let key = keys(None).pop().unwrap();
     let (name, committee) = resolve_name_and_committee();
     let (tx_primaries, rx_primaries) = channel(10);
 

--- a/primary/src/tests/proposer_tests.rs
+++ b/primary/src/tests/proposer_tests.rs
@@ -8,7 +8,7 @@ use tokio::sync::mpsc::channel;
 
 #[tokio::test]
 async fn propose_empty() {
-    let kp = keys().pop().unwrap();
+    let kp = keys(None).pop().unwrap();
     let name = kp.public().clone();
     let signature_service = SignatureService::new(kp);
 
@@ -19,7 +19,7 @@ async fn propose_empty() {
     // Spawn the proposer.
     Proposer::spawn(
         name,
-        &committee(),
+        &committee(None),
         signature_service,
         /* header_size */ 1_000,
         /* max_header_delay */ Duration::from_millis(20),
@@ -32,12 +32,12 @@ async fn propose_empty() {
     let header = rx_headers.recv().await.unwrap();
     assert_eq!(header.round, 1);
     assert!(header.payload.is_empty());
-    assert!(header.verify(&committee()).is_ok());
+    assert!(header.verify(&committee(None)).is_ok());
 }
 
 #[tokio::test]
 async fn propose_payload() {
-    let kp = keys().pop().unwrap();
+    let kp = keys(None).pop().unwrap();
     let name = kp.public().clone();
     let signature_service = SignatureService::new(kp);
 
@@ -48,7 +48,7 @@ async fn propose_payload() {
     // Spawn the proposer.
     Proposer::spawn(
         name.clone(),
-        &committee(),
+        &committee(None),
         signature_service,
         /* header_size */ 32,
         /* max_header_delay */
@@ -68,5 +68,5 @@ async fn propose_payload() {
     let header = rx_headers.recv().await.unwrap();
     assert_eq!(header.round, 1);
     assert_eq!(header.payload.get(&digest), Some(&worker_id));
-    assert!(header.verify(&committee()).is_ok());
+    assert!(header.verify(&committee(None)).is_ok());
 }

--- a/primary/tests/integration_tests.rs
+++ b/primary/tests/integration_tests.rs
@@ -31,10 +31,10 @@ async fn test_get_collections() {
         batch_size: 200, // Two transactions.
         ..Parameters::default()
     };
-    let keypair = keys().pop().unwrap();
+    let keypair = keys(None).pop().unwrap();
     let name = keypair.public().clone();
     let signer = keypair;
-    let committee = committee();
+    let committee = committee(None);
 
     // Make the data store.
     let store = NodeStorage::reopen(temp_dir());
@@ -43,7 +43,7 @@ async fn test_get_collections() {
     let mut header_ids = Vec::new();
     // Blocks/Collections
     let mut collection_ids = Vec::new();
-    let key = keys().pop().unwrap();
+    let key = keys(None).pop().unwrap();
     let mut missing_block = CertificateDigest::new([0; 32]);
 
     // Generate headers
@@ -192,10 +192,10 @@ async fn test_remove_collections() {
         batch_size: 200, // Two transactions.
         ..Parameters::default()
     };
-    let keypair = keys().pop().unwrap();
+    let keypair = keys(None).pop().unwrap();
     let name = keypair.public().clone();
     let signer = keypair;
-    let committee = committee();
+    let committee = committee(None);
 
     // Make the data store.
     let store = NodeStorage::reopen(temp_dir());
@@ -204,7 +204,7 @@ async fn test_remove_collections() {
     let mut header_ids = Vec::new();
     // Blocks/Collections
     let mut collection_ids = Vec::new();
-    let key = keys().pop().unwrap();
+    let key = keys(None).pop().unwrap();
 
     // Make the Dag
     let (tx_new_certificates, rx_new_certificates) = channel(CHANNEL_CAPACITY);
@@ -385,10 +385,10 @@ async fn test_new_network_info() {
         batch_size: 200, // Two transactions.
         ..Parameters::default()
     };
-    let keypair = keys().pop().unwrap();
+    let keypair = keys(None).pop().unwrap();
     let name = keypair.public().clone();
     let signer = keypair;
-    let committee = committee();
+    let committee = committee(None);
 
     // Make the data store.
     let store = NodeStorage::reopen(temp_dir());
@@ -453,7 +453,7 @@ async fn test_new_network_info() {
 #[tokio::test]
 async fn test_get_collections_with_missing_certificates() {
     // GIVEN keys for two primary nodes
-    let mut k = keys();
+    let mut k = keys(None);
 
     let keypair_1 = k.pop().unwrap();
     let name_1 = keypair_1.public().clone();
@@ -461,7 +461,7 @@ async fn test_get_collections_with_missing_certificates() {
     let keypair_2 = k.pop().unwrap();
     let name_2 = keypair_2.public().clone();
 
-    let committee = committee();
+    let committee = committee(None);
     let parameters = Parameters {
         batch_size: 200, // Two transactions.
         ..Parameters::default()
@@ -474,7 +474,7 @@ async fn test_get_collections_with_missing_certificates() {
     let worker_id = 0;
 
     // AND generate and store the certificates
-    let signer_1 = keys().remove(0);
+    let signer_1 = keys(None).remove(0);
 
     // The certificate_1 will be stored in primary 1
     let certificate_1 = fixture_certificate(
@@ -487,7 +487,7 @@ async fn test_get_collections_with_missing_certificates() {
     .await;
 
     // pop first to skip
-    let signer_2 = keys().remove(1);
+    let signer_2 = keys(None).remove(1);
 
     // The certificate_2 will be stored in primary 2
     let certificate_2 = fixture_certificate(
@@ -619,7 +619,7 @@ async fn fixture_certificate(
         .author(key.public().clone())
         .round(1)
         .parents(
-            Certificate::genesis(&committee())
+            Certificate::genesis(&committee(None))
                 .iter()
                 .map(|x| x.digest())
                 .collect(),

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -38,15 +38,21 @@ pub fn temp_dir() -> std::path::PathBuf {
 ////////////////////////////////////////////////////////////////
 
 // Fixture
-pub fn keys() -> Vec<Ed25519KeyPair> {
-    let mut rng = StdRng::from_seed([0; 32]);
+pub fn keys(rng_seed: impl Into<Option<u64>>) -> Vec<Ed25519KeyPair> {
+    let seed = rng_seed.into().unwrap_or(0u64).to_le_bytes();
+    let mut rng_arg = [0u8; 32];
+    for i in 0..4 {
+        rng_arg[i * 8..(i + 1) * 8].copy_from_slice(&seed[..]);
+    }
+
+    let mut rng = StdRng::from_seed(rng_arg);
     (0..4).map(|_| Ed25519KeyPair::generate(&mut rng)).collect()
 }
 
 // Fixture
-pub fn committee() -> Committee<Ed25519PublicKey> {
+pub fn committee(rng_seed: impl Into<Option<u64>>) -> Committee<Ed25519PublicKey> {
     Committee {
-        authorities: keys()
+        authorities: keys(rng_seed)
             .iter()
             .map(|kp| {
                 let id = kp.public();
@@ -174,11 +180,11 @@ pub fn committee() -> Committee<Ed25519PublicKey> {
 
 // Fixture
 pub fn header() -> Header<Ed25519PublicKey> {
-    let kp = keys().pop().unwrap();
+    let kp = keys(None).pop().unwrap();
     let header = Header {
         author: kp.public().clone(),
         round: 1,
-        parents: Certificate::genesis(&committee())
+        parents: Certificate::genesis(&committee(None))
             .iter()
             .map(|x| x.digest())
             .collect(),
@@ -195,13 +201,13 @@ pub fn header() -> Header<Ed25519PublicKey> {
 
 // Fixture
 pub fn headers() -> Vec<Header<Ed25519PublicKey>> {
-    keys()
+    keys(None)
         .into_iter()
         .map(|kp| {
             let header = Header {
                 author: kp.public().clone(),
                 round: 1,
-                parents: Certificate::genesis(&committee())
+                parents: Certificate::genesis(&committee(None))
                     .iter()
                     .map(|x| x.digest())
                     .collect(),
@@ -219,17 +225,17 @@ pub fn headers() -> Vec<Header<Ed25519PublicKey>> {
 
 #[allow(dead_code)]
 pub fn fixture_header() -> Header<Ed25519PublicKey> {
-    let kp = keys().pop().unwrap();
+    let kp = keys(None).pop().unwrap();
 
     fixture_header_builder().build(|payload| kp.sign(payload))
 }
 
 pub fn fixture_header_builder() -> types::HeaderBuilder<Ed25519PublicKey> {
-    let kp = keys().pop().unwrap();
+    let kp = keys(None).pop().unwrap();
 
     let builder = types::HeaderBuilder::<Ed25519PublicKey>::default();
     builder.author(kp.public().clone()).round(1).parents(
-        Certificate::genesis(&committee())
+        Certificate::genesis(&committee(None))
             .iter()
             .map(|x| x.digest())
             .collect(),
@@ -237,7 +243,7 @@ pub fn fixture_header_builder() -> types::HeaderBuilder<Ed25519PublicKey> {
 }
 
 pub fn fixture_header_with_payload(number_of_batches: u8) -> Header<Ed25519PublicKey> {
-    let kp = keys().pop().unwrap();
+    let kp = keys(None).pop().unwrap();
     let mut payload: BTreeMap<BatchDigest, WorkerId> = BTreeMap::new();
 
     for i in 0..number_of_batches {
@@ -269,7 +275,7 @@ pub fn transaction() -> Transaction {
 
 // Fixture
 pub fn votes(header: &Header<Ed25519PublicKey>) -> Vec<Vote<Ed25519PublicKey>> {
-    keys()
+    keys(None)
         .into_iter()
         .map(|kp| {
             let vote = Vote {
@@ -446,11 +452,11 @@ impl WorkerToWorker for WorkerToWorkerMockServer {
 
 // helper method to get a name and a committee.
 pub fn resolve_name_and_committee() -> (Ed25519PublicKey, Committee<Ed25519PublicKey>) {
-    let mut keys = keys();
+    let mut keys = keys(None);
     let _ = keys.pop().unwrap(); // Skip the header' author.
     let kp = keys.pop().unwrap();
     let name = kp.public().clone();
-    let committee = committee();
+    let committee = committee(None);
 
     (name, committee)
 }

--- a/worker/src/primary_connector.rs
+++ b/worker/src/primary_connector.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use multiaddr::Multiaddr;
 use primary::WorkerPrimaryMessage;
-use tokio::sync::mpsc::Receiver;
+use tokio::{sync::mpsc::Receiver, task::JoinHandle};
 use tonic::transport::Channel;
 use types::{BincodeEncodedPayload, WorkerToPrimaryClient};
 
@@ -18,7 +18,10 @@ pub struct PrimaryConnector {
 }
 
 impl PrimaryConnector {
-    pub fn spawn(primary_address: Multiaddr, rx_digest: Receiver<WorkerPrimaryMessage>) {
+    pub fn spawn(
+        primary_address: Multiaddr,
+        rx_digest: Receiver<WorkerPrimaryMessage>,
+    ) -> JoinHandle<()> {
         tokio::spawn(async move {
             Self {
                 _primary_address: primary_address.clone(),
@@ -27,7 +30,7 @@ impl PrimaryConnector {
             }
             .run()
             .await;
-        });
+        })
     }
 
     async fn run(&mut self) {

--- a/worker/src/tests/helper_tests.rs
+++ b/worker/src/tests/helper_tests.rs
@@ -15,9 +15,9 @@ use types::BatchDigest;
 async fn worker_batch_reply() {
     let (tx_worker_request, rx_worker_request) = channel(1);
     let (_tx_client_request, rx_client_request) = channel(1);
-    let requestor = keys().pop().unwrap().public().clone();
+    let requestor = keys(None).pop().unwrap().public().clone();
     let id = 0;
-    let committee = committee();
+    let committee = committee(None);
 
     // Create a new test store.
     let db = rocks::DBMap::<BatchDigest, SerializedBatchMessage>::open(
@@ -61,7 +61,7 @@ async fn client_batch_reply() {
     let (_tx_worker_request, rx_worker_request) = channel(1);
     let (tx_client_request, rx_client_request) = channel(1);
     let id = 0;
-    let committee = committee();
+    let committee = committee(None);
 
     // Create a new test store.
     let db = rocks::DBMap::<BatchDigest, SerializedBatchMessage>::open(

--- a/worker/src/tests/quorum_waiter_tests.rs
+++ b/worker/src/tests/quorum_waiter_tests.rs
@@ -13,8 +13,8 @@ use tokio::sync::mpsc::channel;
 async fn wait_for_quorum() {
     let (tx_message, rx_message) = channel(1);
     let (tx_batch, mut rx_batch) = channel(1);
-    let myself = keys().pop().unwrap().public().clone();
-    let committee = committee();
+    let myself = keys(None).pop().unwrap().public().clone();
+    let committee = committee(None);
 
     // Spawn a `QuorumWaiter` instance.
     QuorumWaiter::spawn(committee.clone(), /* stake */ 1, rx_message, tx_batch);

--- a/worker/src/tests/synchronizer_tests.rs
+++ b/worker/src/tests/synchronizer_tests.rs
@@ -14,10 +14,10 @@ async fn synchronize() {
     let (tx_message, rx_message) = channel(1);
     let (tx_primary, _) = channel(1);
 
-    let mut keys = keys();
+    let mut keys = keys(None);
     let name = keys.pop().unwrap().public().clone();
     let id = 0;
-    let committee = committee();
+    let committee = committee(None);
 
     // Create a new test store.
     let store = open_batch_store();
@@ -57,10 +57,10 @@ async fn test_successful_request_batch() {
     let (tx_message, rx_message) = channel(1);
     let (tx_primary, mut rx_primary) = channel(1);
 
-    let mut keys = keys();
+    let mut keys = keys(None);
     let name = keys.pop().unwrap().public().clone();
     let id = 0;
-    let committee = committee();
+    let committee = committee(None);
 
     // Create a new test store.
     let store = open_batch_store();
@@ -112,10 +112,10 @@ async fn test_request_batch_not_found() {
     let (tx_message, rx_message) = channel(1);
     let (tx_primary, mut rx_primary) = channel(1);
 
-    let mut keys = keys();
+    let mut keys = keys(None);
     let name = keys.pop().unwrap().public().clone();
     let id = 0;
-    let committee = committee();
+    let committee = committee(None);
 
     // Create a new test store.
     let store = open_batch_store();
@@ -166,10 +166,10 @@ async fn test_successful_batch_delete() {
     let (tx_message, rx_message) = channel(1);
     let (tx_primary, mut rx_primary) = channel(1);
 
-    let mut keys = keys();
+    let mut keys = keys(None);
     let name = keys.pop().unwrap().public().clone();
     let id = 0;
-    let committee = committee();
+    let committee = committee(None);
 
     // Create a new test store.
     let store = open_batch_store();

--- a/worker/src/tests/worker_tests.rs
+++ b/worker/src/tests/worker_tests.rs
@@ -16,9 +16,9 @@ use types::{TransactionsClient, WorkerToWorkerClient};
 
 #[tokio::test]
 async fn handle_clients_transactions() {
-    let name = keys().pop().unwrap().public().clone();
+    let name = keys(None).pop().unwrap().public().clone();
     let id = 0;
-    let committee = committee();
+    let committee = committee(None);
     let parameters = Parameters {
         batch_size: 200, // Two transactions.
         ..Parameters::default()
@@ -74,9 +74,9 @@ async fn handle_clients_transactions() {
 
 #[tokio::test]
 async fn handle_client_batch_request() {
-    let name = keys().pop().unwrap().public().clone();
+    let name = keys(None).pop().unwrap().public().clone();
     let id = 0;
-    let committee = committee();
+    let committee = committee(None);
     let parameters = Parameters {
         max_header_delay: Duration::from_millis(100_000), // Ensure no batches are created.
         ..Parameters::default()


### PR DESCRIPTION
## Issue
As @akichidis recently discovered, when one tries to run the node with the latest changes like this (internal consensus disabled):
```rust
./node run --committee committee.json --keys keys.json --store db0 primary --consensus-disabled
```

Issue is that the execution on the [main.rs](https://github.com/MystenLabs/narwhal/blob/83e8bf2039ccea681c5abdb6f85d5e769b4c8e8d/node/src/main.rs#L122-L161) node reaches the end as it doesn’t block [here](https://github.com/MystenLabs/narwhal/blob/fdd4f0b45b1d9bf499fb7822d8e1d36144b09fe6/node/src/main.rs#L158) anymore. We don’t use the `rx_transaction_confirmation` anymore and it appears that the node was not shutting down immediately before because of this loop inside the analyze method.

## Solution

The main primary / worker task now return explicit join handles which we `await` on.
