### PR TITLE
fix: Expose the failibility of `serialize_batch_digest` & error-handle

### DIFF
--- a/executor/src/tests/fixtures.rs
+++ b/executor/src/tests/fixtures.rs
@@ -24,7 +24,7 @@ pub fn test_batch<T: Serialize>(transactions: Vec<T>) -> (BatchDigest, Serialize
         .collect();
     let message = WorkerMessage::<Ed25519PublicKey>::Batch(Batch(batch));
     let serialized = bincode::serialize(&message).unwrap();
-    let digest = serialized_batch_digest(&serialized);
+    let digest = serialized_batch_digest(&serialized).unwrap();
     (digest, serialized)
 }
 

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -310,7 +310,7 @@ pub fn fixture_payload(number_of_batches: u8) -> BTreeMap<BatchDigest, WorkerId>
             5u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, // tx length
             10u8, 5u8, 8u8, 20u8, i, //tx
         ];
-        let batch_digest = serialized_batch_digest(&dummy_serialized_batch);
+        let batch_digest = serialized_batch_digest(&dummy_serialized_batch).unwrap();
 
         payload.insert(batch_digest, 0);
     }
@@ -541,12 +541,12 @@ pub fn batch() -> Batch {
 
 // Fixture
 pub fn batch_digest() -> BatchDigest {
-    serialized_batch_digest(&serialized_batch())
+    serialized_batch_digest(&serialized_batch()).unwrap()
 }
 
 pub fn digest_batch(batch: Batch) -> BatchDigest {
     let serialized_batch = serialize_batch_message(batch);
-    serialized_batch_digest(&serialized_batch)
+    serialized_batch_digest(&serialized_batch).unwrap()
 }
 
 // Fixture

--- a/types/tests/batch_serde.rs
+++ b/types/tests/batch_serde.rs
@@ -94,7 +94,7 @@ proptest::proptest! {
         let digest = batch.digest();
         let message = WorkerMessage::<Ed25519PublicKey>::Batch(batch);
         let serialized = bincode::serialize(&message).expect("Failed to serialize our own batch");
-        let digest_from_serialized = serialized_batch_digest(&serialized);
+        let digest_from_serialized = serialized_batch_digest(&serialized).expect("Failed to hash serialized batch");
         assert_eq!(digest, digest_from_serialized);
     }
 }

--- a/worker/src/tests/synchronizer_tests.rs
+++ b/worker/src/tests/synchronizer_tests.rs
@@ -83,7 +83,7 @@ async fn test_successful_request_batch() {
     // Create a dummy batch and store
     let expected_batch = batch();
     let batch_serialised = serialize_batch_message(expected_batch.clone());
-    let expected_digest = serialized_batch_digest(&batch_serialised.clone());
+    let expected_digest = serialized_batch_digest(&batch_serialised.clone()).unwrap();
     store.write(expected_digest, batch_serialised.clone()).await;
 
     // WHEN we send a message to retrieve the batch
@@ -195,7 +195,7 @@ async fn test_successful_batch_delete() {
 
     for batch in expected_batches.clone() {
         let s = serialize_batch_message(batch);
-        let digest = serialized_batch_digest(&s.clone());
+        let digest = serialized_batch_digest(&s.clone()).unwrap();
 
         batch_digests.push(digest);
 
@@ -225,7 +225,7 @@ async fn test_successful_batch_delete() {
     // AND batches should be deleted
     for batch in expected_batches {
         let s = serialize_batch_message(batch);
-        let digest = serialized_batch_digest(&s.clone());
+        let digest = serialized_batch_digest(&s.clone()).unwrap();
 
         let result = store.read(digest).await;
         assert!(result.as_ref().is_ok());

--- a/worker/src/tests/worker_tests.rs
+++ b/worker/src/tests/worker_tests.rs
@@ -39,7 +39,7 @@ async fn handle_clients_transactions() {
     // Spawn a network listener to receive our batch's digest.
     let batch = batch();
     let serialized_batch = serialize_batch_message(batch.clone());
-    let batch_digest = serialized_batch_digest(&serialized_batch);
+    let batch_digest = serialized_batch_digest(&serialized_batch).unwrap();
 
     let primary_address = committee.primary(&name).unwrap().worker_to_primary;
     let expected = bincode::serialize(&WorkerPrimaryMessage::OurBatch(batch_digest, id)).unwrap();


### PR DESCRIPTION
- responds to an invalid serialized batch,
    * the primary-to-worker flow is straightforward, as an error should not really happen,
    * the processor case is more complex, this is a place where we could use some alerting à la MystenLabs/sui#5295 
- closes MystenLabs/narwhal#268