### PR TITLE
refactor: insert genesis certificates in certificate store when using virtual DAG

### DIFF
--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 use config::{Parameters, SharedCommittee, WorkerId};
 use consensus::{dag::Dag, Consensus, SubscriberHandler};
-use crypto::traits::{KeyPair, Signer, VerifyingKey};
+use crypto::{
+    traits::{KeyPair, Signer, VerifyingKey},
+    Hash,
+};
 use executor::{ExecutionState, Executor, SerializedTransaction, SubscriberResult};
 use primary::{PayloadToken, Primary};
 use std::sync::Arc;
@@ -138,6 +141,16 @@ impl Node {
             .await?;
             None
         };
+
+        if dag.is_some() {
+            // populate genesis to certificate store.
+            let genesis = Certificate::genesis(&committee);
+            store
+                .certificate_store
+                .write_all(genesis.into_iter().map(|c| (c.digest(), c)))
+                .await
+                .unwrap();
+        }
 
         // Spawn the primary.
         let primary_handle = Primary::spawn(


### PR DESCRIPTION
Related to: https://github.com/MystenLabs/narwhal/issues/281

Both the:
* get_collections
* remove_collections

requests are using as source of truth the `certificate_store`. Following the fix on https://github.com/MystenLabs/narwhal/issues/270, now it would be possible via the `read_causal` request to get back the genesis certificate digests which when queried via the above requests, will lead to failures.

To avoid that, we want to store the genesis certificates on the storage as well - when using the virtual DAG (when using Tusk we won't do that) - so those can be discoverable from the above requests.