### PR TITLE
fix error when requesting non found certificate via block waiter

### DIFF
--- a/primary/src/block_synchronizer/handler.rs
+++ b/primary/src/block_synchronizer/handler.rs
@@ -175,6 +175,11 @@ impl<PublicKey: VerifyingKey> Handler<PublicKey> for BlockSynchronizerHandler<Pu
         &self,
         block_ids: Vec<CertificateDigest>,
     ) -> Vec<Result<Certificate<PublicKey>, Error>> {
+        if block_ids.is_empty() {
+            trace!("No blocks were provided, will now return an empty list");
+            return vec![];
+        }
+
         let sync_results = self.get_block_headers(block_ids).await;
         let mut results: Vec<Result<Certificate<PublicKey>, Error>> = Vec::new();
 
@@ -235,6 +240,11 @@ impl<PublicKey: VerifyingKey> Handler<PublicKey> for BlockSynchronizerHandler<Pu
         &self,
         block_ids: Vec<CertificateDigest>,
     ) -> Vec<BlockSynchronizeResult<BlockHeader<PublicKey>>> {
+        if block_ids.is_empty() {
+            trace!("No blocks were provided, will now return an empty list");
+            return vec![];
+        }
+
         let (tx, mut rx) = channel(block_ids.len());
 
         self.tx_block_synchronizer
@@ -267,6 +277,11 @@ impl<PublicKey: VerifyingKey> Handler<PublicKey> for BlockSynchronizerHandler<Pu
         &self,
         certificates: Vec<Certificate<PublicKey>>,
     ) -> Vec<Result<Certificate<PublicKey>, Error>> {
+        if certificates.is_empty() {
+            trace!("No certificates were provided, will now return an empty list");
+            return vec![];
+        }
+
         let (tx, mut rx) = channel(certificates.len());
 
         self.tx_block_synchronizer

--- a/primary/src/block_synchronizer/tests/handler_tests.rs
+++ b/primary/src/block_synchronizer/tests/handler_tests.rs
@@ -286,3 +286,24 @@ async fn test_synchronize_block_payload() {
     // AND
     mock_synchronizer.assert_expectations().await;
 }
+
+#[tokio::test]
+async fn test_call_methods_with_empty_input() {
+    // GIVEN
+    let (_, certificate_store, _) = create_db_stores();
+    let (tx_block_synchronizer, _) = channel(1);
+    let (tx_core, _rx_core) = channel(1);
+
+    let synchronizer = BlockSynchronizerHandler {
+        tx_block_synchronizer,
+        tx_core,
+        certificate_store: certificate_store.clone(),
+        certificate_deliver_timeout: Duration::from_millis(2_000),
+    };
+
+    let result = synchronizer.synchronize_block_payloads(vec![]).await;
+    assert!(result.is_empty());
+
+    let result = synchronizer.get_and_synchronize_block_headers(vec![]).await;
+    assert!(result.is_empty());
+}

--- a/primary/src/block_waiter.rs
+++ b/primary/src/block_waiter.rs
@@ -604,14 +604,12 @@ impl<PublicKey: VerifyingKey, SynchronizerHandler: Handler<PublicKey> + Send + S
     ) -> BlocksResult {
         let result = try_join_all(get_block_receivers).await;
 
-        if result.is_err() {
+        if let Ok(res) = result {
+            Ok(GetBlocksResponse { blocks: res })
+        } else {
             Err(BlocksError {
                 ids,
                 error: BlocksErrorType::Error,
-            })
-        } else {
-            Ok(GetBlocksResponse {
-                blocks: result.unwrap(),
             })
         }
     }


### PR DESCRIPTION
This is a fix of a bug discovered while interacting with a running Narwhal node cluster. To replicate the error should follow the steps:
1. Spin up a Narwhal node cluster
2. Request via the `GetCollections` request a **single** certificate that doesn't exist
3. Primary node should panic with the error `mpsc bounded channel requires buffer > 0` which is raised on the [handler](https://github.com/MystenLabs/narwhal/blob/5cfb317c2a0dfe29190d1ba67281f8e99dc57799/primary/src/block_synchronizer/handler.rs#L270)

After some investigation it appears that when requesting a single certificate via `GetCollections` that doesn't exist (can't even fetch from other peers) , it was ending up passing an empty vector of [found_certificates](https://github.com/MystenLabs/narwhal/blob/5cfb317c2a0dfe29190d1ba67281f8e99dc57799/primary/src/block_waiter.rs#L448) on the block_waiter when fetching the results. The tokio `channel` used on those underlying handler methods are bounded and their size is initialised based on the provided vector of requested certificates - which when `0` it panics.

As a fix I've amended the `handler` methods to immediately return and respond with an empty vector when an empty vector is passed.
