### PR TITLE
refactor: reduce logging level for some modules

### DIFF
--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -84,7 +84,7 @@ async fn main() -> Result<()> {
     let filter = EnvFilter::builder()
         .with_default_directive(LevelFilter::INFO.into())
         .parse(format!(
-            "{tracing_level},h2::codec={network_tracing_level},tower::buffer={network_tracing_level},tonic::transport={network_tracing_level},{custom_directive}"
+            "{tracing_level},h2={network_tracing_level},tower={network_tracing_level},hyper={network_tracing_level},tonic::transport={network_tracing_level},{custom_directive}"
         ))?;
 
     let env_filter = EnvFilter::try_from_default_env().unwrap_or(filter);

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -84,7 +84,7 @@ async fn main() -> Result<()> {
     let filter = EnvFilter::builder()
         .with_default_directive(LevelFilter::INFO.into())
         .parse(format!(
-            "{tracing_level},h2::codec={network_tracing_level},{custom_directive}"
+            "{tracing_level},h2::codec={network_tracing_level},tower::buffer={network_tracing_level},tonic::transport={network_tracing_level},{custom_directive}"
         ))?;
 
     let env_filter = EnvFilter::try_from_default_env().unwrap_or(filter);


### PR DESCRIPTION
There are some third party modules that log excessive information when `trace` log level is enabled , making very hard to see our `trace` logs from our code. This PR is reducing the logging level for some of them. E.x of logs:

```
2022-05-27T22:42:37.309550Z TRACE hyper::client::connect::http: connect error for 127.0.0.1:3100: ConnectError("tcp connect error", Os { code: 61, kind: ConnectionRefused, message: "Connection refused" })
2022-05-27T22:42:37.309641Z TRACE tonic::transport::service::reconnect: poll_ready; error
2022-05-27T22:42:37.309669Z DEBUG tonic::transport::service::reconnect: reconnect::poll_ready: hyper::Error(Connect, ConnectError("tcp connect error", Os { code: 61, kind: ConnectionRefused, message: "Connection refused" }))
2022-05-27T22:42:37.310675Z DEBUG tower::buffer::worker: service.ready=true processing request
2022-05-27T22:42:37.310763Z TRACE tonic::transport::service::reconnect: Reconnect::call
2022-05-27T22:42:37.310793Z DEBUG tonic::transport::service::reconnect: error: error trying to connect: tcp connect error: Connection refused (os error 61)
2022-05-27T22:42:37.310865Z TRACE tower::buffer::worker: returning response future
2022-05-27T22:42:37.310918Z TRACE tower::buffer::worker: worker polling for next message
2022-05-27T22:42:37.539969Z TRACE tower::buffer::service: sending request to buffer worker
2022-05-27T22:42:37.540246Z TRACE tower::buffer::worker: worker polling for next message
2022-05-27T22:42:37.540312Z TRACE tower::buffer::worker: processing new request
2022-05-27T22:42:37.540357Z TRACE tower::buffer::worker: resumed=false worker received request; waiting for service readiness
2022-05-27T22:42:37.540430Z TRACE tonic::transport::service::reconnect: poll_ready; idle
2022-05-27T22:42:37.540526Z TRACE tonic::transport::service::reconnect: poll_ready; connecting
2022-05-27T22:42:37.540643Z TRACE hyper::client::connect::http: Http::connect; scheme=Some("http"), host=Some("127.0.0.1"), port=Some(Port(3300))
2022-05-27T22:42:37.540814Z DEBUG hyper::client::connect::http: connecting to 127.0.0.1:3300
2022-05-27T22:42:37.541496Z TRACE tonic::transport::service::reconnect: poll_ready; not ready
2022-05-27T22:42:37.541530Z TRACE tower::buffer::worker: service.ready=false delay
2022-05-27T22:42:37.541712Z TRACE tower::buffer::worker: worker polling for next message
2022-05-27T22:42:37.541739Z TRACE tower::buffer::worker: resuming buffered request
2022-05-27T22:42:37.541761Z TRACE tower::buffer::worker: resumed=true worker received request; waiting for service readiness
2022-05-27T22:42:37.541792Z TRACE tonic::transport::service::reconnect: poll_ready; connecting
```