### PR TITLE
feat: feed the genesis in the Dag by default

### DIFF
--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -122,7 +122,7 @@ impl Node {
 
         let dag = if !internal_consensus {
             debug!("Consensus is disabled: the primary will run w/o Tusk");
-            let (_handle, dag) = Dag::new(rx_new_certificates);
+            let (_handle, dag) = Dag::new(&committee, rx_new_certificates);
             Some(Arc::new(dag))
         } else {
             Self::spawn_consensus(

--- a/primary/src/block_remover.rs
+++ b/primary/src/block_remover.rs
@@ -122,7 +122,7 @@ pub struct DeleteBatchMessage {
 ///     let committee = Committee{ authorities: BTreeMap::new() };
 ///     // A dag with genesis for the committee
 ///     let (tx_new_certificates, rx_new_certificates) = channel(1);
-///     let dag = Arc::new(Dag::new(rx_new_certificates).1);
+///     let dag = Arc::new(Dag::new(&committee, rx_new_certificates).1);
 ///     // Populate genesis in the Dag
 ///     join_all(
 ///       Certificate::genesis(&committee)

--- a/primary/src/tests/block_remover_tests.rs
+++ b/primary/src/tests/block_remover_tests.rs
@@ -41,7 +41,7 @@ async fn test_successful_blocks_delete() {
     // AND the necessary keys
     let (name, committee) = resolve_name_and_committee();
     // AND a Dag with genesis populated
-    let dag = Arc::new(Dag::new(rx_consensus).1);
+    let dag = Arc::new(Dag::new(&committee, rx_consensus).1);
     populate_genesis(&dag, &committee).await;
 
     BlockRemover::spawn(
@@ -191,7 +191,7 @@ async fn test_timeout() {
     // AND the necessary keys
     let (name, committee) = resolve_name_and_committee();
     // AND a Dag with genesis populated
-    let dag = Arc::new(Dag::new(rx_consensus).1);
+    let dag = Arc::new(Dag::new(&committee, rx_consensus).1);
     populate_genesis(&dag, &committee).await;
 
     BlockRemover::spawn(
@@ -322,7 +322,7 @@ async fn test_unlocking_pending_requests() {
     // AND the necessary keys
     let (name, committee) = resolve_name_and_committee();
     // AND a Dag with genesis populated
-    let dag = Arc::new(Dag::new(rx_consensus).1);
+    let dag = Arc::new(Dag::new(&committee, rx_consensus).1);
     populate_genesis(&dag, &committee).await;
 
     let mut remover = BlockRemover {

--- a/primary/tests/integration_tests_configuration_api.rs
+++ b/primary/tests/integration_tests_configuration_api.rs
@@ -41,7 +41,7 @@ async fn test_new_network_info() {
         store.payload_store.clone(),
         /* tx_consensus */ tx_new_certificates,
         /* rx_consensus */ rx_feedback,
-        /* dag */ Some(Arc::new(Dag::new(rx_new_certificates).1)),
+        /* dag */ Some(Arc::new(Dag::new(&committee, rx_new_certificates).1)),
     );
 
     // Wait for tasks to start

--- a/primary/tests/integration_tests_proposer_api.rs
+++ b/primary/tests/integration_tests_proposer_api.rs
@@ -71,7 +71,7 @@ async fn test_rounds_errors() {
         store_primary.payload_store,
         /* tx_consensus */ tx_new_certificates,
         /* rx_consensus */ rx_feedback,
-        /* external_consensus */ Some(Arc::new(Dag::new(rx_new_certificates).1)),
+        /* external_consensus */ Some(Arc::new(Dag::new(&committee, rx_new_certificates).1)),
     );
 
     // AND Wait for tasks to start
@@ -123,7 +123,7 @@ async fn test_rounds_return_successful_response() {
     let (_tx_feedback, rx_feedback) = channel(CHANNEL_CAPACITY);
 
     // AND setup the DAG
-    let dag = Arc::new(Dag::new(rx_new_certificates).1);
+    let dag = Arc::new(Dag::new(&committee, rx_new_certificates).1);
 
     Primary::spawn(
         name.clone(),

--- a/primary/tests/integration_tests_validator_api.rs
+++ b/primary/tests/integration_tests_validator_api.rs
@@ -112,7 +112,7 @@ async fn test_get_collections() {
         store.payload_store.clone(),
         /* tx_consensus */ tx_new_certificates,
         /* rx_consensus */ rx_feedback,
-        /* dag */ Some(Arc::new(Dag::new(rx_new_certificates).1)),
+        /* dag */ Some(Arc::new(Dag::new(&committee, rx_new_certificates).1)),
     );
 
     // Spawn a `Worker` instance.
@@ -216,7 +216,7 @@ async fn test_remove_collections() {
 
     // Make the Dag
     let (tx_new_certificates, rx_new_certificates) = channel(CHANNEL_CAPACITY);
-    let dag = Arc::new(Dag::new(rx_new_certificates).1);
+    let dag = Arc::new(Dag::new(&committee, rx_new_certificates).1);
     // Populate genesis in the Dag
     assert!(join_all(
         Certificate::genesis(&committee)
@@ -402,7 +402,7 @@ async fn test_read_causal_signed_certificates() {
 
     // Make the Dag
     let (tx_new_certificates, rx_new_certificates) = channel(CHANNEL_CAPACITY);
-    let dag = Arc::new(Dag::new(rx_new_certificates).1);
+    let dag = Arc::new(Dag::new(&committee, rx_new_certificates).1);
 
     // Populate genesis in the Dag
     let genesis_certs = Certificate::genesis(&committee);
@@ -511,7 +511,8 @@ async fn test_read_causal_signed_certificates() {
         primary_store_2.payload_store,
         /* tx_consensus */ tx_new_certificates_2,
         /* rx_consensus */ rx_feedback_2,
-        /* external_consensus */ Some(Arc::new(Dag::new(rx_new_certificates_2).1)),
+        /* external_consensus */
+        Some(Arc::new(Dag::new(&committee, rx_new_certificates_2).1)),
     );
 
     // Wait for tasks to start
@@ -589,7 +590,7 @@ async fn test_read_causal_unsigned_certificates() {
 
     // Make the Dag
     let (tx_new_certificates, rx_new_certificates) = channel(CHANNEL_CAPACITY);
-    let dag = Arc::new(Dag::new(rx_new_certificates).1);
+    let dag = Arc::new(Dag::new(&committee, rx_new_certificates).1);
 
     // Populate genesis in the Dag
     let genesis_certs = Certificate::genesis(&committee);
@@ -692,7 +693,8 @@ async fn test_read_causal_unsigned_certificates() {
         primary_store_2.payload_store,
         /* tx_consensus */ tx_new_certificates_2,
         /* rx_consensus */ rx_feedback_2,
-        /* external_consensus */ Some(Arc::new(Dag::new(rx_new_certificates_2).1)),
+        /* external_consensus */
+        Some(Arc::new(Dag::new(&committee, rx_new_certificates_2).1)),
     );
 
     // Wait for tasks to start
@@ -828,7 +830,8 @@ async fn test_get_collections_with_missing_certificates() {
         store_primary_1.payload_store,
         /* tx_consensus */ tx_new_certificates_1,
         /* rx_consensus */ rx_feedback_1,
-        /* external_consensus */ Some(Arc::new(Dag::new(rx_new_certificates_1).1)),
+        /* external_consensus */
+        Some(Arc::new(Dag::new(&committee, rx_new_certificates_1).1)),
     );
 
     // Spawn a `Worker` instance for primary 1.
@@ -854,7 +857,8 @@ async fn test_get_collections_with_missing_certificates() {
         store_primary_2.payload_store,
         /* tx_consensus */ tx_new_certificates_2,
         /* rx_consensus */ rx_feedback_2,
-        /* external_consensus */ Some(Arc::new(Dag::new(rx_new_certificates_2).1)),
+        /* external_consensus */
+        Some(Arc::new(Dag::new(&committee, rx_new_certificates_2).1)),
     );
 
     // Spawn a `Worker` instance for primary 2.


### PR DESCRIPTION
THis aligns the behavior of our Dag with that of the store

- adds the genesis by default to the Dag as part of the constructor,
- unit tests that initial provisioning,
- adapts the behavior of tests to not feed genesis manually.

Fixes #270