### PR TITLE
fix: align methods for hash computation

### DIFF
--- a/types/src/primary.rs
+++ b/types/src/primary.rs
@@ -9,6 +9,7 @@ use blake2::{digest::Update, VarBlake2b};
 use bytes::Bytes;
 use config::{Committee, WorkerId};
 use crypto::{
+    ed25519::Ed25519PublicKey,
     traits::{EncodeDecodeBase64, VerifyingKey},
     Digest, Hash, SignatureService, DIGEST_LEN,
 };
@@ -67,9 +68,12 @@ impl Hash for Batch {
     type TypedDigest = BatchDigest;
 
     fn digest(&self) -> Self::TypedDigest {
-        BatchDigest(crypto::blake2b_256(|hasher| {
-            self.0.iter().for_each(|tx| hasher.update(tx))
-        }))
+        // While the `WorkerMessage` structure is generic, the parameter has no bearing on this enum variant
+        // TODO: fix in #[246]
+        let message = crate::worker::WorkerMessage::<Ed25519PublicKey>::Batch(self.clone());
+        let serialized = bincode::serialize(&message).expect("Batch serialization should not fail");
+
+        BatchDigest::new(crypto::blake2b_256(|hasher| hasher.update(&serialized)))
     }
 }
 


### PR DESCRIPTION
Our current solution for hashing batches has 3 components:
1. it relies on never deserializing a batch, so that we hash the serialized message,
2. it is not resilient to hash confusion, lenght extension, etc (see MystenLabs/sui#5198).
3. it is split in two functions that disagree with each other (see MystenLabs/narwhal#188).

This stopgap PR does nothing about 1 & 2, but realigns the `impl Hash for Batch` so that it matches with the rest of the code base, and uses it in processor tests.
THe security fixes of the batch hashing will be done in MystenLabs/narwhal#156.

Fixes MystenLabs/narwhal#188