### PR TITLE
feat: generate signed certificates in Mocks

### DIFF
--- a/consensus/benches/process_certificates.rs
+++ b/consensus/benches/process_certificates.rs
@@ -32,7 +32,7 @@ pub fn process_certificates(c: &mut Criterion) {
             .iter()
             .map(|x| x.digest())
             .collect::<BTreeSet<_>>();
-        let (certificates, _next_parents) = make_optimal_certificates(1, rounds, &genesis, &keys);
+        let (certificates, _next_parents) = make_optimal_certificates(1..=rounds, &genesis, &keys);
         let committee = mock_committee(&keys);
 
         let store_path = temp_dir();

--- a/consensus/src/tests/consensus_tests.rs
+++ b/consensus/src/tests/consensus_tests.rs
@@ -79,7 +79,7 @@ async fn commit_one() {
         .map(|x| x.digest())
         .collect::<BTreeSet<_>>();
     let (mut certificates, next_parents) =
-        test_utils::make_optimal_certificates(1, 4, &genesis, &keys);
+        test_utils::make_optimal_certificates(1..=4, &genesis, &keys);
 
     // Make one certificate with round 5 to trigger the commits.
     let (_, certificate) = test_utils::mock_certificate(keys[0].clone(), 5, next_parents);
@@ -133,7 +133,7 @@ async fn dead_node() {
         .map(|x| x.digest())
         .collect::<BTreeSet<_>>();
 
-    let (mut certificates, _) = test_utils::make_optimal_certificates(1, 9, &genesis, &keys);
+    let (mut certificates, _) = test_utils::make_optimal_certificates(1..=9, &genesis, &keys);
 
     // Spawn the consensus engine and sink the primary channel.
     let (tx_waiter, rx_waiter) = channel(1);
@@ -186,7 +186,7 @@ async fn not_enough_support() {
 
     // Round 1: Fully connected graph.
     let nodes: Vec<_> = keys.iter().take(3).cloned().collect();
-    let (out, parents) = test_utils::make_optimal_certificates(1, 1, &genesis, &nodes);
+    let (out, parents) = test_utils::make_optimal_certificates(1..=1, &genesis, &nodes);
     certificates.extend(out);
 
     // Round 2: Fully connect graph. But remember the digest of the leader. Note that this
@@ -196,7 +196,7 @@ async fn not_enough_support() {
     certificates.push_back(certificate);
 
     let nodes: Vec<_> = keys.iter().skip(1).cloned().collect();
-    let (out, mut parents) = test_utils::make_optimal_certificates(2, 2, &parents, &nodes);
+    let (out, mut parents) = test_utils::make_optimal_certificates(2..=2, &parents, &nodes);
     certificates.extend(out);
 
     // Round 3: Only node 0 links to the leader of round 2.
@@ -222,7 +222,7 @@ async fn not_enough_support() {
 
     // Rounds 4, 5, and 6: Fully connected graph.
     let nodes: Vec<_> = keys.iter().take(3).cloned().collect();
-    let (out, parents) = test_utils::make_optimal_certificates(4, 6, &parents, &nodes);
+    let (out, parents) = test_utils::make_optimal_certificates(4..=6, &parents, &nodes);
     certificates.extend(out);
 
     // Round 7: Send a single certificate to trigger the commits.
@@ -286,11 +286,11 @@ async fn missing_leader() {
 
     // Remove the leader for rounds 1 and 2.
     let nodes: Vec<_> = keys.iter().skip(1).cloned().collect();
-    let (out, parents) = test_utils::make_optimal_certificates(1, 2, &genesis, &nodes);
+    let (out, parents) = test_utils::make_optimal_certificates(1..=2, &genesis, &nodes);
     certificates.extend(out);
 
     // Add back the leader for rounds 3, 4, 5 and 6.
-    let (out, parents) = test_utils::make_optimal_certificates(3, 6, &parents, &keys);
+    let (out, parents) = test_utils::make_optimal_certificates(3..=6, &parents, &keys);
     certificates.extend(out);
 
     // Add a certificate of round 7 to commit the leader of round 4.

--- a/consensus/src/tests/dag_tests.rs
+++ b/consensus/src/tests/dag_tests.rs
@@ -25,7 +25,7 @@ async fn inner_dag_insert_one() {
         .iter()
         .map(|x| x.digest())
         .collect::<BTreeSet<_>>();
-    let (mut certificates, _next_parents) = make_optimal_certificates(1, 4, &genesis, &keys);
+    let (mut certificates, _next_parents) = make_optimal_certificates(1..=4, &genesis, &keys);
 
     // set up a Dag
     let (tx_cert, rx_cert) = channel(1);
@@ -52,7 +52,7 @@ async fn dag_mutation_failures() {
         .iter()
         .map(|x| x.digest())
         .collect::<BTreeSet<_>>();
-    let (certificates, _next_parents) = make_optimal_certificates(1, 4, &genesis, &keys);
+    let (certificates, _next_parents) = make_optimal_certificates(1..=4, &genesis, &keys);
 
     // set up a Dag
     let (_tx_cert, rx_cert) = channel(1);
@@ -123,7 +123,7 @@ async fn dag_insert_one_and_rounds_node_read() {
         .iter()
         .map(|x| x.digest())
         .collect::<BTreeSet<_>>();
-    let (certificates, _next_parents) = make_optimal_certificates(1, 4, &genesis, &keys);
+    let (certificates, _next_parents) = make_optimal_certificates(1..=4, &genesis, &keys);
 
     // set up a Dag
     let (_tx_cert, rx_cert) = channel(1);
@@ -171,7 +171,7 @@ async fn dag_insert_and_remove_reads() {
         .iter()
         .map(|x| x.digest())
         .collect::<BTreeSet<_>>();
-    let (mut certificates, _next_parents) = make_optimal_certificates(1, 4, &genesis, &keys);
+    let (mut certificates, _next_parents) = make_optimal_certificates(1..=4, &genesis, &keys);
 
     // set up a Dag
     let (_tx_cert, rx_cert) = channel(1);

--- a/consensus/src/tests/subscriber_tests.rs
+++ b/consensus/src/tests/subscriber_tests.rs
@@ -21,7 +21,7 @@ pub fn commit_certificates() -> VecDeque<Certificate<Ed25519PublicKey>> {
         .map(|x| x.digest())
         .collect::<BTreeSet<_>>();
     let (mut certificates, next_parents) =
-        test_utils::make_optimal_certificates(1, 4, &genesis, &keys);
+        test_utils::make_optimal_certificates(1..=4, &genesis, &keys);
 
     // Make one certificate with round 5 to trigger the commits.
     let (_, certificate) = test_utils::mock_certificate(keys[0].clone(), 5, next_parents);

--- a/consensus/src/tusk.rs
+++ b/consensus/src/tusk.rs
@@ -418,7 +418,7 @@ mod tests {
             .map(|x| x.digest())
             .collect::<BTreeSet<_>>();
         let (certificates, _next_parents) =
-            test_utils::make_optimal_certificates(1, rounds, &genesis, &keys);
+            test_utils::make_optimal_certificates(1..=rounds, &genesis, &keys);
         let committee = mock_committee(&keys);
 
         let store_path = test_utils::temp_dir();
@@ -469,7 +469,7 @@ mod tests {
             .collect::<BTreeSet<_>>();
         // TODO: evidence that this test fails when `failure_probability` parameter >= 1/3
         let (certificates, _next_parents) =
-            test_utils::make_certificates(1, rounds, &genesis, &keys, 0.333);
+            test_utils::make_certificates(1..=rounds, &genesis, &keys, 0.333);
         let committee = mock_committee(&keys);
 
         let store_path = test_utils::temp_dir();

--- a/primary/src/block_synchronizer/tests/block_synchronizer_tests.rs
+++ b/primary/src/block_synchronizer/tests/block_synchronizer_tests.rs
@@ -12,7 +12,6 @@ use crate::{
 use bincode::deserialize;
 use config::BlockSynchronizerParameters;
 use crypto::{ed25519::Ed25519PublicKey, Hash};
-use ed25519_dalek::Signer;
 use futures::{future::try_join_all, stream::FuturesUnordered};
 use network::{PrimaryNetwork, PrimaryToWorkerNetwork};
 use serde::de::DeserializeOwned;
@@ -61,7 +60,8 @@ async fn test_successful_headers_synchronization() {
         let header = fixture_header_builder()
             .with_payload_batch(batch_1.clone(), worker_id_0)
             .with_payload_batch(batch_2.clone(), worker_id_1)
-            .build(|payload| key.sign(payload));
+            .build(&key)
+            .unwrap();
 
         let certificate = certificate(&header);
 
@@ -216,7 +216,8 @@ async fn test_successful_payload_synchronization() {
         let header = fixture_header_builder()
             .with_payload_batch(batch_1.clone(), worker_id_0)
             .with_payload_batch(batch_2.clone(), worker_id_1)
-            .build(|payload| key.sign(payload));
+            .build(&key)
+            .unwrap();
 
         let certificate = certificate(&header);
 
@@ -407,7 +408,8 @@ async fn test_multiple_overlapping_requests() {
     for _ in 0..5 {
         let header = fixture_header_builder()
             .with_payload_batch(fixture_batch_with_transactions(10), 0)
-            .build(|payload| key.sign(payload));
+            .build(&key)
+            .unwrap();
 
         let certificate = certificate(&header);
 
@@ -519,7 +521,8 @@ async fn test_timeout_while_waiting_for_certificates() {
         .map(|_| {
             let header = fixture_header_builder()
                 .with_payload_batch(fixture_batch_with_transactions(10), 0)
-                .build(|payload| key.sign(payload));
+                .build(&key)
+                .unwrap();
 
             certificate(&header).digest()
         })
@@ -629,7 +632,8 @@ async fn test_reply_with_certificates_already_in_storage() {
 
         let header = fixture_header_builder()
             .with_payload_batch(batch.clone(), 0)
-            .build(|payload| key.sign(payload));
+            .build(&key)
+            .unwrap();
 
         let certificate = certificate(&header);
 
@@ -720,7 +724,8 @@ async fn test_reply_with_payload_already_in_storage() {
 
         let header = fixture_header_builder()
             .with_payload_batch(batch.clone(), 0)
-            .build(|payload| key.sign(payload));
+            .build(&key)
+            .unwrap();
 
         let certificate: Certificate<Ed25519PublicKey> = certificate(&header);
 

--- a/primary/src/tests/block_remover_tests.rs
+++ b/primary/src/tests/block_remover_tests.rs
@@ -11,11 +11,7 @@ use crate::{
 use bincode::deserialize;
 use config::{Committee, WorkerId};
 use consensus::dag::Dag;
-use crypto::{
-    ed25519::Ed25519PublicKey,
-    traits::{Signer, VerifyingKey},
-    Hash,
-};
+use crypto::{ed25519::Ed25519PublicKey, traits::VerifyingKey, Hash};
 use futures::{
     future::{join_all, try_join_all},
     stream::FuturesUnordered,
@@ -79,7 +75,8 @@ async fn test_successful_blocks_delete() {
         let header = fixture_header_builder()
             .with_payload_batch(batch_1.clone(), worker_id_0)
             .with_payload_batch(batch_2.clone(), worker_id_1)
-            .build(|payload| key.sign(payload));
+            .build(&key)
+            .unwrap();
 
         let certificate = certificate(&header);
         let block_id = certificate.digest();
@@ -227,7 +224,8 @@ async fn test_timeout() {
         let header = fixture_header_builder()
             .with_payload_batch(batch_1.clone(), worker_id_2)
             .with_payload_batch(batch_2.clone(), worker_id_3)
-            .build(|payload| key.sign(payload));
+            .build(&key)
+            .unwrap();
 
         let certificate = certificate(&header);
         let block_id = certificate.digest();
@@ -352,7 +350,8 @@ async fn test_unlocking_pending_requests() {
     let batch = fixture_batch_with_transactions(10);
     let header = fixture_header_builder()
         .with_payload_batch(batch.clone(), worker_id_0)
-        .build(|payload| key.sign(payload));
+        .build(&key)
+        .unwrap();
 
     let certificate = certificate(&header);
     let block_id = certificate.digest();

--- a/primary/src/tests/block_waiter_tests.rs
+++ b/primary/src/tests/block_waiter_tests.rs
@@ -9,7 +9,6 @@ use crate::{
 };
 use bincode::deserialize;
 use crypto::{ed25519::Ed25519PublicKey, traits::VerifyingKey, Hash};
-use ed25519_dalek::Signer;
 use mockall::*;
 use network::PrimaryToWorkerNetwork;
 use std::collections::HashMap;
@@ -147,7 +146,8 @@ async fn test_successfully_retrieve_multiple_blocks() {
         let header = fixture_header_builder()
             .with_payload_batch(batch_1.clone(), worker_id)
             .with_payload_batch(batch_2.clone(), worker_id)
-            .build(|payload| key.sign(payload));
+            .build(&key)
+            .unwrap();
 
         let certificate = certificate(&header);
         certificates.push(certificate.clone());

--- a/primary/src/tests/helper_tests.rs
+++ b/primary/src/tests/helper_tests.rs
@@ -4,7 +4,6 @@ use crate::{common::create_db_stores, helper::Helper, primary::PrimaryMessage, P
 use bincode::Options;
 use config::WorkerId;
 use crypto::{ed25519::Ed25519PublicKey, Hash};
-use ed25519_dalek::Signer;
 use itertools::Itertools;
 use std::{
     borrow::Borrow,
@@ -42,7 +41,8 @@ async fn test_process_certificates_stream_mode() {
     for _ in 0..5 {
         let header = fixture_header_builder()
             .with_payload_batch(fixture_batch_with_transactions(10), 0)
-            .build(|payload| key.sign(payload));
+            .build(&key)
+            .unwrap();
 
         let certificate = certificate(&header);
         let id = certificate.clone().digest();
@@ -114,7 +114,8 @@ async fn test_process_certificates_batch_mode() {
     for i in 0..10 {
         let header = fixture_header_builder()
             .with_payload_batch(fixture_batch_with_transactions(10), 0)
-            .build(|payload| key.sign(payload));
+            .build(&key)
+            .unwrap();
 
         let certificate = certificate(&header);
         let id = certificate.clone().digest();
@@ -205,7 +206,8 @@ async fn test_process_payload_availability_success() {
     for i in 0..10 {
         let header = fixture_header_builder()
             .with_payload_batch(fixture_batch_with_transactions(10), 0)
-            .build(|payload| key.sign(payload));
+            .build(&key)
+            .unwrap();
 
         let certificate = certificate(&header);
         let id = certificate.clone().digest();
@@ -314,7 +316,8 @@ async fn test_process_payload_availability_when_failures() {
     for _ in 0..10 {
         let header = fixture_header_builder()
             .with_payload_batch(fixture_batch_with_transactions(10), 0)
-            .build(|payload| key.sign(payload));
+            .build(&key)
+            .unwrap();
 
         let certificate = certificate(&header);
         let id = certificate.clone().digest();

--- a/primary/tests/integration_tests.rs
+++ b/primary/tests/integration_tests.rs
@@ -5,7 +5,7 @@ use config::{Parameters, WorkerId};
 use consensus::dag::Dag;
 use crypto::{
     ed25519::{Ed25519KeyPair, Ed25519PublicKey},
-    traits::{KeyPair, Signer},
+    traits::KeyPair,
     Hash,
 };
 use futures::future::join_all;
@@ -57,7 +57,8 @@ async fn test_get_collections() {
 
         let header = fixture_header_builder()
             .with_payload_batch(batch.clone(), worker_id)
-            .build(|payload| key.sign(payload));
+            .build(&key)
+            .unwrap();
 
         let certificate = certificate(&header);
         let block_id = certificate.digest();
@@ -230,7 +231,8 @@ async fn test_remove_collections() {
 
         let header = fixture_header_builder()
             .with_payload_batch(batch.clone(), worker_id)
-            .build(|payload| key.sign(payload));
+            .build(&key)
+            .unwrap();
 
         let certificate = certificate(&header);
         let block_id = certificate.digest();
@@ -641,7 +643,8 @@ async fn fixture_certificate(
                 .collect(),
         )
         .payload(payload)
-        .build(|p| key.sign(p));
+        .build(&key)
+        .unwrap();
 
     let certificate = certificate(&header);
 

--- a/primary/tests/integration_tests_proposer_api.rs
+++ b/primary/tests/integration_tests_proposer_api.rs
@@ -152,7 +152,7 @@ async fn test_rounds_return_successful_response() {
         .iter()
         .map(|x| x.digest())
         .collect::<BTreeSet<_>>();
-    let (mut certificates, _next_parents) = make_optimal_certificates(1, 4, &genesis, &keys);
+    let (mut certificates, _next_parents) = make_optimal_certificates(1..=4, &genesis, &keys);
 
     // Feed the certificates to the Dag
     while let Some(certificate) = genesis_certs.pop() {

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -563,7 +563,7 @@ pub fn make_optimal_signed_certificates(
     make_signed_certificates(range, initial_parents, keys, 0.0)
 }
 
-// Bernouilli-samples from a set of ancestors passed as a argument,
+// Bernoulli-samples from a set of ancestors passed as a argument,
 fn this_cert_parents(
     ancestors: &BTreeSet<CertificateDigest>,
     failure_prob: f64,


### PR DESCRIPTION
- adds mock_signed_certificate, make_signed_certificates, make_optimal_signed_certificates alongside their unsigned variants,
- they all take a row of private keys which will all sign the cert,
- refactors the mocks to avoid code duplication,
- refactors the `HeaderBuilder::build` method to use the `Signer` impl on keypairs rather than a bespoke closure.

(dozens of tests run through these functions)
This should unblock #258.