### PR TITLE
fix: ignore json files & python-version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-.json
+*.json
+*.python-version
 !Docker/**/*.json
 Docker/validators/**/db-*
 Docker/validators/**/logs*


### PR DESCRIPTION
It seems that we reverted the ignoring of the json files . If that wasn't a mistake, let's see what's the configuration we are looking for. Ultimately the should ignore the `json` files under the `benchmarks` folder. Also added ignoring the `.python-version` which is created from the [pyenv](https://github.com/pyenv/pyenv) tool (using it for switching python versions to run benchmarks)