### PR TITLE
Introduce the rounds endpoint for the ProposerAPI

### DIFF
--- a/consensus/benches/process_certificates.rs
+++ b/consensus/benches/process_certificates.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use consensus::tusk::{
-    consensus_tests::{make_consensus_store, make_optimal_certificates, mock_committee},
+    consensus_tests::{make_consensus_store, mock_committee},
     *,
 };
 use criterion::{
@@ -10,7 +10,7 @@ use criterion::{
 use crypto::{traits::KeyPair, Hash};
 use pprof::criterion::{Output, PProfProfiler};
 use std::collections::BTreeSet;
-use test_utils::{keys, temp_dir};
+use test_utils::{keys, make_optimal_certificates, temp_dir};
 use types::{Certificate, Round};
 
 pub fn process_certificates(c: &mut Criterion) {

--- a/consensus/src/tests/consensus_tests.rs
+++ b/consensus/src/tests/consensus_tests.rs
@@ -6,12 +6,12 @@ use config::{Authority, PrimaryAddresses};
 use crypto::ed25519::Ed25519PublicKey;
 #[allow(unused_imports)] // WT*?
 use crypto::traits::KeyPair;
-use rand::Rng;
+#[cfg(test)]
 use std::collections::{BTreeSet, VecDeque};
 use store::{reopen, rocks, rocks::DBMap};
 #[allow(unused_imports)] // WT*?
 use tokio::sync::mpsc::channel;
-use types::{CertificateDigest, Header};
+use types::CertificateDigest;
 
 // Fixture
 pub fn mock_committee(keys: &[Ed25519PublicKey]) -> Committee<Ed25519PublicKey> {
@@ -33,93 +33,6 @@ pub fn mock_committee(keys: &[Ed25519PublicKey]) -> Committee<Ed25519PublicKey> 
             })
             .collect(),
     }
-}
-
-// Fixture
-pub fn mock_certificate(
-    origin: Ed25519PublicKey,
-    round: Round,
-    parents: BTreeSet<CertificateDigest>,
-) -> (CertificateDigest, Certificate<Ed25519PublicKey>) {
-    let certificate = Certificate {
-        header: Header {
-            author: origin,
-            round,
-            parents,
-            ..Header::default()
-        },
-        ..Certificate::default()
-    };
-    (certificate.digest(), certificate)
-}
-
-// Creates one certificate per authority starting and finishing at the specified rounds (inclusive).
-// Outputs a VecDeque of certificates (the certificate with higher round is on the front) and a set
-// of digests to be used as parents for the certificates of the next round.
-pub fn make_optimal_certificates(
-    start: Round,
-    stop: Round,
-    initial_parents: &BTreeSet<CertificateDigest>,
-    keys: &[Ed25519PublicKey],
-) -> (
-    VecDeque<Certificate<Ed25519PublicKey>>,
-    BTreeSet<CertificateDigest>,
-) {
-    make_certificates(start, stop, initial_parents, keys, 0.0)
-}
-
-pub fn make_certificates(
-    start: Round,
-    stop: Round,
-    initial_parents: &BTreeSet<CertificateDigest>,
-    keys: &[Ed25519PublicKey],
-    failure_probability: f64,
-) -> (
-    VecDeque<Certificate<Ed25519PublicKey>>,
-    BTreeSet<CertificateDigest>,
-) {
-    let mut certificates = VecDeque::new();
-    let mut parents = initial_parents.iter().cloned().collect::<BTreeSet<_>>();
-    let mut next_parents = BTreeSet::new();
-
-    fn this_cert_parents(
-        ancestors: &BTreeSet<CertificateDigest>,
-        failure_prob: f64,
-    ) -> BTreeSet<CertificateDigest> {
-        std::iter::from_fn(|| {
-            let f: f64 = rand::thread_rng().gen();
-            if f > failure_prob {
-                Some(true)
-            } else {
-                Some(false)
-            }
-        })
-        .take(ancestors.len())
-        .zip(ancestors)
-        .flat_map(
-            |(parenthood, parent)| {
-                if parenthood {
-                    Some(*parent)
-                } else {
-                    None
-                }
-            },
-        )
-        .collect::<BTreeSet<_>>()
-    }
-
-    for round in start..=stop {
-        next_parents.clear();
-        for name in keys {
-            let this_cert_parents = this_cert_parents(&parents, failure_probability);
-
-            let (digest, certificate) = mock_certificate(name.clone(), round, this_cert_parents);
-            certificates.push_back(certificate);
-            next_parents.insert(digest);
-        }
-        parents = next_parents.clone();
-    }
-    (certificates, next_parents)
 }
 
 pub fn make_consensus_store(store_path: &std::path::Path) -> Arc<ConsensusStore<Ed25519PublicKey>> {
@@ -165,10 +78,11 @@ async fn commit_one() {
         .iter()
         .map(|x| x.digest())
         .collect::<BTreeSet<_>>();
-    let (mut certificates, next_parents) = make_optimal_certificates(1, 4, &genesis, &keys);
+    let (mut certificates, next_parents) =
+        test_utils::make_optimal_certificates(1, 4, &genesis, &keys);
 
     // Make one certificate with round 5 to trigger the commits.
-    let (_, certificate) = mock_certificate(keys[0].clone(), 5, next_parents);
+    let (_, certificate) = test_utils::mock_certificate(keys[0].clone(), 5, next_parents);
     certificates.push_back(certificate);
 
     // Spawn the consensus engine and sink the primary channel.
@@ -219,7 +133,7 @@ async fn dead_node() {
         .map(|x| x.digest())
         .collect::<BTreeSet<_>>();
 
-    let (mut certificates, _) = make_optimal_certificates(1, 9, &genesis, &keys);
+    let (mut certificates, _) = test_utils::make_optimal_certificates(1, 9, &genesis, &keys);
 
     // Spawn the consensus engine and sink the primary channel.
     let (tx_waiter, rx_waiter) = channel(1);
@@ -272,34 +186,35 @@ async fn not_enough_support() {
 
     // Round 1: Fully connected graph.
     let nodes: Vec<_> = keys.iter().take(3).cloned().collect();
-    let (out, parents) = make_optimal_certificates(1, 1, &genesis, &nodes);
+    let (out, parents) = test_utils::make_optimal_certificates(1, 1, &genesis, &nodes);
     certificates.extend(out);
 
     // Round 2: Fully connect graph. But remember the digest of the leader. Note that this
     // round is the only one with 4 certificates.
-    let (leader_2_digest, certificate) = mock_certificate(keys[0].clone(), 2, parents.clone());
+    let (leader_2_digest, certificate) =
+        test_utils::mock_certificate(keys[0].clone(), 2, parents.clone());
     certificates.push_back(certificate);
 
     let nodes: Vec<_> = keys.iter().skip(1).cloned().collect();
-    let (out, mut parents) = make_optimal_certificates(2, 2, &parents, &nodes);
+    let (out, mut parents) = test_utils::make_optimal_certificates(2, 2, &parents, &nodes);
     certificates.extend(out);
 
     // Round 3: Only node 0 links to the leader of round 2.
     let mut next_parents = BTreeSet::new();
 
     let name = &keys[1];
-    let (digest, certificate) = mock_certificate(name.clone(), 3, parents.clone());
+    let (digest, certificate) = test_utils::mock_certificate(name.clone(), 3, parents.clone());
     certificates.push_back(certificate);
     next_parents.insert(digest);
 
     let name = &keys[2];
-    let (digest, certificate) = mock_certificate(name.clone(), 3, parents.clone());
+    let (digest, certificate) = test_utils::mock_certificate(name.clone(), 3, parents.clone());
     certificates.push_back(certificate);
     next_parents.insert(digest);
 
     let name = &keys[0];
     parents.insert(leader_2_digest);
-    let (digest, certificate) = mock_certificate(name.clone(), 3, parents.clone());
+    let (digest, certificate) = test_utils::mock_certificate(name.clone(), 3, parents.clone());
     certificates.push_back(certificate);
     next_parents.insert(digest);
 
@@ -307,11 +222,11 @@ async fn not_enough_support() {
 
     // Rounds 4, 5, and 6: Fully connected graph.
     let nodes: Vec<_> = keys.iter().take(3).cloned().collect();
-    let (out, parents) = make_optimal_certificates(4, 6, &parents, &nodes);
+    let (out, parents) = test_utils::make_optimal_certificates(4, 6, &parents, &nodes);
     certificates.extend(out);
 
     // Round 7: Send a single certificate to trigger the commits.
-    let (_, certificate) = mock_certificate(keys[0].clone(), 7, parents);
+    let (_, certificate) = test_utils::mock_certificate(keys[0].clone(), 7, parents);
     certificates.push_back(certificate);
 
     // Spawn the consensus engine and sink the primary channel.
@@ -371,15 +286,15 @@ async fn missing_leader() {
 
     // Remove the leader for rounds 1 and 2.
     let nodes: Vec<_> = keys.iter().skip(1).cloned().collect();
-    let (out, parents) = make_optimal_certificates(1, 2, &genesis, &nodes);
+    let (out, parents) = test_utils::make_optimal_certificates(1, 2, &genesis, &nodes);
     certificates.extend(out);
 
     // Add back the leader for rounds 3, 4, 5 and 6.
-    let (out, parents) = make_optimal_certificates(3, 6, &parents, &keys);
+    let (out, parents) = test_utils::make_optimal_certificates(3, 6, &parents, &keys);
     certificates.extend(out);
 
     // Add a certificate of round 7 to commit the leader of round 4.
-    let (_, certificate) = mock_certificate(keys[0].clone(), 7, parents.clone());
+    let (_, certificate) = test_utils::mock_certificate(keys[0].clone(), 7, parents.clone());
     certificates.push_back(certificate);
 
     // Spawn the consensus engine and sink the primary channel.

--- a/consensus/src/tests/dag_tests.rs
+++ b/consensus/src/tests/dag_tests.rs
@@ -5,10 +5,11 @@ use std::collections::BTreeSet;
 
 use crypto::{traits::KeyPair, Hash};
 use dag::node_dag::NodeDagError;
+use test_utils::make_optimal_certificates;
 use tokio::sync::mpsc::channel;
 use types::Certificate;
 
-use crate::tusk::consensus_tests::{make_optimal_certificates, mock_committee};
+use crate::tusk::consensus_tests::mock_committee;
 
 use super::{Dag, ValidatorDagError};
 

--- a/consensus/src/tests/subscriber_tests.rs
+++ b/consensus/src/tests/subscriber_tests.rs
@@ -20,10 +20,11 @@ pub fn commit_certificates() -> VecDeque<Certificate<Ed25519PublicKey>> {
         .iter()
         .map(|x| x.digest())
         .collect::<BTreeSet<_>>();
-    let (mut certificates, next_parents) = make_optimal_certificates(1, 4, &genesis, &keys);
+    let (mut certificates, next_parents) =
+        test_utils::make_optimal_certificates(1, 4, &genesis, &keys);
 
     // Make one certificate with round 5 to trigger the commits.
-    let (_, certificate) = mock_certificate(keys[0].clone(), 5, next_parents);
+    let (_, certificate) = test_utils::mock_certificate(keys[0].clone(), 5, next_parents);
     certificates.push_back(certificate);
     certificates
 }

--- a/consensus/src/tusk.rs
+++ b/consensus/src/tusk.rs
@@ -417,7 +417,8 @@ mod tests {
             .iter()
             .map(|x| x.digest())
             .collect::<BTreeSet<_>>();
-        let (certificates, _next_parents) = make_optimal_certificates(1, rounds, &genesis, &keys);
+        let (certificates, _next_parents) =
+            test_utils::make_optimal_certificates(1, rounds, &genesis, &keys);
         let committee = mock_committee(&keys);
 
         let store_path = test_utils::temp_dir();
@@ -467,7 +468,8 @@ mod tests {
             .map(|x| x.digest())
             .collect::<BTreeSet<_>>();
         // TODO: evidence that this test fails when `failure_probability` parameter >= 1/3
-        let (certificates, _next_parents) = make_certificates(1, rounds, &genesis, &keys, 0.333);
+        let (certificates, _next_parents) =
+            test_utils::make_certificates(1, rounds, &genesis, &keys, 0.333);
         let committee = mock_committee(&keys);
 
         let store_path = test_utils::temp_dir();

--- a/primary/src/grpc_server/mod.rs
+++ b/primary/src/grpc_server/mod.rs
@@ -2,31 +2,39 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use self::{configuration::NarwhalConfiguration, validator::NarwhalValidator};
-use crate::{BlockCommand, BlockRemoverCommand};
+use crate::{grpc_server::proposer::NarwhalProposer, BlockCommand, BlockRemoverCommand};
+use config::Committee;
+use consensus::dag::Dag;
+use crypto::traits::VerifyingKey;
 use multiaddr::Multiaddr;
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 use tokio::sync::mpsc::Sender;
 use tracing::error;
-use types::{ConfigurationServer, ValidatorServer};
+use types::{ConfigurationServer, ProposerServer, ValidatorServer};
 
 mod configuration;
+mod proposer;
 mod validator;
 
-pub struct ConsensusAPIGrpc {
+pub struct ConsensusAPIGrpc<PublicKey: VerifyingKey> {
     socket_addr: Multiaddr,
     tx_get_block_commands: Sender<BlockCommand>,
     tx_block_removal_commands: Sender<BlockRemoverCommand>,
     get_collections_timeout: Duration,
     remove_collections_timeout: Duration,
+    dag: Option<Arc<Dag<PublicKey>>>,
+    committee: Committee<PublicKey>,
 }
 
-impl ConsensusAPIGrpc {
+impl<PublicKey: VerifyingKey> ConsensusAPIGrpc<PublicKey> {
     pub fn spawn(
         socket_addr: Multiaddr,
         tx_get_block_commands: Sender<BlockCommand>,
         tx_block_removal_commands: Sender<BlockRemoverCommand>,
         get_collections_timeout: Duration,
         remove_collections_timeout: Duration,
+        dag: Option<Arc<Dag<PublicKey>>>,
+        committee: Committee<PublicKey>,
     ) {
         tokio::spawn(async move {
             let _ = Self {
@@ -35,6 +43,8 @@ impl ConsensusAPIGrpc {
                 tx_block_removal_commands,
                 get_collections_timeout,
                 remove_collections_timeout,
+                dag,
+                committee,
             }
             .run()
             .await
@@ -50,6 +60,8 @@ impl ConsensusAPIGrpc {
             self.remove_collections_timeout,
         );
 
+        let narwhal_proposer = NarwhalProposer::new(self.dag.clone(), self.committee.clone());
+
         let narwhal_configuration = NarwhalConfiguration::new();
 
         let config = mysten_network::config::Config::default();
@@ -57,6 +69,7 @@ impl ConsensusAPIGrpc {
             .server_builder()
             .add_service(ValidatorServer::new(narwhal_validator))
             .add_service(ConfigurationServer::new(narwhal_configuration))
+            .add_service(ProposerServer::new(narwhal_proposer))
             .bind(&self.socket_addr)
             .await?
             .serve()

--- a/primary/src/grpc_server/proposer.rs
+++ b/primary/src/grpc_server/proposer.rs
@@ -1,0 +1,70 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use config::Committee;
+use consensus::dag::Dag;
+use crypto::traits::VerifyingKey;
+use std::sync::Arc;
+use tonic::{Request, Response, Status};
+use types::{Proposer, RoundsRequest, RoundsResponse};
+
+pub struct NarwhalProposer<PublicKey: VerifyingKey> {
+    /// The dag that holds the available certificates to propose
+    dag: Option<Arc<Dag<PublicKey>>>,
+
+    /// The committee
+    committee: Committee<PublicKey>,
+}
+
+impl<PublicKey: VerifyingKey> NarwhalProposer<PublicKey> {
+    pub fn new(dag: Option<Arc<Dag<PublicKey>>>, committee: Committee<PublicKey>) -> Self {
+        Self { dag, committee }
+    }
+
+    /// Extracts and verifies the public key provided from the RoundsRequest.
+    /// The method will return a result where the OK() will hold the
+    /// parsed public key. The Err() will hold a Status message with the
+    /// specific error description.
+    fn get_public_key(&self, request: RoundsRequest) -> Result<PublicKey, Status> {
+        let proto_key = request
+            .public_key
+            .ok_or_else(|| Status::invalid_argument("Invalid public key: no key provided"))?;
+        let key = PublicKey::from_bytes(proto_key.bytes.as_ref())
+            .map_err(|_| Status::invalid_argument("Invalid public key: couldn't parse"))?;
+
+        // ensure provided key is part of the committee
+        if self.committee.primary(&key).is_err() {
+            return Err(Status::invalid_argument(
+                "Invalid public key: unknown authority",
+            ));
+        }
+
+        Ok(key)
+    }
+}
+
+#[tonic::async_trait]
+impl<PublicKey: VerifyingKey> Proposer for NarwhalProposer<PublicKey> {
+    /// Retrieves the min & max rounds that contain collections available for
+    /// block proposal for the dictated validator.
+    /// by the provided public key.
+    async fn rounds(
+        &self,
+        request: Request<RoundsRequest>,
+    ) -> Result<Response<RoundsResponse>, Status> {
+        let key = self.get_public_key(request.into_inner())?;
+
+        // call the dag to retrieve the rounds
+        if let Some(dag) = &self.dag {
+            let result = match dag.rounds(key).await {
+                Ok(r) => Ok(RoundsResponse {
+                    oldest_round: *r.start() as u64,
+                    newest_round: *r.end() as u64,
+                }),
+                Err(err) => Err(Status::internal(format!("Couldn't retrieve rounds: {err}"))),
+            };
+            return result.map(Response::new);
+        }
+
+        Err(Status::internal("Can not serve request"))
+    }
+}

--- a/primary/src/primary.rs
+++ b/primary/src/primary.rs
@@ -231,7 +231,7 @@ impl Primary {
             certificate_store.clone(),
             header_store,
             payload_store.clone(),
-            dag,
+            dag.clone(),
             PrimaryToWorkerNetwork::default(),
             rx_block_removal_commands,
             rx_batch_removal,
@@ -308,6 +308,8 @@ impl Primary {
                 tx_block_removal_commands,
                 parameters.consensus_api_grpc.get_collections_timeout,
                 parameters.consensus_api_grpc.remove_collections_timeout,
+                dag,
+                committee.clone(),
             );
         }
 

--- a/primary/tests/integration_tests_proposer_api.rs
+++ b/primary/tests/integration_tests_proposer_api.rs
@@ -19,7 +19,7 @@ use types::{Certificate, ProposerClient, PublicKeyProto, RoundsRequest};
 #[tokio::test]
 async fn test_rounds_errors() {
     // GIVEN keys
-    let keypair = keys().pop().unwrap();
+    let keypair = keys(None).pop().unwrap();
     let name = keypair.public().clone();
 
     struct TestCase {
@@ -48,7 +48,7 @@ async fn test_rounds_errors() {
         },
     ];
 
-    let committee = committee();
+    let committee = committee(None);
     let parameters = Parameters {
         batch_size: 200, // Two transactions.
         ..Parameters::default()
@@ -106,10 +106,10 @@ async fn test_rounds_errors() {
 #[tokio::test]
 async fn test_rounds_return_successful_response() {
     // GIVEN keys
-    let keypair = keys().pop().unwrap();
+    let keypair = keys(None).pop().unwrap();
     let name = keypair.public().clone();
 
-    let committee = committee();
+    let committee = committee(None);
     let parameters = Parameters {
         batch_size: 200, // Two transactions.
         ..Parameters::default()
@@ -143,7 +143,10 @@ async fn test_rounds_return_successful_response() {
 
     // AND create some certificates and insert to DAG
     // Make certificates for rounds 1 to 4.
-    let keys: Vec<_> = keys().into_iter().map(|kp| kp.public().clone()).collect();
+    let keys: Vec<_> = keys(None)
+        .into_iter()
+        .map(|kp| kp.public().clone())
+        .collect();
     let mut genesis_certs = Certificate::genesis(&committee);
     let genesis = genesis_certs
         .iter()

--- a/primary/tests/integration_tests_proposer_api.rs
+++ b/primary/tests/integration_tests_proposer_api.rs
@@ -1,0 +1,184 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use bytes::Bytes;
+use config::Parameters;
+use consensus::dag::Dag;
+use crypto::{
+    ed25519::Ed25519PublicKey,
+    traits::{KeyPair, ToFromBytes},
+    Hash,
+};
+use node::NodeStorage;
+use primary::{Primary, CHANNEL_CAPACITY};
+use std::{collections::BTreeSet, sync::Arc, time::Duration};
+use test_utils::{committee, keys, make_optimal_certificates, temp_dir};
+use tokio::sync::mpsc::channel;
+use tonic::transport::Channel;
+use types::{Certificate, ProposerClient, PublicKeyProto, RoundsRequest};
+
+#[tokio::test]
+async fn test_rounds_errors() {
+    // GIVEN keys
+    let keypair = keys().pop().unwrap();
+    let name = keypair.public().clone();
+
+    struct TestCase {
+        public_key: Bytes,
+        test_case_name: String,
+        expected_error: String,
+    }
+
+    let test_cases: Vec<TestCase> = vec![
+        TestCase {
+            public_key: Bytes::from(name.clone().as_bytes().to_vec()),
+            test_case_name: "Valid public key but no certificates available".to_string(),
+            expected_error:
+                "Couldn't retrieve rounds: No remaining certificates in Dag for this authority"
+                    .to_string(),
+        },
+        TestCase {
+            public_key: Bytes::from(Ed25519PublicKey::default().as_bytes().to_vec()),
+            test_case_name: "Valid public key, but authority not found in committee".to_string(),
+            expected_error: "Invalid public key: unknown authority".to_string(),
+        },
+        TestCase {
+            public_key: Bytes::from(vec![0u8]),
+            test_case_name: "Invalid public key provided".to_string(),
+            expected_error: "Invalid public key: couldn't parse".to_string(),
+        },
+    ];
+
+    let committee = committee();
+    let parameters = Parameters {
+        batch_size: 200, // Two transactions.
+        ..Parameters::default()
+    };
+
+    // AND create separate data stores
+    let store_primary = NodeStorage::reopen(temp_dir());
+
+    // Spawn the primary
+    let (tx_new_certificates, rx_new_certificates) = channel(CHANNEL_CAPACITY);
+    let (_tx_feedback, rx_feedback) = channel(CHANNEL_CAPACITY);
+
+    Primary::spawn(
+        name.clone(),
+        keypair,
+        committee.clone(),
+        parameters.clone(),
+        store_primary.header_store,
+        store_primary.certificate_store,
+        store_primary.payload_store,
+        /* tx_consensus */ tx_new_certificates,
+        /* rx_consensus */ rx_feedback,
+        /* external_consensus */ Some(Arc::new(Dag::new(rx_new_certificates).1)),
+    );
+
+    // AND Wait for tasks to start
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    // AND
+    let mut client = connect_to_proposer_client(parameters.clone());
+
+    // Run the tests
+    for test in test_cases {
+        println!("Test: {}", test.test_case_name);
+
+        // WHEN we retrieve the rounds
+        let request = tonic::Request::new(RoundsRequest {
+            public_key: Some(PublicKeyProto {
+                bytes: test.public_key,
+            }),
+        });
+        let response = client.rounds(request).await;
+
+        // THEN
+        let err = response.err().unwrap();
+
+        assert!(
+            err.message().contains(test.expected_error.as_str()),
+            "{}",
+            format!("Expected error not found in response: {}", err.message())
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_rounds_return_successful_response() {
+    // GIVEN keys
+    let keypair = keys().pop().unwrap();
+    let name = keypair.public().clone();
+
+    let committee = committee();
+    let parameters = Parameters {
+        batch_size: 200, // Two transactions.
+        ..Parameters::default()
+    };
+
+    // AND create separate data stores
+    let store_primary = NodeStorage::reopen(temp_dir());
+
+    // Spawn the primary
+    let (tx_new_certificates, rx_new_certificates) = channel(CHANNEL_CAPACITY);
+    let (_tx_feedback, rx_feedback) = channel(CHANNEL_CAPACITY);
+
+    // AND setup the DAG
+    let dag = Arc::new(Dag::new(rx_new_certificates).1);
+
+    Primary::spawn(
+        name.clone(),
+        keypair,
+        committee.clone(),
+        parameters.clone(),
+        store_primary.header_store,
+        store_primary.certificate_store,
+        store_primary.payload_store,
+        /* tx_consensus */ tx_new_certificates,
+        /* rx_consensus */ rx_feedback,
+        /* external_consensus */ Some(dag.clone()),
+    );
+
+    // AND Wait for tasks to start
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    // AND create some certificates and insert to DAG
+    // Make certificates for rounds 1 to 4.
+    let keys: Vec<_> = keys().into_iter().map(|kp| kp.public().clone()).collect();
+    let mut genesis_certs = Certificate::genesis(&committee);
+    let genesis = genesis_certs
+        .iter()
+        .map(|x| x.digest())
+        .collect::<BTreeSet<_>>();
+    let (mut certificates, _next_parents) = make_optimal_certificates(1, 4, &genesis, &keys);
+
+    // Feed the certificates to the Dag
+    while let Some(certificate) = genesis_certs.pop() {
+        dag.insert(certificate).await.unwrap();
+    }
+    while let Some(certificate) = certificates.pop_front() {
+        dag.insert(certificate).await.unwrap();
+    }
+
+    // AND
+    let mut client = connect_to_proposer_client(parameters.clone());
+
+    // WHEN we retrieve the rounds
+    let request = tonic::Request::new(RoundsRequest {
+        public_key: Some(PublicKeyProto::from(name)),
+    });
+    let response = client.rounds(request).await;
+
+    // THEN
+    let r = response.ok().unwrap().into_inner();
+
+    assert_eq!(0, r.oldest_round);
+    assert_eq!(4, r.newest_round);
+}
+
+fn connect_to_proposer_client(parameters: Parameters) -> ProposerClient<Channel> {
+    let config = mysten_network::config::Config::new();
+    let channel = config
+        .connect_lazy(&parameters.consensus_api_grpc.socket_addr)
+        .unwrap();
+    ProposerClient::new(channel)
+}

--- a/types/proto/narwhal.proto
+++ b/types/proto/narwhal.proto
@@ -97,6 +97,28 @@ service Validator {
     rpc RemoveCollections (RemoveCollectionsRequest) returns (Empty);
 }
 
+message RoundsRequest {
+    /// The validator's key for which we want to retrieve
+    /// the available rounds.
+    PublicKey public_key = 1;
+}
+
+message RoundsResponse {
+    /// The oldest round for which the node has available
+    /// blocks to propose for the defined validator.
+    uint64 oldest_round = 1;
+
+    /// The newest (latest) round for which the node has available
+    /// blocks to propose for the defined validator.
+    uint64 newest_round = 2;
+}
+
+/// The API that hosts the endpoints that should be used to help
+/// proposing a block.
+service Proposer {
+  rpc Rounds (RoundsRequest) returns (RoundsResponse);
+}
+
 service Configuration {
     // Signals a change in networking info
     rpc NewNetworkInfo (NewNetworkInfoRequest) returns (Empty);

--- a/types/src/generated/narwhal.rs
+++ b/types/src/generated/narwhal.rs
@@ -105,6 +105,24 @@ pub struct BincodeEncodedPayload {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Empty {
 }
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RoundsRequest {
+    //// The validator's key for which we want to retrieve
+    //// the available rounds.
+    #[prost(message, optional, tag="1")]
+    pub public_key: ::core::option::Option<PublicKey>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RoundsResponse {
+    //// The oldest round for which the node has available
+    //// blocks to propose for the defined validator.
+    #[prost(uint64, tag="1")]
+    pub oldest_round: u64,
+    //// The newest (latest) round for which the node has available
+    //// blocks to propose for the defined validator.
+    #[prost(uint64, tag="2")]
+    pub newest_round: u64,
+}
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum CollectionErrorType {
@@ -215,6 +233,91 @@ pub mod validator_client {
             let path = http::uri::PathAndQuery::from_static(
                 "/narwhal.Validator/RemoveCollections",
             );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+    }
+}
+/// Generated client implementations.
+pub mod proposer_client {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    //// The API that hosts the endpoints that should be used to help
+    //// proposing a block.
+    #[derive(Debug, Clone)]
+    pub struct ProposerClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl ProposerClient<tonic::transport::Channel> {
+        /// Attempt to create a new client by connecting to a given endpoint.
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> ProposerClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> ProposerClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
+        {
+            ProposerClient::new(InterceptedService::new(inner, interceptor))
+        }
+        /// Compress requests with `gzip`.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_gzip(mut self) -> Self {
+            self.inner = self.inner.send_gzip();
+            self
+        }
+        /// Enable decompressing responses with `gzip`.
+        #[must_use]
+        pub fn accept_gzip(mut self) -> Self {
+            self.inner = self.inner.accept_gzip();
+            self
+        }
+        pub async fn rounds(
+            &mut self,
+            request: impl tonic::IntoRequest<super::RoundsRequest>,
+        ) -> Result<tonic::Response<super::RoundsResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/narwhal.Proposer/Rounds");
             self.inner.unary(request.into_request(), path, codec).await
         }
     }
@@ -967,6 +1070,142 @@ pub mod validator_server {
     }
     impl<T: Validator> tonic::transport::NamedService for ValidatorServer<T> {
         const NAME: &'static str = "narwhal.Validator";
+    }
+}
+/// Generated server implementations.
+pub mod proposer_server {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    ///Generated trait containing gRPC methods that should be implemented for use with ProposerServer.
+    #[async_trait]
+    pub trait Proposer: Send + Sync + 'static {
+        async fn rounds(
+            &self,
+            request: tonic::Request<super::RoundsRequest>,
+        ) -> Result<tonic::Response<super::RoundsResponse>, tonic::Status>;
+    }
+    //// The API that hosts the endpoints that should be used to help
+    //// proposing a block.
+    #[derive(Debug)]
+    pub struct ProposerServer<T: Proposer> {
+        inner: _Inner<T>,
+        accept_compression_encodings: (),
+        send_compression_encodings: (),
+    }
+    struct _Inner<T>(Arc<T>);
+    impl<T: Proposer> ProposerServer<T> {
+        pub fn new(inner: T) -> Self {
+            Self::from_arc(Arc::new(inner))
+        }
+        pub fn from_arc(inner: Arc<T>) -> Self {
+            let inner = _Inner(inner);
+            Self {
+                inner,
+                accept_compression_encodings: Default::default(),
+                send_compression_encodings: Default::default(),
+            }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
+        where
+            F: tonic::service::Interceptor,
+        {
+            InterceptedService::new(Self::new(inner), interceptor)
+        }
+    }
+    impl<T, B> tonic::codegen::Service<http::Request<B>> for ProposerServer<T>
+    where
+        T: Proposer,
+        B: Body + Send + 'static,
+        B::Error: Into<StdError> + Send + 'static,
+    {
+        type Response = http::Response<tonic::body::BoxBody>;
+        type Error = std::convert::Infallible;
+        type Future = BoxFuture<Self::Response, Self::Error>;
+        fn poll_ready(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+        fn call(&mut self, req: http::Request<B>) -> Self::Future {
+            let inner = self.inner.clone();
+            match req.uri().path() {
+                "/narwhal.Proposer/Rounds" => {
+                    #[allow(non_camel_case_types)]
+                    struct RoundsSvc<T: Proposer>(pub Arc<T>);
+                    impl<T: Proposer> tonic::server::UnaryService<super::RoundsRequest>
+                    for RoundsSvc<T> {
+                        type Response = super::RoundsResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::RoundsRequest>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move { (*inner).rounds(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = RoundsSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                _ => {
+                    Box::pin(async move {
+                        Ok(
+                            http::Response::builder()
+                                .status(200)
+                                .header("grpc-status", "12")
+                                .header("content-type", "application/grpc")
+                                .body(empty_body())
+                                .unwrap(),
+                        )
+                    })
+                }
+            }
+        }
+    }
+    impl<T: Proposer> Clone for ProposerServer<T> {
+        fn clone(&self) -> Self {
+            let inner = self.inner.clone();
+            Self {
+                inner,
+                accept_compression_encodings: self.accept_compression_encodings,
+                send_compression_encodings: self.send_compression_encodings,
+            }
+        }
+    }
+    impl<T: Proposer> Clone for _Inner<T> {
+        fn clone(&self) -> Self {
+            Self(self.0.clone())
+        }
+    }
+    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{:?}", self.0)
+        }
+    }
+    impl<T: Proposer> tonic::transport::NamedService for ProposerServer<T> {
+        const NAME: &'static str = "narwhal.Proposer";
     }
 }
 /// Generated server implementations.

--- a/types/src/proto.rs
+++ b/types/src/proto.rs
@@ -4,7 +4,6 @@
 #[path = "generated/narwhal.rs"]
 #[rustfmt::skip]
 mod narwhal;
-use crypto::{ed25519::Ed25519PublicKey, traits::ToFromBytes};
 
 use std::{array::TryFromSliceError, ops::Deref};
 
@@ -12,6 +11,7 @@ use crate::{
     Batch, BatchDigest, BatchMessage, BlockError, BlockErrorKind, CertificateDigest, Transaction,
 };
 use bytes::{Buf, Bytes};
+use crypto::traits::VerifyingKey;
 
 pub use narwhal::{
     collection_retrieval_result::RetrievalResult,
@@ -21,6 +21,8 @@ pub use narwhal::{
     primary_to_primary_server::{PrimaryToPrimary, PrimaryToPrimaryServer},
     primary_to_worker_client::PrimaryToWorkerClient,
     primary_to_worker_server::{PrimaryToWorker, PrimaryToWorkerServer},
+    proposer_client::ProposerClient,
+    proposer_server::{Proposer, ProposerServer},
     transactions_client::TransactionsClient,
     transactions_server::{Transactions, TransactionsServer},
     validator_client::ValidatorClient,
@@ -33,23 +35,15 @@ pub use narwhal::{
     BincodeEncodedPayload, CertificateDigest as CertificateDigestProto, CollectionError,
     CollectionErrorType, CollectionRetrievalResult, Empty, GetCollectionsRequest,
     GetCollectionsResponse, MultiAddr as MultiAddrProto, NewNetworkInfoRequest,
-    PublicKey as PublicKeyProto, RemoveCollectionsRequest, Transaction as TransactionProto,
-    ValidatorData,
+    PublicKey as PublicKeyProto, RemoveCollectionsRequest, RoundsRequest, RoundsResponse,
+    Transaction as TransactionProto, ValidatorData,
 };
 
-impl From<Ed25519PublicKey> for PublicKeyProto {
-    fn from(pub_key: Ed25519PublicKey) -> Self {
+impl<PublicKey: VerifyingKey> From<PublicKey> for PublicKeyProto {
+    fn from(pub_key: PublicKey) -> Self {
         PublicKeyProto {
             bytes: Bytes::from(pub_key.as_ref().to_vec()),
         }
-    }
-}
-
-impl TryFrom<&PublicKeyProto> for Ed25519PublicKey {
-    type Error = crypto::traits::Error;
-
-    fn try_from(pub_key: &PublicKeyProto) -> Result<Self, Self::Error> {
-        Ed25519PublicKey::from_bytes(pub_key.bytes.as_ref())
     }
 }
 


### PR DESCRIPTION
Resolves: MystenLabs/narwhal#253 

Introduces the `rounds` endpoint under the validator api. Performed a small refactoring on some test helper methods of the `consensus` where moved functions under the `test_utils` crate.