### PR TITLE
[configuration] Make the committee representation updatable

### DIFF
--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -14,6 +14,7 @@ multiaddr = "0.14.0"
 
 crypto = { path = "../crypto" }
 arc-swap = { version = "1.5.0", features = ["serde"] }
+itertools = "0.10.3"
 
 [dev-dependencies]
 tempfile = "3.3.0"

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -14,8 +14,10 @@ multiaddr = "0.14.0"
 
 crypto = { path = "../crypto" }
 arc-swap = { version = "1.5.0", features = ["serde"] }
-itertools = "0.10.3"
 
 [dev-dependencies]
+rand = "0.7.3"
 tempfile = "3.3.0"
 tracing-test = { version = "0.2.1" }
+
+test_utils = { path = "../test_utils"}

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -13,6 +13,7 @@ tracing = "0.1.34"
 multiaddr = "0.14.0"
 
 crypto = { path = "../crypto" }
+arc-swap = { version = "1.5.0", features = ["serde"] }
 
 [dev-dependencies]
 tempfile = "3.3.0"

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -298,15 +298,6 @@ impl<PublicKey: VerifyingKey> Committee<PublicKey> {
             .map_or_else(|| 0, |x| x.stake)
     }
 
-    /// Returns the stake of all authorities except `myself`.
-    pub fn others_stake(&self, myself: &PublicKey) -> Vec<(PublicKey, Stake)> {
-        self.authorities
-            .iter()
-            .filter(|(name, _)| *name != myself)
-            .map(|(name, authority)| (name.deref().clone(), authority.stake))
-            .collect()
-    }
-
     /// Returns the stake required to reach a quorum (2f+1).
     pub fn quorum_threshold(&self) -> Stake {
         // If N = 3f + 1 + k (0 <= k < 3)

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -265,7 +265,7 @@ impl Parameters {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PrimaryAddresses {
     /// Address to receive messages from other primaries (WAN).
     pub primary_to_primary: Multiaddr,

--- a/config/tests/config_tests.rs
+++ b/config/tests/config_tests.rs
@@ -1,0 +1,79 @@
+use std::collections::BTreeMap;
+
+use config::{PrimaryAddresses, Stake};
+use crypto::ed25519::Ed25519PublicKey;
+use rand::seq::SliceRandom;
+
+#[test]
+fn update_primary_network_info_test() {
+    let committee = test_utils::committee(None);
+    let res = committee
+        .update_primary_network_info(BTreeMap::new())
+        .unwrap_err();
+    for err in res {
+        assert!(matches!(
+            err,
+            config::ComitteeUpdateError::MissingFromUpdate(_)
+        ))
+    }
+
+    let committee2 = test_utils::committee(42);
+    let invalid_new_info = committee2
+        .authorities
+        .load()
+        .iter()
+        .map(|(pk, a)| (pk.clone(), (a.stake, a.primary.clone())))
+        .collect::<BTreeMap<_, (Stake, PrimaryAddresses)>>();
+    let res2 = committee
+        .update_primary_network_info(invalid_new_info)
+        .unwrap_err();
+    for err in res2 {
+        // we'll get the two collections reporting missing from each other
+        assert!(matches!(
+            err,
+            config::ComitteeUpdateError::NotInCommittee(_)
+                | config::ComitteeUpdateError::MissingFromUpdate(_)
+        ))
+    }
+
+    let committee3 = test_utils::committee(None);
+    let invalid_new_info = committee3
+        .authorities
+        .load()
+        .iter()
+        // change the stake
+        .map(|(pk, a)| (pk.clone(), (a.stake + 1, a.primary.clone())))
+        .collect::<BTreeMap<_, (Stake, PrimaryAddresses)>>();
+    let res2 = committee
+        .update_primary_network_info(invalid_new_info)
+        .unwrap_err();
+    for err in res2 {
+        assert!(matches!(
+            err,
+            config::ComitteeUpdateError::DifferentStake(_)
+        ))
+    }
+
+    let committee4 = test_utils::committee(None);
+    let mut pk_n_stake = Vec::new();
+    let mut addresses = Vec::new();
+
+    committee4.authorities.load().iter().for_each(|(pk, a)| {
+        pk_n_stake.push((pk.clone(), a.stake));
+        addresses.push(a.primary.clone())
+    });
+
+    let mut rng = rand::thread_rng();
+    addresses.shuffle(&mut rng);
+
+    let new_info = pk_n_stake
+        .into_iter()
+        .zip(addresses)
+        .map(|((pk, stk), addr)| (pk, (stk, addr)))
+        .collect::<BTreeMap<Ed25519PublicKey, (Stake, PrimaryAddresses)>>();
+    let res = committee.update_primary_network_info(new_info.clone());
+    assert!(res.is_ok());
+    for (pk, a) in committee.authorities.load().iter() {
+        assert_eq!(a.primary, new_info.get(pk).unwrap().1);
+    }
+}

--- a/config/tests/config_tests.rs
+++ b/config/tests/config_tests.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::BTreeMap;
 
 use config::{PrimaryAddresses, Stake};

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2021"
 
 [dependencies]
+arc-swap = { version = "1.5.0", features = ["serde"]}
 bincode = "1.3.3"
 blake2 = "0.9"
 bytes = "1.1.0"

--- a/executor/src/lib.rs
+++ b/executor/src/lib.rs
@@ -23,7 +23,7 @@ pub use state::ExecutionIndices;
 
 use crate::{batch_loader::BatchLoader, core::Core, subscriber::Subscriber};
 use async_trait::async_trait;
-use config::Committee;
+use config::SharedCommittee;
 use consensus::{ConsensusOutput, ConsensusSyncRequest};
 use crypto::traits::VerifyingKey;
 use serde::de::DeserializeOwned;
@@ -81,7 +81,7 @@ impl Executor {
     /// Spawn a new client subscriber.
     pub async fn spawn<State, PublicKey>(
         name: PublicKey,
-        committee: Committee<PublicKey>,
+        committee: SharedCommittee<PublicKey>,
         store: Store<BatchDigest, SerializedBatchMessage>,
         execution_state: Arc<State>,
         rx_consensus: Receiver<ConsensusOutput<PublicKey>>,
@@ -130,6 +130,7 @@ impl Executor {
         // Spawn the batch loader.
         let worker_addresses = committee
             .authorities
+            .load()
             .iter()
             .find(|(x, _)| *x == &name)
             .map(|(_, authority)| authority)

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.57"
+arc-swap = { version = "1.5.0", features = ["serde"] }
 async-trait = "0.1.53"
 bincode = "1.3.3"
 bytes = "1.1.0"

--- a/node/src/generate_format.rs
+++ b/node/src/generate_format.rs
@@ -37,45 +37,46 @@ fn get_registry() -> Result<Registry> {
     // Trace the correspondng header
     let keys: Vec<_> = (0..4).map(|_| Ed25519KeyPair::generate(&mut rng)).collect();
     let committee = Committee {
-        authorities: keys
-            .iter()
-            .enumerate()
-            .map(|(i, kp)| {
-                let id = kp.public();
-                let primary = PrimaryAddresses {
-                    primary_to_primary: format!("/ip4/127.0.0.1/tcp/{}/http", 100 + i)
-                        .parse()
-                        .unwrap(),
-                    worker_to_primary: format!("/ip4/127.0.0.1/tcp/{}/http", 200 + i)
-                        .parse()
-                        .unwrap(),
-                };
-                let workers = vec![(
-                    0,
-                    WorkerAddresses {
-                        primary_to_worker: format!("/ip4/127.0.0.1/tcp/{}/http", 300 + i)
+        authorities: arc_swap::ArcSwap::from_pointee(
+            keys.iter()
+                .enumerate()
+                .map(|(i, kp)| {
+                    let id = kp.public();
+                    let primary = PrimaryAddresses {
+                        primary_to_primary: format!("/ip4/127.0.0.1/tcp/{}/http", 100 + i)
                             .parse()
                             .unwrap(),
-                        transactions: format!("/ip4/127.0.0.1/tcp/{}/http", 400 + i)
+                        worker_to_primary: format!("/ip4/127.0.0.1/tcp/{}/http", 200 + i)
                             .parse()
                             .unwrap(),
-                        worker_to_worker: format!("/ip4/127.0.0.1/tcp/{}/http", 500 + i)
-                            .parse()
-                            .unwrap(),
-                    },
-                )]
-                .into_iter()
-                .collect();
-                (
-                    id.clone(),
-                    Authority {
-                        stake: 1,
-                        primary,
-                        workers,
-                    },
-                )
-            })
-            .collect(),
+                    };
+                    let workers = vec![(
+                        0,
+                        WorkerAddresses {
+                            primary_to_worker: format!("/ip4/127.0.0.1/tcp/{}/http", 300 + i)
+                                .parse()
+                                .unwrap(),
+                            transactions: format!("/ip4/127.0.0.1/tcp/{}/http", 400 + i)
+                                .parse()
+                                .unwrap(),
+                            worker_to_worker: format!("/ip4/127.0.0.1/tcp/{}/http", 500 + i)
+                                .parse()
+                                .unwrap(),
+                        },
+                    )]
+                    .into_iter()
+                    .collect();
+                    (
+                        id.clone(),
+                        Authority {
+                            stake: 1,
+                            primary,
+                            workers,
+                        },
+                    )
+                })
+                .collect(),
+        ),
     };
 
     let certificates: Vec<Certificate<Ed25519PublicKey>> = Certificate::genesis(&committee);

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use config::{Committee, Parameters, WorkerId};
+use config::{Parameters, SharedCommittee, WorkerId};
 use consensus::{dag::Dag, Consensus, SubscriberHandler};
 use crypto::traits::{KeyPair, Signer, VerifyingKey};
 use executor::{ExecutionState, Executor, SerializedTransaction, SubscriberResult};
@@ -93,7 +93,7 @@ impl Node {
         // The private-public key pair of this authority.
         keypair: Keys,
         // The committee information.
-        committee: Committee<PublicKey>,
+        committee: SharedCommittee<PublicKey>,
         // The node's storage.
         store: &NodeStorage<PublicKey>,
         // The configuration parameters.
@@ -159,7 +159,7 @@ impl Node {
     /// Spawn the consensus core and the client executing transactions.
     async fn spawn_consensus<PublicKey, State>(
         name: PublicKey,
-        committee: Committee<PublicKey>,
+        committee: SharedCommittee<PublicKey>,
         store: &NodeStorage<PublicKey>,
         parameters: Parameters,
         execution_state: Arc<State>,
@@ -219,7 +219,7 @@ impl Node {
         // The ids of the validators to spawn.
         ids: Vec<WorkerId>,
         // The committee information.
-        committee: Committee<PublicKey>,
+        committee: SharedCommittee<PublicKey>,
         // The node's storage,
         store: &NodeStorage<PublicKey>,
         // The configuration parameters.

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -123,8 +123,9 @@ async fn run(matches: &ArgMatches<'_>) -> Result<()> {
 
     // Read the committee and node's keypair from file.
     let keypair = Ed25519KeyPair::import(key_file).context("Failed to load the node's keypair")?;
-    let committee =
-        Committee::import(committee_file).context("Failed to load the committee information")?;
+    let committee = Arc::new(
+        Committee::import(committee_file).context("Failed to load the committee information")?,
+    );
 
     // Load default parameters if none are specified.
     let parameters = match parameters_file {

--- a/primary/Cargo.toml
+++ b/primary/Cargo.toml
@@ -38,6 +38,7 @@ mysten-network = { git = "https://github.com/mystenlabs/mysten-infra.git", rev =
 store = { git = "https://github.com/mystenlabs/mysten-infra.git", package = "typed-store", rev = "7c247967e5a5abd59ecaa75bc62b05bcdf4503fe" }
 
 [dev-dependencies]
+arc-swap = { version = "1.5.0", features = ["serde"] }
 itertools = "0.10.3"
 mockall = "0.11.0"
 node = { path = "../node" }

--- a/primary/src/block_remover.rs
+++ b/primary/src/block_remover.rs
@@ -4,7 +4,7 @@
 #![allow(unused_variables)]
 
 use crate::{utils, PayloadToken, PrimaryWorkerMessage};
-use config::{Committee, WorkerId};
+use config::{SharedCommittee, WorkerId};
 use consensus::dag::{Dag, ValidatorDagError};
 use crypto::{traits::VerifyingKey, Digest, Hash};
 use futures::{
@@ -177,7 +177,7 @@ pub struct BlockRemover<PublicKey: VerifyingKey> {
     name: PublicKey,
 
     /// The committee information.
-    committee: Committee<PublicKey>,
+    committee: SharedCommittee<PublicKey>,
 
     /// Storage that keeps the Certificates by their digest id.
     certificate_store: Store<CertificateDigest, Certificate<PublicKey>>,
@@ -215,7 +215,7 @@ pub struct BlockRemover<PublicKey: VerifyingKey> {
 impl<PublicKey: VerifyingKey> BlockRemover<PublicKey> {
     pub fn spawn(
         name: PublicKey,
-        committee: Committee<PublicKey>,
+        committee: SharedCommittee<PublicKey>,
         certificate_store: Store<CertificateDigest, Certificate<PublicKey>>,
         header_store: Store<HeaderDigest, Header<PublicKey>>,
         payload_store: Store<(BatchDigest, WorkerId), PayloadToken>,

--- a/primary/src/block_remover.rs
+++ b/primary/src/block_remover.rs
@@ -80,6 +80,7 @@ pub struct DeleteBatchMessage {
 /// # use store::{reopen, rocks, rocks::DBMap, Store};
 /// # use network::PrimaryToWorkerNetwork;
 /// # use tokio::sync::mpsc::{channel};
+/// # use arc_swap::ArcSwap;
 /// # use crypto::Hash;
 /// # use std::env::temp_dir;
 /// # use crypto::Digest;
@@ -119,7 +120,7 @@ pub struct DeleteBatchMessage {
 ///     let (tx_delete_block_result, mut rx_delete_block_result) = channel(1);
 ///
 ///     let name = Ed25519PublicKey::default();
-///     let committee = Committee{ authorities: BTreeMap::new() };
+///     let committee = Arc::new(Committee{ authorities: ArcSwap::from_pointee(BTreeMap::new()) });
 ///     // A dag with genesis for the committee
 ///     let (tx_new_certificates, rx_new_certificates) = channel(1);
 ///     let dag = Arc::new(Dag::new(&committee, rx_new_certificates).1);

--- a/primary/src/block_synchronizer/mod.rs
+++ b/primary/src/block_synchronizer/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     primary::PrimaryMessage,
     utils, PayloadToken, PrimaryWorkerMessage,
 };
-use config::{BlockSynchronizerParameters, Committee, WorkerId};
+use config::{BlockSynchronizerParameters, SharedCommittee, WorkerId};
 use crypto::{traits::VerifyingKey, Hash};
 use futures::{
     future::{join_all, BoxFuture},
@@ -146,7 +146,7 @@ pub struct BlockSynchronizer<PublicKey: VerifyingKey> {
     name: PublicKey,
 
     /// The committee information.
-    committee: Committee<PublicKey>,
+    committee: SharedCommittee<PublicKey>,
 
     /// Receive the commands for the synchronizer
     rx_commands: Receiver<Command<PublicKey>>,
@@ -191,7 +191,7 @@ pub struct BlockSynchronizer<PublicKey: VerifyingKey> {
 impl<PublicKey: VerifyingKey> BlockSynchronizer<PublicKey> {
     pub fn spawn(
         name: PublicKey,
-        committee: Committee<PublicKey>,
+        committee: SharedCommittee<PublicKey>,
         rx_commands: Receiver<Command<PublicKey>>,
         rx_certificate_responses: Receiver<CertificatesResponse<PublicKey>>,
         rx_payload_availability_responses: Receiver<PayloadAvailabilityResponse<PublicKey>>,
@@ -708,7 +708,7 @@ impl<PublicKey: VerifyingKey> BlockSynchronizer<PublicKey> {
     async fn wait_for_certificate_responses(
         fetch_certificates_timeout: Duration,
         request_id: RequestID,
-        committee: Committee<PublicKey>,
+        committee: SharedCommittee<PublicKey>,
         block_ids: Vec<CertificateDigest>,
         primaries_sent_requests_to: Vec<PublicKey>,
         mut receiver: Receiver<CertificatesResponse<PublicKey>>,

--- a/primary/src/block_waiter.rs
+++ b/primary/src/block_waiter.rs
@@ -114,6 +114,7 @@ type RequestKey = Vec<u8>;
 /// ```rust
 /// # use tokio::sync::mpsc::{channel};
 /// # use tokio::sync::oneshot;
+/// # use arc_swap::ArcSwap;
 /// # use crypto::Hash;
 /// # use std::env::temp_dir;
 /// # use crypto::ed25519::Ed25519PublicKey;
@@ -154,7 +155,7 @@ type RequestKey = Vec<u8>;
 ///     let (tx_get_block, mut rx_get_block) = oneshot::channel();
 ///
 ///     let name = Ed25519PublicKey::default();
-///     let committee = Committee{ authorities: BTreeMap::new() };
+///     let committee = Arc::new(Committee{ authorities: ArcSwap::from_pointee(BTreeMap::new()) });
 ///
 ///     // A dummy certificate
 ///     let certificate = Certificate::<Ed25519PublicKey>::default();

--- a/primary/src/block_waiter.rs
+++ b/primary/src/block_waiter.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use crate::{block_synchronizer::handler::Handler, PrimaryWorkerMessage};
-use config::Committee;
+use config::SharedCommittee;
 use crypto::{traits::VerifyingKey, Digest, Hash};
 use futures::{
     future::{try_join_all, BoxFuture},
@@ -200,7 +200,7 @@ pub struct BlockWaiter<
     name: PublicKey,
 
     /// The committee information.
-    committee: Committee<PublicKey>,
+    committee: SharedCommittee<PublicKey>,
 
     /// Receive all the requests to get a block
     rx_commands: Receiver<BlockCommand>,
@@ -247,7 +247,7 @@ impl<PublicKey: VerifyingKey, SynchronizerHandler: Handler<PublicKey> + Send + S
     // commands to fetch a block
     pub fn spawn(
         name: PublicKey,
-        committee: Committee<PublicKey>,
+        committee: SharedCommittee<PublicKey>,
         rx_commands: Receiver<BlockCommand>,
         batch_receiver: Receiver<BatchResult>,
         block_synchronizer_handler: Arc<SynchronizerHandler>,

--- a/primary/src/core.rs
+++ b/primary/src/core.rs
@@ -7,7 +7,7 @@ use crate::{
     synchronizer::Synchronizer,
 };
 use async_recursion::async_recursion;
-use config::Committee;
+use config::SharedCommittee;
 use crypto::{traits::VerifyingKey, Hash as _, SignatureService};
 use network::{CancelHandler, PrimaryNetwork};
 use std::{
@@ -37,7 +37,7 @@ pub struct Core<PublicKey: VerifyingKey> {
     /// The public key of this primary.
     name: PublicKey,
     /// The committee information.
-    committee: Committee<PublicKey>,
+    committee: SharedCommittee<PublicKey>,
     /// The persistent storage keyed to headers.
     header_store: Store<HeaderDigest, Header<PublicKey>>,
     /// The persistent storage keyed to certificates.
@@ -85,7 +85,7 @@ pub struct Core<PublicKey: VerifyingKey> {
 impl<PublicKey: VerifyingKey> Core<PublicKey> {
     pub fn spawn(
         name: PublicKey,
-        committee: Committee<PublicKey>,
+        committee: SharedCommittee<PublicKey>,
         header_store: Store<HeaderDigest, Header<PublicKey>>,
         certificate_store: Store<CertificateDigest, Certificate<PublicKey>>,
         synchronizer: Synchronizer<PublicKey>,

--- a/primary/src/grpc_server/mod.rs
+++ b/primary/src/grpc_server/mod.rs
@@ -6,7 +6,7 @@ use crate::{
     block_synchronizer::handler::Handler, grpc_server::proposer::NarwhalProposer, BlockCommand,
     BlockRemoverCommand,
 };
-use config::Committee;
+use config::SharedCommittee;
 use consensus::dag::Dag;
 use crypto::traits::VerifyingKey;
 use multiaddr::Multiaddr;
@@ -30,7 +30,7 @@ pub struct ConsensusAPIGrpc<
     remove_collections_timeout: Duration,
     block_synchronizer_handler: Arc<SynchronizerHandler>,
     dag: Option<Arc<Dag<PublicKey>>>,
-    committee: Committee<PublicKey>,
+    committee: SharedCommittee<PublicKey>,
 }
 
 impl<PublicKey: VerifyingKey, SynchronizerHandler: Handler<PublicKey> + Send + Sync + 'static>
@@ -44,7 +44,7 @@ impl<PublicKey: VerifyingKey, SynchronizerHandler: Handler<PublicKey> + Send + S
         remove_collections_timeout: Duration,
         block_synchronizer_handler: Arc<SynchronizerHandler>,
         dag: Option<Arc<Dag<PublicKey>>>,
-        committee: Committee<PublicKey>,
+        committee: SharedCommittee<PublicKey>,
     ) {
         tokio::spawn(async move {
             let _ = Self {
@@ -73,7 +73,7 @@ impl<PublicKey: VerifyingKey, SynchronizerHandler: Handler<PublicKey> + Send + S
             self.dag.clone(),
         );
 
-        let narwhal_proposer = NarwhalProposer::new(self.dag.clone(), self.committee.clone());
+        let narwhal_proposer = NarwhalProposer::new(self.dag.clone(), Arc::clone(&self.committee));
 
         let narwhal_configuration = NarwhalConfiguration::new();
 

--- a/primary/src/grpc_server/proposer.rs
+++ b/primary/src/grpc_server/proposer.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use config::Committee;
+use config::SharedCommittee;
 use consensus::dag::Dag;
 use crypto::traits::VerifyingKey;
 use std::sync::Arc;
@@ -15,11 +15,11 @@ pub struct NarwhalProposer<PublicKey: VerifyingKey> {
     dag: Option<Arc<Dag<PublicKey>>>,
 
     /// The committee
-    committee: Committee<PublicKey>,
+    committee: SharedCommittee<PublicKey>,
 }
 
 impl<PublicKey: VerifyingKey> NarwhalProposer<PublicKey> {
-    pub fn new(dag: Option<Arc<Dag<PublicKey>>>, committee: Committee<PublicKey>) -> Self {
+    pub fn new(dag: Option<Arc<Dag<PublicKey>>>, committee: SharedCommittee<PublicKey>) -> Self {
         Self { dag, committee }
     }
 

--- a/primary/src/header_waiter.rs
+++ b/primary/src/header_waiter.rs
@@ -2,7 +2,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use crate::primary::{PayloadToken, PrimaryMessage, PrimaryWorkerMessage};
-use config::{Committee, WorkerId};
+use config::{SharedCommittee, WorkerId};
 use crypto::traits::VerifyingKey;
 use futures::{
     future::{try_join_all, BoxFuture},
@@ -45,7 +45,7 @@ pub struct HeaderWaiter<PublicKey: VerifyingKey> {
     /// The name of this authority.
     name: PublicKey,
     /// The committee information.
-    committee: Committee<PublicKey>,
+    committee: SharedCommittee<PublicKey>,
     /// The persistent storage for parent Certificates.
     certificate_store: Store<CertificateDigest, Certificate<PublicKey>>,
     /// The persistent storage for payload markers from workers.
@@ -81,7 +81,7 @@ pub struct HeaderWaiter<PublicKey: VerifyingKey> {
 impl<PublicKey: VerifyingKey> HeaderWaiter<PublicKey> {
     pub fn spawn(
         name: PublicKey,
-        committee: Committee<PublicKey>,
+        committee: SharedCommittee<PublicKey>,
         certificate_store: Store<CertificateDigest, Certificate<PublicKey>>,
         payload_store: Store<(BatchDigest, WorkerId), PayloadToken>,
         consensus_round: Arc<AtomicU64>,

--- a/primary/src/helper.rs
+++ b/primary/src/helper.rs
@@ -2,7 +2,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use crate::{primary::PrimaryMessage, PayloadToken};
-use config::{Committee, WorkerId};
+use config::{SharedCommittee, WorkerId};
 use crypto::traits::{EncodeDecodeBase64, VerifyingKey};
 use network::PrimaryNetwork;
 use store::{Store, StoreError};
@@ -33,7 +33,7 @@ pub struct Helper<PublicKey: VerifyingKey> {
     /// The node's name
     name: PublicKey,
     /// The committee information.
-    committee: Committee<PublicKey>,
+    committee: SharedCommittee<PublicKey>,
     /// The certificate persistent storage.
     certificate_store: Store<CertificateDigest, Certificate<PublicKey>>,
     /// The payloads (batches) persistent storage.
@@ -47,7 +47,7 @@ pub struct Helper<PublicKey: VerifyingKey> {
 impl<PublicKey: VerifyingKey> Helper<PublicKey> {
     pub fn spawn(
         name: PublicKey,
-        committee: Committee<PublicKey>,
+        committee: SharedCommittee<PublicKey>,
         certificate_store: Store<CertificateDigest, Certificate<PublicKey>>,
         payload_store: Store<(BatchDigest, WorkerId), PayloadToken>,
         rx_primaries: Receiver<PrimaryMessage<PublicKey>>,

--- a/primary/src/primary.rs
+++ b/primary/src/primary.rs
@@ -17,7 +17,7 @@ use crate::{
     BlockRemover, CertificatesResponse, DeleteBatchMessage, PayloadAvailabilityResponse,
 };
 use async_trait::async_trait;
-use config::{Committee, Parameters, WorkerId};
+use config::{Parameters, SharedCommittee, WorkerId};
 use consensus::dag::Dag;
 use crypto::{
     traits::{EncodeDecodeBase64, Signer, VerifyingKey},
@@ -86,7 +86,7 @@ impl Primary {
     pub fn spawn<PublicKey: VerifyingKey, Signatory: Signer<PublicKey::Sig> + Send + 'static>(
         name: PublicKey,
         signer: Signatory,
-        committee: Committee<PublicKey>,
+        committee: SharedCommittee<PublicKey>,
         parameters: Parameters,
         header_store: Store<HeaderDigest, Header<PublicKey>>,
         certificate_store: Store<CertificateDigest, Certificate<PublicKey>>,

--- a/primary/tests/integration_tests_validator_api.rs
+++ b/primary/tests/integration_tests_validator_api.rs
@@ -625,6 +625,7 @@ async fn test_read_causal_unsigned_certificates() {
         &genesis,
         &committee
             .authorities
+            .load()
             .keys()
             .cloned()
             .collect::<Vec<Ed25519PublicKey>>(),

--- a/test_utils/Cargo.toml
+++ b/test_utils/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 publish = false
 
 [dependencies]
+arc-swap = { version = "1.5.0", features = ["serde"]}
 base64 = "0.13.0"
 bincode = "1.3.3"
 blake2 = "0.9"

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -2,8 +2,10 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use arc_swap::ArcSwap;
 use config::{
-    utils::get_available_port, Authority, Committee, PrimaryAddresses, WorkerAddresses, WorkerId,
+    utils::get_available_port, Authority, Committee, PrimaryAddresses, SharedCommittee,
+    WorkerAddresses, WorkerId,
 };
 use crypto::{
     ed25519::{Ed25519KeyPair, Ed25519PublicKey, Ed25519Signature},
@@ -57,132 +59,139 @@ pub fn keys(rng_seed: impl Into<Option<u64>>) -> Vec<Ed25519KeyPair> {
 }
 
 // Fixture
-pub fn committee(rng_seed: impl Into<Option<u64>>) -> Committee<Ed25519PublicKey> {
+pub fn committee(rng_seed: impl Into<Option<u64>>) -> SharedCommittee<Ed25519PublicKey> {
     committee_from_keys(&keys(rng_seed))
 }
 
-pub fn committee_from_keys(keys: &[Ed25519KeyPair]) -> Committee<Ed25519PublicKey> {
-    Committee {
-        authorities: keys
-            .iter()
-            .map(|kp| {
-                let id = kp.public();
-                let primary = PrimaryAddresses {
-                    primary_to_primary: format!("/ip4/127.0.0.1/tcp/{}/http", get_available_port())
+pub fn committee_from_keys(keys: &[Ed25519KeyPair]) -> SharedCommittee<Ed25519PublicKey> {
+    Arc::new(Committee {
+        authorities: ArcSwap::from_pointee(
+            keys.iter()
+                .map(|kp| {
+                    let id = kp.public();
+                    let primary = PrimaryAddresses {
+                        primary_to_primary: format!(
+                            "/ip4/127.0.0.1/tcp/{}/http",
+                            get_available_port()
+                        )
                         .parse()
                         .unwrap(),
-                    worker_to_primary: format!("/ip4/127.0.0.1/tcp/{}/http", get_available_port())
+                        worker_to_primary: format!(
+                            "/ip4/127.0.0.1/tcp/{}/http",
+                            get_available_port()
+                        )
                         .parse()
                         .unwrap(),
-                };
-                let workers = vec![
+                    };
+                    let workers = vec![
+                        (
+                            0,
+                            WorkerAddresses {
+                                primary_to_worker: format!(
+                                    "/ip4/127.0.0.1/tcp/{}/http",
+                                    get_available_port()
+                                )
+                                .parse()
+                                .unwrap(),
+                                transactions: format!(
+                                    "/ip4/127.0.0.1/tcp/{}/http",
+                                    get_available_port()
+                                )
+                                .parse()
+                                .unwrap(),
+                                worker_to_worker: format!(
+                                    "/ip4/127.0.0.1/tcp/{}/http",
+                                    get_available_port()
+                                )
+                                .parse()
+                                .unwrap(),
+                            },
+                        ),
+                        (
+                            1,
+                            WorkerAddresses {
+                                primary_to_worker: format!(
+                                    "/ip4/127.0.0.1/tcp/{}/http",
+                                    get_available_port()
+                                )
+                                .parse()
+                                .unwrap(),
+                                transactions: format!(
+                                    "/ip4/127.0.0.1/tcp/{}/http",
+                                    get_available_port()
+                                )
+                                .parse()
+                                .unwrap(),
+                                worker_to_worker: format!(
+                                    "/ip4/127.0.0.1/tcp/{}/http",
+                                    get_available_port()
+                                )
+                                .parse()
+                                .unwrap(),
+                            },
+                        ),
+                        (
+                            2,
+                            WorkerAddresses {
+                                primary_to_worker: format!(
+                                    "/ip4/127.0.0.1/tcp/{}/http",
+                                    get_available_port()
+                                )
+                                .parse()
+                                .unwrap(),
+                                transactions: format!(
+                                    "/ip4/127.0.0.1/tcp/{}/http",
+                                    get_available_port()
+                                )
+                                .parse()
+                                .unwrap(),
+                                worker_to_worker: format!(
+                                    "/ip4/127.0.0.1/tcp/{}/http",
+                                    get_available_port()
+                                )
+                                .parse()
+                                .unwrap(),
+                            },
+                        ),
+                        (
+                            3,
+                            WorkerAddresses {
+                                primary_to_worker: format!(
+                                    "/ip4/127.0.0.1/tcp/{}/http",
+                                    get_available_port()
+                                )
+                                .parse()
+                                .unwrap(),
+                                transactions: format!(
+                                    "/ip4/127.0.0.1/tcp/{}/http",
+                                    get_available_port()
+                                )
+                                .parse()
+                                .unwrap(),
+                                worker_to_worker: format!(
+                                    "/ip4/127.0.0.1/tcp/{}/http",
+                                    get_available_port()
+                                )
+                                .parse()
+                                .unwrap(),
+                            },
+                        ),
+                    ]
+                    .iter()
+                    .cloned()
+                    .collect();
                     (
-                        0,
-                        WorkerAddresses {
-                            primary_to_worker: format!(
-                                "/ip4/127.0.0.1/tcp/{}/http",
-                                get_available_port()
-                            )
-                            .parse()
-                            .unwrap(),
-                            transactions: format!(
-                                "/ip4/127.0.0.1/tcp/{}/http",
-                                get_available_port()
-                            )
-                            .parse()
-                            .unwrap(),
-                            worker_to_worker: format!(
-                                "/ip4/127.0.0.1/tcp/{}/http",
-                                get_available_port()
-                            )
-                            .parse()
-                            .unwrap(),
+                        id.clone(),
+                        Authority {
+                            stake: 1,
+                            primary,
+                            workers,
                         },
-                    ),
-                    (
-                        1,
-                        WorkerAddresses {
-                            primary_to_worker: format!(
-                                "/ip4/127.0.0.1/tcp/{}/http",
-                                get_available_port()
-                            )
-                            .parse()
-                            .unwrap(),
-                            transactions: format!(
-                                "/ip4/127.0.0.1/tcp/{}/http",
-                                get_available_port()
-                            )
-                            .parse()
-                            .unwrap(),
-                            worker_to_worker: format!(
-                                "/ip4/127.0.0.1/tcp/{}/http",
-                                get_available_port()
-                            )
-                            .parse()
-                            .unwrap(),
-                        },
-                    ),
-                    (
-                        2,
-                        WorkerAddresses {
-                            primary_to_worker: format!(
-                                "/ip4/127.0.0.1/tcp/{}/http",
-                                get_available_port()
-                            )
-                            .parse()
-                            .unwrap(),
-                            transactions: format!(
-                                "/ip4/127.0.0.1/tcp/{}/http",
-                                get_available_port()
-                            )
-                            .parse()
-                            .unwrap(),
-                            worker_to_worker: format!(
-                                "/ip4/127.0.0.1/tcp/{}/http",
-                                get_available_port()
-                            )
-                            .parse()
-                            .unwrap(),
-                        },
-                    ),
-                    (
-                        3,
-                        WorkerAddresses {
-                            primary_to_worker: format!(
-                                "/ip4/127.0.0.1/tcp/{}/http",
-                                get_available_port()
-                            )
-                            .parse()
-                            .unwrap(),
-                            transactions: format!(
-                                "/ip4/127.0.0.1/tcp/{}/http",
-                                get_available_port()
-                            )
-                            .parse()
-                            .unwrap(),
-                            worker_to_worker: format!(
-                                "/ip4/127.0.0.1/tcp/{}/http",
-                                get_available_port()
-                            )
-                            .parse()
-                            .unwrap(),
-                        },
-                    ),
-                ]
-                .iter()
-                .cloned()
-                .collect();
-                (
-                    id.clone(),
-                    Authority {
-                        stake: 1,
-                        primary,
-                        workers,
-                    },
-                )
-            })
-            .collect(),
-    }
+                    )
+                })
+                .collect(),
+        ),
+    })
 }
 
 ////////////////////////////////////////////////////////////////
@@ -190,25 +199,26 @@ pub fn committee_from_keys(keys: &[Ed25519KeyPair]) -> Committee<Ed25519PublicKe
 ////////////////////////////////////////////////////////////////
 
 // Fixture
-pub fn mock_committee(keys: &[Ed25519PublicKey]) -> Committee<Ed25519PublicKey> {
-    Committee {
-        authorities: keys
-            .iter()
-            .map(|id| {
-                (
-                    id.clone(),
-                    Authority {
-                        stake: 1,
-                        primary: PrimaryAddresses {
-                            primary_to_primary: "/ip4/0.0.0.0/tcp/0/http".parse().unwrap(),
-                            worker_to_primary: "/ip4/0.0.0.0/tcp/0/http".parse().unwrap(),
+pub fn mock_committee(keys: &[Ed25519PublicKey]) -> SharedCommittee<Ed25519PublicKey> {
+    Arc::new(Committee {
+        authorities: ArcSwap::from_pointee(
+            keys.iter()
+                .map(|id| {
+                    (
+                        id.clone(),
+                        Authority {
+                            stake: 1,
+                            primary: PrimaryAddresses {
+                                primary_to_primary: "/ip4/0.0.0.0/tcp/0/http".parse().unwrap(),
+                                worker_to_primary: "/ip4/0.0.0.0/tcp/0/http".parse().unwrap(),
+                            },
+                            workers: HashMap::default(),
                         },
-                        workers: HashMap::default(),
-                    },
-                )
-            })
-            .collect(),
-    }
+                    )
+                })
+                .collect(),
+        ),
+    })
 }
 
 pub fn make_consensus_store(store_path: &std::path::Path) -> Arc<ConsensusStore<Ed25519PublicKey>> {
@@ -510,7 +520,7 @@ impl WorkerToWorker for WorkerToWorkerMockServer {
 }
 
 // helper method to get a name and a committee.
-pub fn resolve_name_and_committee() -> (Ed25519PublicKey, Committee<Ed25519PublicKey>) {
+pub fn resolve_name_and_committee() -> (Ed25519PublicKey, SharedCommittee<Ed25519PublicKey>) {
     let mut keys = keys(None);
     let _ = keys.pop().unwrap(); // Skip the header' author.
     let kp = keys.pop().unwrap();

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -15,11 +15,11 @@ use crypto::{
 use futures::Stream;
 use multiaddr::Multiaddr;
 use rand::{rngs::StdRng, Rng, SeedableRng as _};
-use std::sync::Arc;
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, VecDeque},
     ops::RangeInclusive,
     pin::Pin,
+    sync::Arc,
 };
 use store::{reopen, rocks, rocks::DBMap, Store};
 use tokio::sync::mpsc::{channel, Receiver, Sender};

--- a/types/src/primary.rs
+++ b/types/src/primary.rs
@@ -349,6 +349,7 @@ impl<PublicKey: VerifyingKey> Certificate<PublicKey> {
     pub fn genesis(committee: &Committee<PublicKey>) -> Vec<Self> {
         committee
             .authorities
+            .load()
             .keys()
             .map(|name| Self {
                 header: Header {

--- a/worker/src/helper.rs
+++ b/worker/src/helper.rs
@@ -2,7 +2,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use bytes::Bytes;
-use config::{Committee, WorkerId};
+use config::{SharedCommittee, WorkerId};
 use crypto::traits::VerifyingKey;
 use network::WorkerNetwork;
 use store::Store;
@@ -19,7 +19,7 @@ pub struct Helper<PublicKey: VerifyingKey> {
     /// The id of this worker.
     id: WorkerId,
     /// The committee information.
-    committee: Committee<PublicKey>,
+    committee: SharedCommittee<PublicKey>,
     /// The persistent storage.
     store: Store<BatchDigest, SerializedBatchMessage>,
     /// Input channel to receive batch requests from workers.
@@ -33,7 +33,7 @@ pub struct Helper<PublicKey: VerifyingKey> {
 impl<PublicKey: VerifyingKey> Helper<PublicKey> {
     pub fn spawn(
         id: WorkerId,
-        committee: Committee<PublicKey>,
+        committee: SharedCommittee<PublicKey>,
         store: Store<BatchDigest, SerializedBatchMessage>,
         rx_worker_request: Receiver<(Vec<BatchDigest>, PublicKey)>,
         rx_client_request: Receiver<(Vec<BatchDigest>, Sender<SerializedBatchMessage>)>,

--- a/worker/src/quorum_waiter.rs
+++ b/worker/src/quorum_waiter.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2021, Facebook, Inc. and its affiliates
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use config::{Committee, Stake};
+use config::{SharedCommittee, Stake};
 use crypto::traits::VerifyingKey;
 use futures::stream::{futures_unordered::FuturesUnordered, StreamExt as _};
 use network::CancelHandler;
@@ -23,7 +23,7 @@ pub struct QuorumWaiterMessage<PublicKey> {
 /// The QuorumWaiter waits for 2f authorities to acknowledge reception of a batch.
 pub struct QuorumWaiter<PublicKey: VerifyingKey> {
     /// The committee information.
-    committee: Committee<PublicKey>,
+    committee: SharedCommittee<PublicKey>,
     /// The stake of this authority.
     stake: Stake,
     /// Input Channel to receive commands.
@@ -35,7 +35,7 @@ pub struct QuorumWaiter<PublicKey: VerifyingKey> {
 impl<PublicKey: VerifyingKey> QuorumWaiter<PublicKey> {
     /// Spawn a new QuorumWaiter.
     pub fn spawn(
-        committee: Committee<PublicKey>,
+        committee: SharedCommittee<PublicKey>,
         stake: Stake,
         rx_message: Receiver<QuorumWaiterMessage<PublicKey>>,
         tx_batch: Sender<Vec<u8>>,

--- a/worker/src/synchronizer.rs
+++ b/worker/src/synchronizer.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2021, Facebook, Inc. and its affiliates
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use config::{Committee, WorkerId};
+use config::{SharedCommittee, WorkerId};
 use crypto::traits::VerifyingKey;
 use futures::stream::{futures_unordered::FuturesUnordered, StreamExt as _};
 use network::WorkerNetwork;
@@ -32,7 +32,7 @@ pub struct Synchronizer<PublicKey: VerifyingKey> {
     /// The id of this worker.
     id: WorkerId,
     /// The committee information.
-    committee: Committee<PublicKey>,
+    committee: SharedCommittee<PublicKey>,
     // The persistent storage.
     store: Store<BatchDigest, SerializedBatchMessage>,
     /// The depth of the garbage collection.
@@ -60,7 +60,7 @@ impl<PublicKey: VerifyingKey> Synchronizer<PublicKey> {
     pub fn spawn(
         name: PublicKey,
         id: WorkerId,
-        committee: Committee<PublicKey>,
+        committee: SharedCommittee<PublicKey>,
         store: Store<BatchDigest, SerializedBatchMessage>,
         gc_depth: Round,
         sync_retry_delay: Duration,

--- a/worker/src/worker.rs
+++ b/worker/src/worker.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use async_trait::async_trait;
 use bytes::Bytes;
-use config::{Committee, Parameters, WorkerId};
+use config::{Parameters, SharedCommittee, WorkerId};
 use crypto::traits::VerifyingKey;
 use futures::{Stream, StreamExt};
 use multiaddr::{Multiaddr, Protocol};
@@ -41,8 +41,8 @@ pub struct Worker<PublicKey: VerifyingKey> {
     /// The id of this worker.
     id: WorkerId,
     /// The committee information.
-    committee: Committee<PublicKey>,
-    /// The configuration parameters.
+    committee: SharedCommittee<PublicKey>,
+    /// The configuration parameters
     parameters: Parameters,
     /// The persistent storage.
     store: Store<BatchDigest, SerializedBatchMessage>,
@@ -54,7 +54,7 @@ impl<PublicKey: VerifyingKey> Worker<PublicKey> {
     pub fn spawn(
         name: PublicKey,
         id: WorkerId,
-        committee: Committee<PublicKey>,
+        committee: SharedCommittee<PublicKey>,
         parameters: Parameters,
         store: Store<BatchDigest, SerializedBatchMessage>,
     ) -> JoinHandle<()> {


### PR DESCRIPTION
This is step 1/2 of making primaries connect to other primaries in the code base: 
- making the `Committee` data structure updatable,
- adding an `update_primary_network_info` call that has the edition semantics we want (repeat the `ValidatorData`, and make adjustments to the `MultiAddr`s therein),
- tests that

This does not yet connect this updatability to `new_network_info`, or implement a wait-until-ping protocol, but I'm issuing the PR anyway because the change is pervasive, and in its current state, this is a nice cutoff point, which will help avoid long rebases in the future.