### PR TITLE
fix: refactor log statements to event ones

### DIFF
--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
 thiserror = "1.0.30"
-tracing = { version = "0.1.34", features = ["log"] }
+tracing = "0.1.34"
 multiaddr = "0.14.0"
 
 crypto = { path = "../crypto" }

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -14,7 +14,7 @@ rand = { version = "0.7.3", features = ["small_rng"] }
 thiserror = "1.0.30"
 tokio = { version = "1.17.0", features = ["rt", "net", "sync", "macros", "time"] }
 tokio-util = { version = "0.7.1", features = ["codec"] }
-tracing = { version = "0.1.34", features = ["log"] }
+tracing = "0.1.34"
 types = { path = "../types" }
 crypto = { path = "../crypto" }
 tonic = { version = "0.7", features = ["tls"] }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -19,7 +19,7 @@ thiserror = "1.0.30"
 tokio = { version = "1.17.0", features = ["full"] }
 tokio-stream = "0.1.8"
 tokio-util = { version = "0.7.1", features = ["codec"] }
-tracing = { version = "0.1.34", features = ["log"] }
+tracing = "0.1.34"
 tracing-log = "0.1.3"
 tracing-subscriber = { version = "0.3.11", features = ["time", "env-filter"] }
 url = "2.2.2"

--- a/primary/Cargo.toml
+++ b/primary/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1.0.136", features = ["derive"] }
 thiserror = "1.0.30"
 tokio = { version = "1.17.0", features = ["sync", "rt", "macros"] }
 tokio-util = { version = "0.7.1", features = ["codec"] }
-tracing = { version = "0.1.34", features = ["log"] }
+tracing = "0.1.34"
 tonic = "0.7"
 prost = "0.10.1"
 rand = { version = "0.7.3", features = ["small_rng"] }

--- a/primary/src/block_synchronizer/mod.rs
+++ b/primary/src/block_synchronizer/mod.rs
@@ -28,7 +28,7 @@ use tokio::{
     sync::mpsc::{channel, Receiver, Sender},
     time::{sleep, timeout},
 };
-use tracing::log::{debug, error, warn};
+use tracing::{debug, error, trace, warn};
 use types::{BatchDigest, Certificate, CertificateDigest};
 
 #[cfg(test)]
@@ -725,6 +725,8 @@ impl<PublicKey: VerifyingKey> BlockSynchronizer<PublicKey> {
         loop {
             tokio::select! {
                 Some(response) = receiver.recv() => {
+                    trace!("Received response: {:?}", &response);
+
                     if peers.contains_peer(&response.from) {
                         // skip , we already got an answer from this peer
                         continue;
@@ -767,8 +769,8 @@ impl<PublicKey: VerifyingKey> BlockSynchronizer<PublicKey> {
                                 };
                             }
                         },
-                        Err(_) => {
-                            warn!("Got invalid certificates from peer");
+                        Err(err) => {
+                            warn!("Got invalid certificates from peer: {:?}", err);
                         }
                     }
                 },

--- a/primary/src/block_synchronizer/responses.rs
+++ b/primary/src/block_synchronizer/responses.rs
@@ -5,7 +5,7 @@ use config::Committee;
 use crypto::{traits::VerifyingKey, Digest, Hash};
 use std::fmt::{Display, Formatter};
 use thiserror::Error;
-use tracing::log::{error, warn};
+use tracing::{error, warn};
 use types::{Certificate, CertificateDigest};
 
 // RequestID helps us identify an incoming request and
@@ -109,7 +109,17 @@ impl<PublicKey: VerifyingKey> CertificatesResponse<PublicKey> {
         let invalid_certificates: Vec<Certificate<PublicKey>> = peer_found_certs
             .clone()
             .into_iter()
-            .filter(|c| c.verify(committee).is_err())
+            .filter(|c| {
+                if let Err(err) = c.verify(committee) {
+                    error!(
+                        "Certificate verification failed for id {} with error {:?}",
+                        c.digest(),
+                        err
+                    );
+                    return true;
+                }
+                false
+            })
             .collect();
 
         if !invalid_certificates.is_empty() {

--- a/primary/src/block_synchronizer/tests/block_synchronizer_tests.rs
+++ b/primary/src/block_synchronizer/tests/block_synchronizer_tests.rs
@@ -30,7 +30,7 @@ use tokio::{
     time::{sleep, timeout},
 };
 
-use tracing::log::debug;
+use tracing::debug;
 use types::{Certificate, CertificateDigest};
 
 #[tokio::test]

--- a/primary/src/block_waiter.rs
+++ b/primary/src/block_waiter.rs
@@ -19,7 +19,7 @@ use tokio::{
     sync::{mpsc::Receiver, oneshot},
     time::timeout,
 };
-use tracing::{error, instrument, log::debug, warn};
+use tracing::{debug, error, instrument, warn};
 use types::{
     BatchDigest, BatchMessage, BlockError, BlockErrorKind, BlockResult, Certificate,
     CertificateDigest, Header,

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -16,7 +16,7 @@ futures = "0.3.21"
 serde = { version = "1.0.136", features = ["derive"] }
 tokio = { version = "1.17.0", features = ["sync", "rt", "macros"] }
 tokio-util = { version = "0.7.1", features = ["codec"] }
-tracing = { version = "0.1.34", features = ["log"] }
+tracing = "0.1.34"
 tonic = "0.7"
 tokio-stream = "0.1.8"
 tower = "0.4.12"


### PR DESCRIPTION
A quick fix to change the `tracing::log` statements to `tracing` events as those are properly logged via our tracing capability and it's the practice used from the rest of the codebase. Also added a few more event statements.