### PR TITLE
[refactor] Batch digests and serialized batch digests

### DIFF
--- a/executor/src/batch_loader.rs
+++ b/executor/src/batch_loader.rs
@@ -17,8 +17,8 @@ use tokio::{
     task::JoinHandle,
 };
 use tracing::warn;
+use types::SerializedBatchMessage;
 use types::{BatchDigest, BincodeEncodedPayload, ClientBatchRequest, WorkerToWorkerClient};
-use worker::SerializedBatchMessage;
 
 /// Download transactions data from the consensus workers and notifies the called when the job is done.
 pub struct BatchLoader<PublicKey: VerifyingKey> {

--- a/executor/src/core.rs
+++ b/executor/src/core.rs
@@ -15,8 +15,8 @@ use tokio::{
     task::JoinHandle,
 };
 use tracing::debug;
-use types::{Batch, BatchDigest};
-use worker::{SerializedBatchMessage, WorkerMessage};
+use types::{Batch, BatchDigest, SerializedBatchMessage};
+use worker::WorkerMessage;
 
 #[cfg(test)]
 #[path = "tests/executor_tests.rs"]

--- a/executor/src/lib.rs
+++ b/executor/src/lib.rs
@@ -34,8 +34,7 @@ use tokio::{
     task::JoinHandle,
 };
 use tracing::info;
-use types::BatchDigest;
-use worker::SerializedBatchMessage;
+use types::{BatchDigest, SerializedBatchMessage};
 
 /// Default inter-task channel size.
 pub const DEFAULT_CHANNEL_SIZE: usize = 1_000;

--- a/executor/src/subscriber.rs
+++ b/executor/src/subscriber.rs
@@ -17,8 +17,7 @@ use tokio::{
     task::JoinHandle,
 };
 use tracing::debug;
-use types::BatchDigest;
-use worker::SerializedBatchMessage;
+use types::{BatchDigest, SerializedBatchMessage};
 
 #[cfg(test)]
 #[path = "tests/subscriber_tests.rs"]

--- a/executor/src/tests/fixtures.rs
+++ b/executor/src/tests/fixtures.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use blake2::digest::Update;
+
 use config::WorkerId;
 use crypto::ed25519::Ed25519PublicKey;
 use rand::{rngs::StdRng, RngCore, SeedableRng};
@@ -11,7 +11,9 @@ use store::{
     rocks::{open_cf, DBMap},
     Store,
 };
-use types::{Batch, BatchDigest, Certificate, Header, SerializedBatchMessage};
+use types::{
+    serialized_batch_digest, Batch, BatchDigest, Certificate, Header, SerializedBatchMessage,
+};
 use worker::WorkerMessage;
 
 /// A test batch containing specific transactions.
@@ -22,7 +24,7 @@ pub fn test_batch<T: Serialize>(transactions: Vec<T>) -> (BatchDigest, Serialize
         .collect();
     let message = WorkerMessage::<Ed25519PublicKey>::Batch(Batch(batch));
     let serialized = bincode::serialize(&message).unwrap();
-    let digest = BatchDigest::new(crypto::blake2b_256(|hasher| hasher.update(&serialized)));
+    let digest = serialized_batch_digest(&serialized);
     (digest, serialized)
 }
 

--- a/executor/src/tests/fixtures.rs
+++ b/executor/src/tests/fixtures.rs
@@ -11,8 +11,8 @@ use store::{
     rocks::{open_cf, DBMap},
     Store,
 };
-use types::{Batch, BatchDigest, Certificate, Header};
-use worker::{SerializedBatchMessage, WorkerMessage};
+use types::{Batch, BatchDigest, Certificate, Header, SerializedBatchMessage};
+use worker::WorkerMessage;
 
 /// A test batch containing specific transactions.
 pub fn test_batch<T: Serialize>(transactions: Vec<T>) -> (BatchDigest, SerializedBatchMessage) {

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -16,8 +16,11 @@ use tokio::{
     task::JoinHandle,
 };
 use tracing::debug;
-use types::{BatchDigest, Certificate, CertificateDigest, Header, HeaderDigest, Round};
-use worker::{SerializedBatchMessage, Worker};
+use types::{
+    BatchDigest, Certificate, CertificateDigest, Header, HeaderDigest, Round,
+    SerializedBatchMessage,
+};
+use worker::Worker;
 
 /// All the data stores of the node.
 pub struct NodeStorage<PublicKey: VerifyingKey> {

--- a/primary/tests/integration_tests.rs
+++ b/primary/tests/integration_tests.rs
@@ -26,9 +26,9 @@ use types::{
     Batch, BatchDigest, Certificate, CertificateDigest, CertificateDigestProto,
     CollectionRetrievalResult, ConfigurationClient, Empty, GetCollectionsRequest, Header,
     HeaderDigest, MultiAddrProto, NewNetworkInfoRequest, PublicKeyProto, RemoveCollectionsRequest,
-    RetrievalResult, ValidatorClient, ValidatorData,
+    RetrievalResult, SerializedBatchMessage, ValidatorClient, ValidatorData,
 };
-use worker::{SerializedBatchMessage, Worker, WorkerMessage};
+use worker::{Worker, WorkerMessage};
 
 #[tokio::test]
 async fn test_get_collections() {

--- a/primary/tests/integration_tests.rs
+++ b/primary/tests/integration_tests.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use blake2::digest::Update;
+
 use config::{Parameters, WorkerId};
 use consensus::dag::Dag;
 use crypto::{
@@ -23,10 +23,11 @@ use test_utils::{
 use tokio::sync::mpsc::channel;
 use tonic::transport::Channel;
 use types::{
-    Batch, BatchDigest, Certificate, CertificateDigest, CertificateDigestProto,
-    CollectionRetrievalResult, ConfigurationClient, Empty, GetCollectionsRequest, Header,
-    HeaderDigest, MultiAddrProto, NewNetworkInfoRequest, PublicKeyProto, RemoveCollectionsRequest,
-    RetrievalResult, SerializedBatchMessage, ValidatorClient, ValidatorData,
+    serialized_batch_digest, Batch, BatchDigest, Certificate, CertificateDigest,
+    CertificateDigestProto, CollectionRetrievalResult, ConfigurationClient, Empty,
+    GetCollectionsRequest, Header, HeaderDigest, MultiAddrProto, NewNetworkInfoRequest,
+    PublicKeyProto, RemoveCollectionsRequest, RetrievalResult, SerializedBatchMessage,
+    ValidatorClient, ValidatorData,
 };
 use worker::{Worker, WorkerMessage};
 
@@ -625,9 +626,7 @@ async fn fixture_certificate(
     // TODO: refactor this when the above is changed/fixed.
     let message = WorkerMessage::<Ed25519PublicKey>::Batch(batch.clone());
     let serialized_batch = bincode::serialize(&message).unwrap();
-    let batch_digest = BatchDigest::new(crypto::blake2b_256(|hasher| {
-        hasher.update(&serialized_batch)
-    }));
+    let batch_digest = serialized_batch_digest(&serialized_batch);
 
     let mut payload = BTreeMap::new();
     payload.insert(batch_digest, worker_id);

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -526,8 +526,8 @@ pub fn batch_with_transactions(num_of_transactions: usize) -> Batch {
 
 const BATCHES_CF: &str = "batches";
 
-pub fn open_batch_store() -> Store<BatchDigest, worker::SerializedBatchMessage> {
-    let db = rocks::DBMap::<BatchDigest, worker::SerializedBatchMessage>::open(
+pub fn open_batch_store() -> Store<BatchDigest, types::SerializedBatchMessage> {
+    let db = rocks::DBMap::<BatchDigest, types::SerializedBatchMessage>::open(
         temp_dir(),
         None,
         Some(BATCHES_CF),

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -477,17 +477,12 @@ pub fn batch() -> Batch {
 
 // Fixture
 pub fn batch_digest() -> BatchDigest {
-    resolve_batch_digest(serialized_batch())
+    serialized_batch_digest(&serialized_batch())
 }
 
 pub fn digest_batch(batch: Batch) -> BatchDigest {
     let serialized_batch = serialize_batch_message(batch);
-    resolve_batch_digest(serialized_batch)
-}
-
-// Fixture
-pub fn resolve_batch_digest(batch_serialised: Vec<u8>) -> BatchDigest {
-    serialized_batch_digest(&batch_serialised)
+    serialized_batch_digest(&serialized_batch)
 }
 
 // Fixture

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -252,7 +252,12 @@ pub fn fixture_header_with_payload(number_of_batches: u8) -> Header<Ed25519Publi
     let mut payload: BTreeMap<BatchDigest, WorkerId> = BTreeMap::new();
 
     for i in 0..number_of_batches {
-        let dummy_serialized_batch = vec![10u8, 5u8, 8u8, 20u8, i];
+        let dummy_serialized_batch = vec![
+            0u8, 0u8, 0u8, 0u8, // enum variant prefix
+            1u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, // num txes
+            5u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, // tx length
+            10u8, 5u8, 8u8, 20u8, i, //tx
+        ];
         let batch_digest = serialized_batch_digest(&dummy_serialized_batch);
 
         payload.insert(batch_digest, 0);

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -13,25 +13,27 @@ blake2 = "0.9"
 bytes = "1.1.0"
 derive_builder = "0.11.2"
 ed25519-dalek = "1.0.1"
+proptest = "1.0.0"
+proptest-derive = "0.3.0"
+prost = "0.10"
 rand = "0.7.3"
 serde = { version = "1.0.136", features = ["derive"] }
 store = { git = "https://github.com/mystenlabs/mysten-infra.git", package = "typed-store", rev = "7c247967e5a5abd59ecaa75bc62b05bcdf4503fe" }
 thiserror = "1.0.30"
 tokio = { version = "1.17.0", features = ["sync", "rt", "macros"] }
 tokio-util = { version = "0.7.1", features = ["codec"] }
-prost = "0.10"
 tonic = { version = "0.7", features = ["tls"] }
 
 config = { path = "../config" }
 crypto = { path = "../crypto" }
 dag = { path = "../dag" }
 
+[dev-dependencies]
+hex = "0.4.3"
+prost-build = "0.10.1"
+serde_test = "1.0.137"
+tonic-build = { version = "0.7", features = [ "prost", "transport" ] }
+
 [features]
 default = []
 test = []
-
-[dev-dependencies]
-tonic-build = { version = "0.7", features = [ "prost", "transport" ] }
-prost-build = "0.10.1"
-serde_test = "1.0.137"
-hex = "0.4.3"

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -17,7 +17,6 @@ proptest = "1.0.0"
 proptest-derive = "0.3.0"
 prost = "0.10"
 rand = "0.7.3"
-scroll = { version = "0.11.0", features = ["derive"] }
 serde = { version = "1.0.136", features = ["derive"] }
 store = { git = "https://github.com/mystenlabs/mysten-infra.git", package = "typed-store", rev = "7c247967e5a5abd59ecaa75bc62b05bcdf4503fe" }
 thiserror = "1.0.30"

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -34,3 +34,4 @@ test = []
 tonic-build = { version = "0.7", features = [ "prost", "transport" ] }
 prost-build = "0.10.1"
 serde_test = "1.0.137"
+hex = "0.4.3"

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -33,3 +33,4 @@ test = []
 [dev-dependencies]
 tonic-build = { version = "0.7", features = [ "prost", "transport" ] }
 prost-build = "0.10.1"
+serde_test = "1.0.137"

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -17,6 +17,7 @@ proptest = "1.0.0"
 proptest-derive = "0.3.0"
 prost = "0.10"
 rand = "0.7.3"
+scroll = { version = "0.11.0", features = ["derive"] }
 serde = { version = "1.0.136", features = ["derive"] }
 store = { git = "https://github.com/mystenlabs/mysten-infra.git", package = "typed-store", rev = "7c247967e5a5abd59ecaa75bc62b05bcdf4503fe" }
 thiserror = "1.0.30"
@@ -28,12 +29,18 @@ config = { path = "../config" }
 crypto = { path = "../crypto" }
 dag = { path = "../dag" }
 
+
 [dev-dependencies]
 hex = "0.4.3"
 prost-build = "0.10.1"
 serde_test = "1.0.137"
 tonic-build = { version = "0.7", features = [ "prost", "transport" ] }
+criterion = "0.3.5"
 
 [features]
 default = []
 test = []
+
+[[bench]]
+name = "batch_digest"
+harness = false

--- a/types/benches/batch_digest.rs
+++ b/types/benches/batch_digest.rs
@@ -3,9 +3,9 @@
 use criterion::{
     criterion_group, criterion_main, BenchmarkId, Criterion, SamplingMode, Throughput,
 };
-use crypto::ed25519::Ed25519PublicKey;
+use crypto::{ed25519::Ed25519PublicKey, Hash};
 use rand::Rng;
-use types::{hash_all_transactions, serialized_batch_digest, Batch, WorkerMessage};
+use types::{serialized_batch_digest, Batch, WorkerMessage};
 
 pub fn batch_digest(c: &mut Criterion) {
     let mut digest_group = c.benchmark_group("Batch digests");
@@ -30,11 +30,9 @@ pub fn batch_digest(c: &mut Criterion) {
             &serialized_batch,
             |b, i| b.iter(|| serialized_batch_digest(i)),
         );
-        digest_group.bench_with_input(
-            BenchmarkId::new("iterating through serialized batch digest", size),
-            &serialized_batch,
-            |b, i| b.iter(|| hash_all_transactions(i).unwrap()),
-        );
+        digest_group.bench_with_input(BenchmarkId::new("batch digest", size), &batch, |b, i| {
+            b.iter(|| i.digest())
+        });
     }
 }
 

--- a/types/benches/batch_digest.rs
+++ b/types/benches/batch_digest.rs
@@ -1,0 +1,46 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use criterion::{
+    criterion_group, criterion_main, BenchmarkId, Criterion, SamplingMode, Throughput,
+};
+use crypto::ed25519::Ed25519PublicKey;
+use rand::Rng;
+use types::{hash_all_transactions, serialized_batch_digest, Batch, WorkerMessage};
+
+pub fn batch_digest(c: &mut Criterion) {
+    let mut digest_group = c.benchmark_group("Batch digests");
+    digest_group.sampling_mode(SamplingMode::Flat);
+
+    static BATCH_SIZES: [usize; 4] = [100, 500, 1000, 5000];
+
+    for size in BATCH_SIZES {
+        let tx_gen = || {
+            (0..512)
+                .map(|_| rand::thread_rng().gen())
+                .collect::<Vec<u8>>()
+        };
+        let batch = Batch((0..size).map(|_| tx_gen()).collect::<Vec<_>>());
+        let message = WorkerMessage::<Ed25519PublicKey>::Batch(batch.clone());
+        let serialized_batch = bincode::serialize(&message).unwrap();
+
+        digest_group.throughput(Throughput::Bytes(512 * size as u64));
+
+        digest_group.bench_with_input(
+            BenchmarkId::new("serialized batch digest", size),
+            &serialized_batch,
+            |b, i| b.iter(|| serialized_batch_digest(i)),
+        );
+        digest_group.bench_with_input(
+            BenchmarkId::new("iterating through serialized batch digest", size),
+            &serialized_batch,
+            |b, i| b.iter(|| hash_all_transactions(i).unwrap()),
+        );
+    }
+}
+
+criterion_group! {
+    name = consensus_group;
+    config = Criterion::default();
+    targets = batch_digest
+}
+criterion_main!(consensus_group);

--- a/types/src/primary.rs
+++ b/types/src/primary.rs
@@ -15,6 +15,7 @@ use crypto::{
 };
 use dag::node_dag::Affiliated;
 use derive_builder::Builder;
+use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{BTreeMap, BTreeSet, HashSet},
@@ -26,7 +27,7 @@ use std::{
 pub type Round = u64;
 
 pub type Transaction = Vec<u8>;
-#[derive(Clone, Serialize, Deserialize, Default, Debug, PartialEq, Eq)]
+#[derive(Clone, Serialize, Deserialize, Default, Debug, PartialEq, Eq, Arbitrary)]
 pub struct Batch(pub Vec<Transaction>);
 
 #[derive(Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]

--- a/types/src/worker.rs
+++ b/types/src/worker.rs
@@ -18,3 +18,6 @@ pub enum WorkerMessage<PublicKey: VerifyingKey> {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ClientBatchRequest(pub Vec<BatchDigest>);
+
+/// Indicates a serialized `WorkerMessage::Batch` message.
+pub type SerializedBatchMessage = Vec<u8>;

--- a/types/src/worker.rs
+++ b/types/src/worker.rs
@@ -24,8 +24,35 @@ pub struct ClientBatchRequest(pub Vec<BatchDigest>);
 /// Indicates a serialized `WorkerMessage::Batch` message.
 pub type SerializedBatchMessage = Vec<u8>;
 
+/// Hashes a serialized batch message without deserializing it into a batch.
+///
+/// See the test `test_batch_and_serialized`, which guarantees that the output of this
+/// function remains the same as the [`Hash::digest`] result you would get from [`Batch`].
+/// See also the micro-benchmark `batch_digest`, which checks the performance of this is
+/// identical to hashing a serialized batch.
+///
+/// TODO: remove the expects in the below, making this return a `Result` and correspondingly
+/// doing error management at the callers.
+/// TODO: update batch hashing to reflect hashing fixed sequences of transactions, see #87.
 pub fn serialized_batch_digest<K: AsRef<[u8]>>(sbm: K) -> BatchDigest {
-    BatchDigest::new(crypto::blake2b_256(|hasher| hasher.update(&sbm)))
+    let sbm = sbm.as_ref();
+    let mut offset = 4; // skip the enum variant selector
+    let num_transactions = u64::from_le_bytes(
+        sbm[offset..offset + 8]
+            .try_into()
+            .expect("Invalid serialized batch"),
+    );
+    offset += 8;
+    let mut transactions = Vec::new();
+    for _i in 0..num_transactions {
+        let (tx_ref, new_offset) =
+            read_one_transaction(sbm, offset).expect("Invalid serialized transaction!");
+        transactions.push(tx_ref);
+        offset = new_offset;
+    }
+    BatchDigest::new(crypto::blake2b_256(|hasher| {
+        transactions.iter().for_each(|tx| hasher.update(tx))
+    }))
 }
 
 #[derive(Debug, Error)]
@@ -44,23 +71,4 @@ fn read_one_transaction(sbm: &[u8], offset: usize) -> Result<(&[u8], usize), Dig
     let length = usize::try_from(length).map_err(|_| DigestError::InvalidArgumentError(offset))?;
     let end = offset + 8 + length;
     Ok((&sbm[offset + 8..end], end))
-}
-
-pub fn hash_all_transactions(sbm: &SerializedBatchMessage) -> Result<BatchDigest, DigestError> {
-    let mut offset = 4; // skip the enum variant selector
-    let num_transactions = u64::from_le_bytes(
-        sbm[offset..offset + 8]
-            .try_into()
-            .map_err(|_| DigestError::InvalidArgumentError(offset))?,
-    );
-    offset += 8;
-    let mut transactions = Vec::new();
-    for _i in 0..num_transactions {
-        let (tx_ref, new_offset) = read_one_transaction(sbm, offset)?;
-        transactions.push(tx_ref);
-        offset = new_offset;
-    }
-    Ok(BatchDigest::new(crypto::blake2b_256(|hasher| {
-        transactions.iter().for_each(|tx| hasher.update(tx))
-    })))
 }

--- a/types/src/worker.rs
+++ b/types/src/worker.rs
@@ -1,11 +1,10 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-
-
 use blake2::digest::Update;
 use crypto::traits::VerifyingKey;
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
 use crate::{Batch, BatchDigest};
 
@@ -27,4 +26,41 @@ pub type SerializedBatchMessage = Vec<u8>;
 
 pub fn serialized_batch_digest<K: AsRef<[u8]>>(sbm: K) -> BatchDigest {
     BatchDigest::new(crypto::blake2b_256(|hasher| hasher.update(&sbm)))
+}
+
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum DigestError {
+    #[error("Invalid argument: invalid byte at {0}")]
+    InvalidArgumentError(usize),
+}
+
+fn read_one_transaction(sbm: &[u8], offset: usize) -> Result<(&[u8], usize), DigestError> {
+    let length = u64::from_le_bytes(
+        sbm[offset..offset + 8]
+            .try_into()
+            .map_err(|_| DigestError::InvalidArgumentError(offset))?,
+    );
+    let length = usize::try_from(length).map_err(|_| DigestError::InvalidArgumentError(offset))?;
+    let end = offset + 8 + length;
+    Ok((&sbm[offset + 8..end], end))
+}
+
+pub fn hash_all_transactions(sbm: &SerializedBatchMessage) -> Result<BatchDigest, DigestError> {
+    let mut offset = 4; // skip the enum variant selector
+    let num_transactions = u64::from_le_bytes(
+        sbm[offset..offset + 8]
+            .try_into()
+            .map_err(|_| DigestError::InvalidArgumentError(offset))?,
+    );
+    offset += 8;
+    let mut transactions = Vec::new();
+    for _i in 0..num_transactions {
+        let (tx_ref, new_offset) = read_one_transaction(sbm, offset)?;
+        transactions.push(tx_ref);
+        offset = new_offset;
+    }
+    Ok(BatchDigest::new(crypto::blake2b_256(|hasher| {
+        transactions.iter().for_each(|tx| hasher.update(tx))
+    })))
 }

--- a/types/src/worker.rs
+++ b/types/src/worker.rs
@@ -32,7 +32,7 @@ pub type SerializedBatchMessage = Vec<u8>;
 /// identical to hashing a serialized batch.
 ///
 /// TODO: remove the expects in the below, making this return a `Result` and correspondingly
-/// doing error management at the callers.
+/// doing error management at the callers. See #268
 /// TODO: update batch hashing to reflect hashing fixed sequences of transactions, see #87.
 pub fn serialized_batch_digest<K: AsRef<[u8]>>(sbm: K) -> BatchDigest {
     let sbm = sbm.as_ref();

--- a/types/src/worker.rs
+++ b/types/src/worker.rs
@@ -1,6 +1,9 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+
+
+use blake2::digest::Update;
 use crypto::traits::VerifyingKey;
 use serde::{Deserialize, Serialize};
 
@@ -21,3 +24,7 @@ pub struct ClientBatchRequest(pub Vec<BatchDigest>);
 
 /// Indicates a serialized `WorkerMessage::Batch` message.
 pub type SerializedBatchMessage = Vec<u8>;
+
+pub fn serialized_batch_digest<K: AsRef<[u8]>>(sbm: K) -> BatchDigest {
+    BatchDigest::new(crypto::blake2b_256(|hasher| hasher.update(&sbm)))
+}

--- a/types/tests/batch_serde.rs
+++ b/types/tests/batch_serde.rs
@@ -1,0 +1,35 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use serde_test::{assert_tokens, Token};
+use types::Batch;
+
+#[test]
+fn test_ser_de() {
+    let tx = || vec![1; 5];
+
+    let txes: Batch = Batch((0..2).map(|_| tx()).collect());
+
+    assert_tokens(
+        &txes,
+        &[
+            Token::NewtypeStruct { name: "Batch" },
+            Token::Seq { len: Some(2) },
+            Token::Seq { len: Some(5) },
+            Token::U8(1),
+            Token::U8(1),
+            Token::U8(1),
+            Token::U8(1),
+            Token::U8(1),
+            Token::SeqEnd,
+            Token::Seq { len: Some(5) },
+            Token::U8(1),
+            Token::U8(1),
+            Token::U8(1),
+            Token::U8(1),
+            Token::U8(1),
+            Token::SeqEnd,
+            Token::SeqEnd,
+        ],
+    );
+}

--- a/types/tests/batch_serde.rs
+++ b/types/tests/batch_serde.rs
@@ -1,8 +1,5 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-
-use bincode::Options;
-
 use crypto::{ed25519::Ed25519PublicKey, Hash};
 use proptest::arbitrary::Arbitrary;
 use serde_test::{assert_tokens, Token};
@@ -44,19 +41,15 @@ fn test_bincode_serde_batch() {
 
     let txes: Batch = Batch((0..2).map(|_| tx()).collect());
 
-    let config = bincode::DefaultOptions::new()
-        .with_big_endian()
-        .with_fixint_encoding();
-
-    let txes_bytes = config.serialize(&txes).unwrap();
+    let txes_bytes = bincode::serialize(&txes).unwrap();
 
     // Length as u64: 0000000000000002,
-    let bytes: [u8; 8] = hex::decode("0000000000000002").unwrap().try_into().unwrap();
-    assert_eq!(u64::from_be_bytes(bytes), 2u64);
+    let bytes: [u8; 8] = hex::decode("0200000000000000").unwrap().try_into().unwrap();
+    assert_eq!(u64::from_le_bytes(bytes), 2u64);
 
     // Length-prefix 2, length-prefix 5, 11111, length-prefix 5, 11111
     let expected_bytes =
-        hex::decode("00000000000000020000000000000005010101010100000000000000050101010101")
+        hex::decode("02000000000000000500000000000000010101010105000000000000000101010101")
             .unwrap();
 
     assert_eq!(
@@ -74,18 +67,14 @@ fn test_bincode_serde_batch_message() {
     let txes: WorkerMessage<Ed25519PublicKey> =
         WorkerMessage::Batch(Batch((0..2).map(|_| tx()).collect()));
 
-    let config = bincode::DefaultOptions::new()
-        .with_big_endian()
-        .with_fixint_encoding();
-
-    let txes_bytes = config.serialize(&txes).unwrap();
+    let txes_bytes = bincode::serialize(&txes).unwrap();
 
     // We expect the difference with the above test will be the enum variant above on 4 bytes,
     // see https://github.com/bincode-org/bincode/blob/75a2e0bc9d35cfa7537633b07a9307bf71da84b5/src/features/serde/ser.rs#L212-L224
 
     // Variant index 0 (4 bytes), Length-prefix 2, length-prefix 5, 11111, length-prefix 5, 11111
     let expected_bytes =
-        hex::decode("0000000000000000000000020000000000000005010101010100000000000000050101010101")
+        hex::decode("0000000002000000000000000500000000000000010101010105000000000000000101010101")
             .unwrap();
 
     assert_eq!(

--- a/types/tests/batch_serde.rs
+++ b/types/tests/batch_serde.rs
@@ -1,11 +1,12 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use bincode::Options;
 use serde_test::{assert_tokens, Token};
 use types::Batch;
 
 #[test]
-fn test_ser_de() {
+fn test_serde_batch() {
     let tx = || vec![1; 5];
 
     let txes: Batch = Batch((0..2).map(|_| tx()).collect());
@@ -31,5 +32,34 @@ fn test_ser_de() {
             Token::SeqEnd,
             Token::SeqEnd,
         ],
+    );
+}
+
+#[test]
+fn test_bincode_serde_batch() {
+    let tx = || vec![1; 5];
+
+    let txes: Batch = Batch((0..2).map(|_| tx()).collect());
+
+    let config = bincode::DefaultOptions::new()
+        .with_big_endian()
+        .with_fixint_encoding();
+
+    let txes_bytes = config.serialize(&txes).unwrap();
+
+    // Length as u64: 0000000000000002,
+    let bytes: [u8; 8] = hex::decode("0000000000000002").unwrap().try_into().unwrap();
+    assert_eq!(u64::from_be_bytes(bytes), 2u64);
+
+    // Length-prefix 2, length-prefix 5, 11111, length-prefix 5, 11111
+    let expected_bytes =
+        hex::decode("00000000000000020000000000000005010101010100000000000000050101010101")
+            .unwrap();
+
+    assert_eq!(
+        txes_bytes.clone(),
+        expected_bytes,
+        "received {}",
+        hex::encode(txes_bytes)
     );
 }

--- a/types/tests/batch_serde.rs
+++ b/types/tests/batch_serde.rs
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use bincode::Options;
+use crypto::ed25519::Ed25519PublicKey;
 use serde_test::{assert_tokens, Token};
-use types::Batch;
+use types::{Batch, WorkerMessage};
 
 #[test]
 fn test_serde_batch() {
@@ -54,6 +55,35 @@ fn test_bincode_serde_batch() {
     // Length-prefix 2, length-prefix 5, 11111, length-prefix 5, 11111
     let expected_bytes =
         hex::decode("00000000000000020000000000000005010101010100000000000000050101010101")
+            .unwrap();
+
+    assert_eq!(
+        txes_bytes.clone(),
+        expected_bytes,
+        "received {}",
+        hex::encode(txes_bytes)
+    );
+}
+
+#[test]
+fn test_bincode_serde_batch_message() {
+    let tx = || vec![1; 5];
+
+    let txes: WorkerMessage<Ed25519PublicKey> =
+        WorkerMessage::Batch(Batch((0..2).map(|_| tx()).collect()));
+
+    let config = bincode::DefaultOptions::new()
+        .with_big_endian()
+        .with_fixint_encoding();
+
+    let txes_bytes = config.serialize(&txes).unwrap();
+
+    // We expect the difference with the above test will be the enum variant above on 4 bytes,
+    // see https://github.com/bincode-org/bincode/blob/75a2e0bc9d35cfa7537633b07a9307bf71da84b5/src/features/serde/ser.rs#L212-L224
+
+    // Variant index 0 (4 bytes), Length-prefix 2, length-prefix 5, 11111, length-prefix 5, 11111
+    let expected_bytes =
+        hex::decode("0000000000000000000000020000000000000005010101010100000000000000050101010101")
             .unwrap();
 
     assert_eq!(

--- a/worker/src/batch_maker.rs
+++ b/worker/src/batch_maker.rs
@@ -4,8 +4,6 @@
 use crate::{quorum_waiter::QuorumWaiterMessage, worker::WorkerMessage};
 use crypto::traits::VerifyingKey;
 
-#[cfg(feature = "benchmark")]
-use blake2::digest::Update;
 use multiaddr::Multiaddr;
 use network::WorkerNetwork;
 #[cfg(feature = "benchmark")]
@@ -17,7 +15,7 @@ use tokio::{
 #[cfg(feature = "benchmark")]
 use tracing::info;
 #[cfg(feature = "benchmark")]
-use types::BatchDigest;
+use types::serialized_batch_digest;
 use types::{Batch, Transaction};
 
 #[cfg(test)]
@@ -123,7 +121,7 @@ impl<PublicKey: VerifyingKey> BatchMaker<PublicKey> {
         #[cfg(feature = "benchmark")]
         {
             // NOTE: This is one extra hash that is only needed to print the following log entries.
-            let digest = BatchDigest::new(crypto::blake2b_256(|hasher| hasher.update(&serialized)));
+            let digest = serialized_batch_digest(&serialized);
             for id in tx_ids {
                 // NOTE: This log entry is used to compute performance.
                 info!(

--- a/worker/src/helper.rs
+++ b/worker/src/helper.rs
@@ -1,7 +1,6 @@
 // Copyright (c) 2021, Facebook, Inc. and its affiliates
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use crate::worker::SerializedBatchMessage;
 use bytes::Bytes;
 use config::{Committee, WorkerId};
 use crypto::traits::VerifyingKey;
@@ -9,7 +8,7 @@ use network::WorkerNetwork;
 use store::Store;
 use tokio::sync::mpsc::{Receiver, Sender};
 use tracing::{error, warn};
-use types::BatchDigest;
+use types::{BatchDigest, SerializedBatchMessage};
 
 #[cfg(test)]
 #[path = "tests/helper_tests.rs"]

--- a/worker/src/lib.rs
+++ b/worker/src/lib.rs
@@ -16,4 +16,4 @@ mod quorum_waiter;
 mod synchronizer;
 mod worker;
 
-pub use crate::worker::{SerializedBatchMessage, Worker, WorkerMessage};
+pub use crate::worker::{Worker, WorkerMessage};

--- a/worker/src/processor.rs
+++ b/worker/src/processor.rs
@@ -1,13 +1,12 @@
 // Copyright (c) 2021, Facebook, Inc. and its affiliates
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use types::SerializedBatchMessage;
-use blake2::digest::Update;
+
 use config::WorkerId;
 use primary::WorkerPrimaryMessage;
 use store::Store;
 use tokio::sync::mpsc::{Receiver, Sender};
-use types::BatchDigest;
+use types::{serialized_batch_digest, BatchDigest, SerializedBatchMessage};
 
 #[cfg(test)]
 #[path = "tests/processor_tests.rs"]
@@ -32,7 +31,7 @@ impl Processor {
         tokio::spawn(async move {
             while let Some(batch) = rx_batch.recv().await {
                 // Hash the batch.
-                let digest = BatchDigest::new(crypto::blake2b_256(|hasher| hasher.update(&batch)));
+                let digest = serialized_batch_digest(&batch);
 
                 // Store the batch.
                 store.write(digest, batch).await;

--- a/worker/src/processor.rs
+++ b/worker/src/processor.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2021, Facebook, Inc. and its affiliates
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use crate::worker::SerializedBatchMessage;
+use types::SerializedBatchMessage;
 use blake2::digest::Update;
 use config::WorkerId;
 use primary::WorkerPrimaryMessage;

--- a/worker/src/quorum_waiter.rs
+++ b/worker/src/quorum_waiter.rs
@@ -1,12 +1,12 @@
 // Copyright (c) 2021, Facebook, Inc. and its affiliates
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use crate::worker::SerializedBatchMessage;
 use config::{Committee, Stake};
 use crypto::traits::VerifyingKey;
 use futures::stream::{futures_unordered::FuturesUnordered, StreamExt as _};
 use network::CancelHandler;
 use tokio::sync::mpsc::{Receiver, Sender};
+use types::SerializedBatchMessage;
 
 #[cfg(test)]
 #[path = "tests/quorum_waiter_tests.rs"]

--- a/worker/src/synchronizer.rs
+++ b/worker/src/synchronizer.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2021, Facebook, Inc. and its affiliates
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use crate::worker::{Round, SerializedBatchMessage};
+use crate::worker::SerializedBatchMessage;
 use config::{Committee, WorkerId};
 use crypto::traits::VerifyingKey;
 use futures::stream::{futures_unordered::FuturesUnordered, StreamExt as _};
@@ -17,7 +17,7 @@ use tokio::{
     time::{sleep, Duration, Instant},
 };
 use tracing::{debug, error};
-use types::{BatchDigest, WorkerMessage};
+use types::{BatchDigest, Round, SerializedBatchMessage, WorkerMessage};
 
 #[cfg(test)]
 #[path = "tests/synchronizer_tests.rs"]

--- a/worker/src/synchronizer.rs
+++ b/worker/src/synchronizer.rs
@@ -1,7 +1,6 @@
 // Copyright (c) 2021, Facebook, Inc. and its affiliates
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use crate::worker::SerializedBatchMessage;
 use config::{Committee, WorkerId};
 use crypto::traits::VerifyingKey;
 use futures::stream::{futures_unordered::FuturesUnordered, StreamExt as _};

--- a/worker/src/tests/synchronizer_tests.rs
+++ b/worker/src/tests/synchronizer_tests.rs
@@ -4,10 +4,11 @@
 use super::*;
 use crypto::{ed25519::Ed25519PublicKey, traits::KeyPair};
 use test_utils::{
-    batch, batch_digest, batches, committee, keys, open_batch_store, resolve_batch_digest,
-    serialize_batch_message, WorkerToWorkerMockServer,
+    batch, batch_digest, batches, committee, keys, open_batch_store, serialize_batch_message,
+    WorkerToWorkerMockServer,
 };
 use tokio::{sync::mpsc::channel, time::timeout};
+use types::serialized_batch_digest;
 
 #[tokio::test]
 async fn synchronize() {
@@ -82,7 +83,7 @@ async fn test_successful_request_batch() {
     // Create a dummy batch and store
     let expected_batch = batch();
     let batch_serialised = serialize_batch_message(expected_batch.clone());
-    let expected_digest = resolve_batch_digest(batch_serialised.clone());
+    let expected_digest = serialized_batch_digest(&batch_serialised.clone());
     store.write(expected_digest, batch_serialised.clone()).await;
 
     // WHEN we send a message to retrieve the batch
@@ -194,7 +195,7 @@ async fn test_successful_batch_delete() {
 
     for batch in expected_batches.clone() {
         let s = serialize_batch_message(batch);
-        let digest = resolve_batch_digest(s.clone());
+        let digest = serialized_batch_digest(&s.clone());
 
         batch_digests.push(digest);
 
@@ -224,7 +225,7 @@ async fn test_successful_batch_delete() {
     // AND batches should be deleted
     for batch in expected_batches {
         let s = serialize_batch_message(batch);
-        let digest = resolve_batch_digest(s.clone());
+        let digest = serialized_batch_digest(&s.clone());
 
         let result = store.read(digest).await;
         assert!(result.as_ref().is_ok());

--- a/worker/src/tests/worker_tests.rs
+++ b/worker/src/tests/worker_tests.rs
@@ -2,7 +2,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use super::*;
-use blake2::digest::Update;
+
 use crypto::traits::KeyPair;
 use futures::StreamExt;
 use primary::WorkerPrimaryMessage;
@@ -12,7 +12,7 @@ use test_utils::{
     batch, committee, digest_batch, keys, serialize_batch_message, temp_dir,
     WorkerToPrimaryMockServer, WorkerToWorkerMockServer,
 };
-use types::{TransactionsClient, WorkerToWorkerClient};
+use types::{serialized_batch_digest, TransactionsClient, WorkerToWorkerClient};
 
 #[tokio::test]
 async fn handle_clients_transactions() {
@@ -39,9 +39,7 @@ async fn handle_clients_transactions() {
     // Spawn a network listener to receive our batch's digest.
     let batch = batch();
     let serialized_batch = serialize_batch_message(batch.clone());
-    let batch_digest = BatchDigest::new(crypto::blake2b_256(|hasher| {
-        hasher.update(&serialized_batch)
-    }));
+    let batch_digest = serialized_batch_digest(&serialized_batch);
 
     let primary_address = committee.primary(&name).unwrap().worker_to_primary;
     let expected = bincode::serialize(&WorkerPrimaryMessage::OurBatch(batch_digest, id)).unwrap();

--- a/worker/src/worker.rs
+++ b/worker/src/worker.rs
@@ -22,8 +22,8 @@ use tonic::{Request, Response, Status};
 use tracing::info;
 use types::{
     BatchDigest, BincodeEncodedPayload, ClientBatchRequest, Empty, PrimaryToWorker,
-    PrimaryToWorkerServer, Transaction, TransactionProto, Transactions, TransactionsServer,
-    WorkerToWorker, WorkerToWorkerServer,
+    PrimaryToWorkerServer, SerializedBatchMessage, Transaction, TransactionProto, Transactions,
+    TransactionsServer, WorkerToWorker, WorkerToWorkerServer,
 };
 
 #[cfg(test)]
@@ -32,9 +32,6 @@ pub mod worker_tests;
 
 /// The default channel capacity for each channel of the worker.
 pub const CHANNEL_CAPACITY: usize = 1_000;
-
-/// Indicates a serialized `WorkerMessage::Batch` message.
-pub type SerializedBatchMessage = Vec<u8>;
 
 pub use types::WorkerMessage;
 

--- a/worker/src/worker.rs
+++ b/worker/src/worker.rs
@@ -33,10 +33,6 @@ pub mod worker_tests;
 /// The default channel capacity for each channel of the worker.
 pub const CHANNEL_CAPACITY: usize = 1_000;
 
-/// The primary round number.
-// TODO: Move to the primary.
-pub type Round = u64;
-
 /// Indicates a serialized `WorkerMessage::Batch` message.
 pub type SerializedBatchMessage = Vec<u8>;
 


### PR DESCRIPTION
- refactors the digest of `Batch` from hashing the serialized batch message (bincode serialization of `WorkerMessage::Batch`) to hashing transactions one by one,
    * while this is not the ideal approach (we'd like to also hash the tx lengths, rlp-style), this framework offers a pathway towards implementing this in the future,
    * this makes errors that come up in hashing of a structurally invalid serialized batch message explicit, but leaves propagating error handling in the handlers to a further PR,
- defines a function `serialized_batch_digest` on the serialized batch message itself, that computes the same digest,
- introduces randomized test to guarantee this invariant (`serialized_batch_digest` and `Batch::digest` output the same),
- proves the new approach is not a performance regression through a micro-benchmark (see also [results in the next-to-last commit message](https://github.com/MystenLabs/narwhal/pull/267/commits/50d850d7d17b2bb4cf2a8f70b26e6482b498e9e2))

Fixes #156 