### PR TITLE
[refactor] trace only necessary fields

### DIFF
--- a/consensus/src/dag.rs
+++ b/consensus/src/dag.rs
@@ -146,7 +146,7 @@ impl<PublicKey: VerifyingKey> InnerDag<PublicKey> {
         }
     }
 
-    #[instrument(level = "debug", err)]
+    #[instrument(level = "debug", skip_all, fields(certificate = ?certificate), err)]
     fn insert(
         &mut self,
         certificate: Certificate<PublicKey>,
@@ -172,7 +172,7 @@ impl<PublicKey: VerifyingKey> InnerDag<PublicKey> {
     }
 
     /// Returns the oldest and newest rounds for which a validator has (live) certificates in the DAG
-    #[instrument(level = "debug", err)]
+    #[instrument(level = "debug", skip_all, fields(origin = ?origin), err)]
     fn rounds(
         &mut self,
         origin: PublicKey,
@@ -205,7 +205,7 @@ impl<PublicKey: VerifyingKey> InnerDag<PublicKey> {
 
     /// Returns a breadth first traversal of the Dag, starting with the certified collection
     /// passed as argument.
-    #[instrument(level = "debug", err)]
+    #[instrument(level = "debug", skip_all, fields(start_certificate_id = ?start), err)]
     fn read_causal(
         &self,
         start: CertificateDigest,
@@ -216,7 +216,7 @@ impl<PublicKey: VerifyingKey> InnerDag<PublicKey> {
 
     /// Returns a breadth first traversal of the Dag, starting with the certified collection
     /// passed as argument.
-    #[instrument(level = "debug", err)]
+    #[instrument(level = "debug", skip_all, fields(origin = ?origin, round = ?round), err)]
     fn node_read_causal(
         &self,
         origin: PublicKey,
@@ -230,7 +230,7 @@ impl<PublicKey: VerifyingKey> InnerDag<PublicKey> {
     }
 
     /// Removes certificates from the Dag, reclaiming memory in the process.
-    #[instrument(level = "debug", err)]
+    #[instrument(level = "debug", skip_all, fields(certificate_ids = ?digests), err)]
     fn remove(
         &mut self,
         digests: Vec<CertificateDigest>,

--- a/primary/tests/integration_tests_proposer_api.rs
+++ b/primary/tests/integration_tests_proposer_api.rs
@@ -11,8 +11,11 @@ use crypto::{
 use futures::future::join_all;
 use node::NodeStorage;
 use primary::{Primary, CHANNEL_CAPACITY};
-use std::collections::BTreeMap;
-use std::{collections::BTreeSet, sync::Arc, time::Duration};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    sync::Arc,
+    time::Duration,
+};
 use test_utils::{
     committee, committee_from_keys, keys, make_optimal_certificates,
     make_optimal_signed_certificates, temp_dir,


### PR DESCRIPTION
This PR ensures that we don't track excessive information on our tracing which when enabled (on log level DEBUG) is causing the CPU maxing out and memory excessively consumed (in ~1 min more than 1 GB is consumed) as the whole DAG structure was always captured. We recently observed that behaviour during the docker cluster deployment.

### Before:
* Running a cluster of 4 authorities with log level DEBUG and consensus disabled (so the virtual DAG is used. After 1 minute of running the `primary_0` node had the following stats:
<img width="1243" alt="Screenshot 2022-05-26 at 13 07 38" src="https://user-images.githubusercontent.com/17335598/170514154-b0b51acf-78ed-4fd3-bd51-a9ba6bba9e43.png">

### After the changes on similar setup and running time of 5 minutes:

<img width="999" alt="Screenshot 2022-05-26 at 14 48 08" src="https://user-images.githubusercontent.com/17335598/170514481-187febe7-0d23-4558-ad84-5351dd3e5341.png">

