### PR TITLE
[demo_client] make output more clean

### DIFF
--- a/examples/src/demo_client.rs
+++ b/examples/src/demo_client.rs
@@ -113,7 +113,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut proposed_block_gas_cost: i32 = 0;
 
     println!("\n2) Find collections from earliest round and continue to add collections until gas limit is hit\n");
-    //println!("---- Use NodeReadCausal endpoint ----\n");
     let mut collection_ids = Vec::new();
     let mut extra_collections = Vec::new();
     while round <= newest_round {
@@ -144,7 +143,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     println!(
                         "\n\t\t2b) Get collection [{}] payloads to calculate gas cost of proposed block.\n", collection_id
                     );
-                    //println!("\t---- Use GetCollections endpoint ----\n");
 
                     let get_collections_request = GetCollectionsRequest {
                         collection_ids: vec![collection_id.clone()],

--- a/examples/src/demo_client.rs
+++ b/examples/src/demo_client.rs
@@ -2,17 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::{crate_name, crate_version, App, AppSettings, Arg, SubCommand};
-use narwhal::proposer_client::ProposerClient;
-use narwhal::validator_client::ValidatorClient;
-use narwhal::CollectionRetrievalResult;
 use narwhal::{
-    collection_retrieval_result::RetrievalResult, BatchDigest, CertificateDigest, Empty,
-    GetCollectionsRequest, GetCollectionsResponse, NodeReadCausalRequest, NodeReadCausalResponse,
-    PublicKey, ReadCausalRequest, ReadCausalResponse, RemoveCollectionsRequest, RoundsRequest,
-    RoundsResponse,
+    collection_retrieval_result::RetrievalResult, proposer_client::ProposerClient,
+    validator_client::ValidatorClient, BatchDigest, CertificateDigest, CollectionRetrievalResult,
+    Empty, GetCollectionsRequest, GetCollectionsResponse, NodeReadCausalRequest,
+    NodeReadCausalResponse, PublicKey, ReadCausalRequest, ReadCausalResponse,
+    RemoveCollectionsRequest, RoundsRequest, RoundsResponse,
 };
-use std::fmt;
-use std::fmt::{Display, Formatter};
+use std::{
+    fmt,
+    fmt::{Display, Formatter},
+};
 use tonic::Status;
 
 pub mod narwhal {
@@ -89,8 +89,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut validator_client_1 = ValidatorClient::connect(dsts[0].clone()).await?;
     let public_key = base64::decode(&base64_keys[0]).unwrap();
 
-    println!("\n1) Retrieve the range of rounds you have a collection for\n");
-    println!("\n---- Use Rounds endpoint ----\n");
+    println!("\n1) Retrieve the range of rounds you have a collection for");
+    println!("\n\t---- Use Rounds endpoint ----\n");
 
     let rounds_request = RoundsRequest {
         public_key: Some(PublicKey {
@@ -98,13 +98,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }),
     };
 
-    println!("{}\n", rounds_request);
+    println!("\t{}\n", rounds_request);
 
     let request = tonic::Request::new(rounds_request);
     let response = proposer_client_1.rounds(request).await;
     let rounds_response = response.unwrap().into_inner();
 
-    println!("{}\n", rounds_response);
+    println!("\t{}\n", rounds_response);
 
     let oldest_round = rounds_response.oldest_round;
     let newest_round = rounds_response.newest_round;
@@ -113,8 +113,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut proposed_block_gas_cost: i32 = 0;
 
     println!("\n2) Find collections from earliest round and continue to add collections until gas limit is hit\n");
-    println!("\n---- Use NodeReadCausal endpoint ----\n");
-
+    //println!("---- Use NodeReadCausal endpoint ----\n");
     let mut collection_ids = Vec::new();
     let mut extra_collections = Vec::new();
     while round <= newest_round {
@@ -125,7 +124,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             round,
         };
 
-        println!("{}\n", node_read_causal_request);
+        println!("\t-------------------------------------");
+        println!("\t| 2a) Find collections for round = {}", round);
+        println!("\t-------------------------------------");
+
+        println!("\t{}\n", node_read_causal_request);
 
         let request = tonic::Request::new(node_read_causal_request);
         let response = proposer_client_1.node_read_causal(request).await;
@@ -139,15 +142,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     duplicate_collection_count += 1;
                 } else {
                     println!(
-                        "\n2a) Get collection payloads to calculate gas cost of proposed block.\n"
+                        "\n\t\t2b) Get collection [{}] payloads to calculate gas cost of proposed block.\n", collection_id
                     );
-                    println!("\n---- Use GetCollections endpoint ----\n");
+                    //println!("\t---- Use GetCollections endpoint ----\n");
 
                     let get_collections_request = GetCollectionsRequest {
                         collection_ids: vec![collection_id.clone()],
                     };
 
-                    println!("{}\n", get_collections_request);
+                    println!("\t\t{}\n", get_collections_request);
 
                     let request = tonic::Request::new(get_collections_request);
                     let response = validator_client_1.get_collections(request).await;
@@ -159,14 +162,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         );
 
                     // TODO: This doesn't work in Docker yet, figure out why
-                    println!("Found {total_num_of_transactions} transactions with a total size of {total_transactions_size} bytes");
+                    println!("\t\tFound {total_num_of_transactions} transactions with a total size of {total_transactions_size} bytes");
 
                     proposed_block_gas_cost += total_num_of_transactions;
                     if proposed_block_gas_cost <= BLOCK_GAS_LIMIT {
-                        println!("Adding {total_num_of_transactions} transactions to the proposed block, increasing the block gas cost to {proposed_block_gas_cost}");
+                        println!("\t\tAdding {total_num_of_transactions} transactions to the proposed block, increasing the block gas cost to {proposed_block_gas_cost}");
                         new_collections.push(collection_id);
                     } else {
-                        println!("Not adding {total_num_of_transactions} transactions to the proposed block as it would increase the block gas cost to {proposed_block_gas_cost} which is greater than block gas limit of {BLOCK_GAS_LIMIT}");
+                        println!("\t\t*Not adding {total_num_of_transactions} transactions to the proposed block as it would increase the block gas cost to {proposed_block_gas_cost} which is greater than block gas limit of {BLOCK_GAS_LIMIT}");
                         break;
                     }
                 }
@@ -174,7 +177,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             if new_collections.len() + duplicate_collection_count != count_of_retrieved_collections
             {
                 println!(
-                    "We added {} extra collections to the block proposal from round {round}",
+                    "\t\tWe added {} extra collections to the block proposal from round {round}",
                     new_collections.len()
                 );
                 extra_collections.extend(new_collections.clone());
@@ -183,11 +186,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             collection_ids.extend(new_collections);
 
-            println!("Deduped {:?} collections\n", duplicate_collection_count);
+            println!("\t\tDeduped {:?} collections\n", duplicate_collection_count);
         } else {
-            println!("Error trying to node read causal at round {round}\n")
+            println!("\tError trying to node read causal at round {round}\n")
         }
         if proposed_block_gas_cost >= BLOCK_GAS_LIMIT {
+            println!("\t\t***********************************************************************");
+            println!(
+                "\t\t* Will not continue on more rounds as gas limit {} has been reached",
+                BLOCK_GAS_LIMIT
+            );
+            println!("\t\t***********************************************************************");
             break;
         } else {
             round += 1;
@@ -199,9 +208,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     println!(
-        "\n2 b) Find the first collection returned from node read causal for round {max_round}\n"
+        "\n2c) Find the first collection returned from node read causal for round {max_round}\n"
     );
-    println!("\n---- Use NodeReadCausal endpoint ----\n");
+    println!("---- Use NodeReadCausal endpoint ----\n");
 
     let mut block_proposal_starting_collection: Option<CertificateDigest> = None;
 
@@ -213,7 +222,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             round: max_round,
         };
 
-        println!("{}\n", node_read_causal_request);
+        println!("\t{}\n", node_read_causal_request);
 
         let request = tonic::Request::new(node_read_causal_request);
         let response = proposer_client_1.node_read_causal(request).await;
@@ -222,7 +231,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             block_proposal_starting_collection =
                 Some(node_read_causal_response.collection_ids[0].clone());
         } else {
-            println!("Error trying to node read causal at round {max_round} going back another round and retrying...\n");
+            println!("\tError trying to node read causal at round {max_round} going back another round and retrying...\n");
             max_round -= 1;
         }
     }
@@ -230,15 +239,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let block_proposal_starting_collection = block_proposal_starting_collection.unwrap();
 
     println!(
-        "\nProposing a block with {} collections starting from collection {block_proposal_starting_collection}!\n",
+        "\n\tProposing a block with {} collections starting from collection {block_proposal_starting_collection}!\n",
         collection_ids.len()
     );
 
     // TODO: Add extra collections to fill block proposal as per spec.
     println!(
-        "Broadcasting block proposal with starting certificate `H` {block_proposal_starting_collection} from round {round} in DAG + {} extra collections that fit in the block proposal.", extra_collections.len()
+        "\tBroadcasting block proposal with starting certificate `H` {block_proposal_starting_collection} from round {round} in DAG + {} extra collections that fit in the block proposal.", extra_collections.len()
     );
-    println!("Validators should call ReadCausal(H) which will return [collections] and call GetCollections([collections] + [{} extra_collections]) ", extra_collections.len());
+    println!("\tValidators should call ReadCausal(H) which will return [collections] and call GetCollections([collections] + [{} extra_collections]) ", extra_collections.len());
 
     println!(
         "\n******************************** Validator Service ********************************\n"
@@ -255,66 +264,66 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!(
         "\n3) Find all causal collections from the starting collection {block_proposal_starting_collection} in block proposal.\n",
     );
-    println!("\n---- Use ReadCausal endpoint ----\n");
+    println!("\n\t---- Use ReadCausal endpoint ----\n");
 
     let mut block_proposal_collection_ids = Vec::new();
     let read_causal_request = ReadCausalRequest {
         collection_id: Some(block_proposal_starting_collection),
     };
 
-    println!("{}\n", read_causal_request);
+    println!("\t{}\n", read_causal_request);
 
     let request = tonic::Request::new(read_causal_request);
     let response = validator_client_2.read_causal(request).await;
     let read_causal_response = response.unwrap().into_inner();
 
-    println!("{}\n", read_causal_response);
+    println!("\t{}\n", read_causal_response);
 
     block_proposal_collection_ids.extend(read_causal_response.collection_ids);
 
-    println!("Found {} collections from read causal which will be combined with the {} extra collections from the block proposal", block_proposal_collection_ids.len(), extra_collections.len());
+    println!("\tFound {} collections from read causal which will be combined with the {} extra collections from the block proposal", block_proposal_collection_ids.len(), extra_collections.len());
     block_proposal_collection_ids.extend(extra_collections);
 
     println!(
         "\n4) Obtain the data payload for {} collections in block proposal.\n",
         block_proposal_collection_ids.len()
     );
-    println!("\n---- Use GetCollections endpoint ----\n");
+    println!("\n\t---- Use GetCollections endpoint ----\n");
 
     let get_collections_request = GetCollectionsRequest {
         collection_ids: block_proposal_collection_ids.clone(),
     };
 
-    println!("{}\n", get_collections_request);
+    println!("\t{}\n", get_collections_request);
 
     let request = tonic::Request::new(get_collections_request);
     let response = validator_client_2.get_collections(request).await;
     let get_collection_response = response.unwrap().into_inner();
 
-    println!("{}\n", get_collection_response);
+    println!("\t{}\n", get_collection_response);
 
     let (total_num_of_transactions, total_transactions_size) =
         get_total_transaction_count_and_size(get_collection_response.result.clone());
 
     // TODO: This doesn't work in Docker yet, figure out why
-    println!("Found {total_num_of_transactions} transactions with a total size of {total_transactions_size} bytes\n");
+    println!("\tFound {total_num_of_transactions} transactions with a total size of {total_transactions_size} bytes\n");
 
-    println!("Waiting for validators to decide wheter to vote for the block...\n");
-    println!("Vote completed successfully, block can be removed!\n");
+    println!("\tWaiting for validators to decide wheter to vote for the block...\n");
+    println!("\tVote completed successfully, block can be removed!\n");
 
     println!("\n4) Remove collections that have been voted on and committed.\n");
-    println!("\n---- Test RemoveCollections endpoint ----\n");
+    println!("\n\t---- Test RemoveCollections endpoint ----\n");
 
     let remove_collections_request = RemoveCollectionsRequest { collection_ids };
 
-    println!("{}\n", remove_collections_request);
+    println!("\t{}\n", remove_collections_request);
 
     let request = tonic::Request::new(remove_collections_request);
     let response = validator_client_2.remove_collections(request).await;
     if response.is_ok() {
-        println!("Successfully removed committed collections\n");
+        println!("\tSuccessfully removed committed collections\n");
     } else {
-        println!("Was not able to remove committed collections\n");
+        println!("\tWas not able to remove committed collections\n");
     }
 
     Ok(())
@@ -344,7 +353,7 @@ impl std::fmt::Display for GetCollectionsRequest {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let mut result = "*** GetCollectionsRequest ***".to_string();
         for id in &self.collection_ids {
-            result = format!("{}\nid=\"{}\"", result, id);
+            result = format!("{}\n\t\t|-id=\"{}\"", result, id);
         }
         write!(f, "{}", result)
     }
@@ -354,7 +363,7 @@ impl std::fmt::Display for RemoveCollectionsRequest {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let mut result = "*** RemoveCollectionsRequest ***".to_string();
         for id in &self.collection_ids {
-            result = format!("{}\nid=\"{}\"", result, id);
+            result = format!("{}\n\t|-id=\"{}\"", result, id);
         }
         write!(f, "{}", result)
     }
@@ -385,7 +394,7 @@ impl std::fmt::Display for GetCollectionsResponse {
                     }
 
                     result = format!(
-                        "{}\nBatch id {}, transactions {}, size: {} bytes",
+                        "{}\n\t|-Batch id {}, transactions {}, size: {} bytes",
                         result, batch_id, num_of_transactions, transactions_size
                     );
                 }
@@ -393,7 +402,7 @@ impl std::fmt::Display for GetCollectionsResponse {
                     //let certificate_id = base64::encode(&error.id.unwrap().digest);
 
                     result = format!(
-                        "{}\nError for certificate id {:?}, error: {}",
+                        "{}\n\tError for certificate id {}, error: {}",
                         result,
                         &error.id.unwrap(),
                         error.error
@@ -411,7 +420,7 @@ impl std::fmt::Display for NodeReadCausalResponse {
         let mut result = "*** NodeReadCausalResponse ***".to_string();
 
         for id in &self.collection_ids {
-            result = format!("{}\nid=\"{}\"", result, id);
+            result = format!("{}\n\t|-id=\"{}\"", result, id);
         }
 
         write!(f, "{}", result)
@@ -422,9 +431,9 @@ impl std::fmt::Display for NodeReadCausalRequest {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let mut result = "**** NodeReadCausalRequest ***".to_string();
 
-        result = format!("{}\nRequest for round {}", result, &self.round);
+        result = format!("{}\n\t|-Request for round {}", result, &self.round);
         result = format!(
-            "{}\nAuthority: {}",
+            "{}\n\t|-Authority: {}",
             result,
             base64::encode(&self.public_key.clone().unwrap().bytes)
         );
@@ -438,7 +447,7 @@ impl std::fmt::Display for ReadCausalResponse {
         let mut result = "*** ReadCausalResponse ***".to_string();
 
         for id in &self.collection_ids {
-            result = format!("{}\nid=\"{}\"", result, id);
+            result = format!("{}\n\tid=\"{}\"", result, id);
         }
 
         write!(f, "{}", result)
@@ -450,7 +459,7 @@ impl std::fmt::Display for ReadCausalRequest {
         let mut result = "**** ReadCausalRequest ***".to_string();
 
         result = format!(
-            "{}\nRequest for collection {}",
+            "{}\n\t|-Request for collection {}",
             result,
             &self.collection_id.as_ref().unwrap()
         );
@@ -464,7 +473,7 @@ impl std::fmt::Display for RoundsRequest {
         let mut result = "**** RoundsRequest ***".to_string();
 
         result = format!(
-            "{}\nAuthority: {}",
+            "{}\n\t|-Authority: {}",
             result,
             base64::encode(&self.public_key.clone().unwrap().bytes)
         );
@@ -477,7 +486,7 @@ impl std::fmt::Display for RoundsResponse {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let mut result = "**** RoundsResponse ***".to_string();
         result = format!(
-            "{}\noldest_round: {}, newest_round: {}",
+            "{}\n\t|-oldest_round: {}, newest_round: {}",
             result, &self.oldest_round, &self.newest_round
         );
 
@@ -504,11 +513,11 @@ where
     match result {
         Ok(response) => {
             let inner = response.into_inner();
-            println!("{}", &inner);
+            println!("\t{}", &inner);
             Some(inner)
         }
         Err(error) => {
-            println!("{:?}", error);
+            println!("\t{:?}", error);
             None
         }
     }


### PR DESCRIPTION
Added more padding / indentation to the output and some extra formatting to make output steps more distinguishable.

See example output here:
```
******************************** Proposer Service ********************************


Connecting to http://127.0.0.1:60258 as the proposer.

1) Retrieve the range of rounds you have a collection for

	---- Use Rounds endpoint ----

	**** RoundsRequest ***
	|-Authority: jguVU0r+77F2+JayjOj957jUfzbJMx0MqASK1kkC45I=

	**** RoundsResponse ***
	|-oldest_round: 0, newest_round: 5


2) Find collections from earliest round and continue to add collections until gas limit is hit

	-------------------------------------
	| 2a) Find collections for round = 1
	-------------------------------------
	**** NodeReadCausalRequest ***
	|-Request for round 1
	|-Authority: jguVU0r+77F2+JayjOj957jUfzbJMx0MqASK1kkC45I=

	*** NodeReadCausalResponse ***
	|-id="A9WD9sh3SYZSPiQ9FjCBsx0iMFElJRwDiKGDazRWMvo="

		2b) Get collection [A9WD9sh3SYZSPiQ9FjCBsx0iMFElJRwDiKGDazRWMvo=] payloads to calculate gas cost of proposed block.

		*** GetCollectionsRequest ***
		|-id="A9WD9sh3SYZSPiQ9FjCBsx0iMFElJRwDiKGDazRWMvo="

		Found 23448 transactions with a total size of 12005376 bytes
		Adding 23448 transactions to the proposed block, increasing the block gas cost to 23448
		Deduped 0 collections

	-------------------------------------
	| 2a) Find collections for round = 2
	-------------------------------------
	**** NodeReadCausalRequest ***
	|-Request for round 2
	|-Authority: jguVU0r+77F2+JayjOj957jUfzbJMx0MqASK1kkC45I=

	*** NodeReadCausalResponse ***
	|-id="GVpgkeqUm1BLhMCyjSBU0RVylMYQ+Xtw+OQZXAU9SJc="
	|-id="A9WD9sh3SYZSPiQ9FjCBsx0iMFElJRwDiKGDazRWMvo="
	|-id="XaBnrI3zZ5TcJtHglifmwuoDmwPbEzaHVByHdsFpbpU="
	|-id="m6HxeLHUpUEE6TO7aIH45u3lG2bPhvQ+X2r3l2tkExY="

		2b) Get collection [GVpgkeqUm1BLhMCyjSBU0RVylMYQ+Xtw+OQZXAU9SJc=] payloads to calculate gas cost of proposed block.

		*** GetCollectionsRequest ***
		|-id="GVpgkeqUm1BLhMCyjSBU0RVylMYQ+Xtw+OQZXAU9SJc="

		Found 24425 transactions with a total size of 12505600 bytes
		Adding 24425 transactions to the proposed block, increasing the block gas cost to 47873

		2b) Get collection [XaBnrI3zZ5TcJtHglifmwuoDmwPbEzaHVByHdsFpbpU=] payloads to calculate gas cost of proposed block.

		*** GetCollectionsRequest ***
		|-id="XaBnrI3zZ5TcJtHglifmwuoDmwPbEzaHVByHdsFpbpU="

		Found 23448 transactions with a total size of 12005376 bytes
		Adding 23448 transactions to the proposed block, increasing the block gas cost to 71321

		2b) Get collection [m6HxeLHUpUEE6TO7aIH45u3lG2bPhvQ+X2r3l2tkExY=] payloads to calculate gas cost of proposed block.

		*** GetCollectionsRequest ***
		|-id="m6HxeLHUpUEE6TO7aIH45u3lG2bPhvQ+X2r3l2tkExY="

		Found 23448 transactions with a total size of 12005376 bytes
		Adding 23448 transactions to the proposed block, increasing the block gas cost to 94769
		Deduped 1 collections

	-------------------------------------
	| 2a) Find collections for round = 3
	-------------------------------------
	**** NodeReadCausalRequest ***
	|-Request for round 3
	|-Authority: jguVU0r+77F2+JayjOj957jUfzbJMx0MqASK1kkC45I=

	*** NodeReadCausalResponse ***
	|-id="+kC7wvvKvBXGKjy5XLtye6KsbS35UegOU78ATfwdxnA="
	|-id="GVpgkeqUm1BLhMCyjSBU0RVylMYQ+Xtw+OQZXAU9SJc="
	|-id="UeOtqE1H9Gyp7vPqRoXBBqFECDZSG/UBp+szEaIyn18="
	|-id="+5Nz6E9tqqOIC4E8Eej3mw7J/xKKPigbm5IxgGPkFlE="
	|-id="A9WD9sh3SYZSPiQ9FjCBsx0iMFElJRwDiKGDazRWMvo="
	|-id="XaBnrI3zZ5TcJtHglifmwuoDmwPbEzaHVByHdsFpbpU="
	|-id="m6HxeLHUpUEE6TO7aIH45u3lG2bPhvQ+X2r3l2tkExY="

		2b) Get collection [+kC7wvvKvBXGKjy5XLtye6KsbS35UegOU78ATfwdxnA=] payloads to calculate gas cost of proposed block.

		*** GetCollectionsRequest ***
		|-id="+kC7wvvKvBXGKjy5XLtye6KsbS35UegOU78ATfwdxnA="

		Found 25402 transactions with a total size of 13005824 bytes
		Adding 25402 transactions to the proposed block, increasing the block gas cost to 120171

		2b) Get collection [UeOtqE1H9Gyp7vPqRoXBBqFECDZSG/UBp+szEaIyn18=] payloads to calculate gas cost of proposed block.

		*** GetCollectionsRequest ***
		|-id="UeOtqE1H9Gyp7vPqRoXBBqFECDZSG/UBp+szEaIyn18="

		Found 24425 transactions with a total size of 12505600 bytes
		Adding 24425 transactions to the proposed block, increasing the block gas cost to 144596

		2b) Get collection [+5Nz6E9tqqOIC4E8Eej3mw7J/xKKPigbm5IxgGPkFlE=] payloads to calculate gas cost of proposed block.

		*** GetCollectionsRequest ***
		|-id="+5Nz6E9tqqOIC4E8Eej3mw7J/xKKPigbm5IxgGPkFlE="

		Found 24425 transactions with a total size of 12505600 bytes
		Adding 24425 transactions to the proposed block, increasing the block gas cost to 169021
		Deduped 4 collections

	-------------------------------------
	| 2a) Find collections for round = 4
	-------------------------------------
	**** NodeReadCausalRequest ***
	|-Request for round 4
	|-Authority: jguVU0r+77F2+JayjOj957jUfzbJMx0MqASK1kkC45I=

	*** NodeReadCausalResponse ***
	|-id="5Z1r39oIPK+3INvw1tbPz6kb2UFuMq0//r7ORs8g2bg="
	|-id="UjaqQtME6AjDloUUDGjNlpSXdxBTortvJ/3K6MR3cL0="
	|-id="xa4oHLn8e48nZLzoe1QL7SSfPE2wuavd4MMvN/Z+CRc="
	|-id="+kC7wvvKvBXGKjy5XLtye6KsbS35UegOU78ATfwdxnA="
	|-id="GVpgkeqUm1BLhMCyjSBU0RVylMYQ+Xtw+OQZXAU9SJc="
	|-id="UeOtqE1H9Gyp7vPqRoXBBqFECDZSG/UBp+szEaIyn18="
	|-id="+5Nz6E9tqqOIC4E8Eej3mw7J/xKKPigbm5IxgGPkFlE="
	|-id="A9WD9sh3SYZSPiQ9FjCBsx0iMFElJRwDiKGDazRWMvo="
	|-id="XaBnrI3zZ5TcJtHglifmwuoDmwPbEzaHVByHdsFpbpU="
	|-id="m6HxeLHUpUEE6TO7aIH45u3lG2bPhvQ+X2r3l2tkExY="

		2b) Get collection [5Z1r39oIPK+3INvw1tbPz6kb2UFuMq0//r7ORs8g2bg=] payloads to calculate gas cost of proposed block.

		*** GetCollectionsRequest ***
		|-id="5Z1r39oIPK+3INvw1tbPz6kb2UFuMq0//r7ORs8g2bg="

		Found 25402 transactions with a total size of 13005824 bytes
		Adding 25402 transactions to the proposed block, increasing the block gas cost to 194423

		2b) Get collection [UjaqQtME6AjDloUUDGjNlpSXdxBTortvJ/3K6MR3cL0=] payloads to calculate gas cost of proposed block.

		*** GetCollectionsRequest ***
		|-id="UjaqQtME6AjDloUUDGjNlpSXdxBTortvJ/3K6MR3cL0="

		Found 25402 transactions with a total size of 13005824 bytes
		Adding 25402 transactions to the proposed block, increasing the block gas cost to 219825

		2b) Get collection [xa4oHLn8e48nZLzoe1QL7SSfPE2wuavd4MMvN/Z+CRc=] payloads to calculate gas cost of proposed block.

		*** GetCollectionsRequest ***
		|-id="xa4oHLn8e48nZLzoe1QL7SSfPE2wuavd4MMvN/Z+CRc="

		Found 25402 transactions with a total size of 13005824 bytes
		Adding 25402 transactions to the proposed block, increasing the block gas cost to 245227
		Deduped 7 collections

	-------------------------------------
	| 2a) Find collections for round = 5
	-------------------------------------
	**** NodeReadCausalRequest ***
	|-Request for round 5
	|-Authority: jguVU0r+77F2+JayjOj957jUfzbJMx0MqASK1kkC45I=

	*** NodeReadCausalResponse ***
	|-id="Mrm1f0gfzmZElD8u1FDSf6HPZA3iJUWtu2jb2wf/IgY="
	|-id="QsTGmD/+CMPYYajy0SaSZ1upI5dPLlekb8fSoq8ncDE="
	|-id="yCYy1OveQReBSVQCBu3WHG2uehp72cQtRNunxdsnHGA="
	|-id="5Z1r39oIPK+3INvw1tbPz6kb2UFuMq0//r7ORs8g2bg="
	|-id="UjaqQtME6AjDloUUDGjNlpSXdxBTortvJ/3K6MR3cL0="
	|-id="xa4oHLn8e48nZLzoe1QL7SSfPE2wuavd4MMvN/Z+CRc="
	|-id="+kC7wvvKvBXGKjy5XLtye6KsbS35UegOU78ATfwdxnA="
	|-id="GVpgkeqUm1BLhMCyjSBU0RVylMYQ+Xtw+OQZXAU9SJc="
	|-id="UeOtqE1H9Gyp7vPqRoXBBqFECDZSG/UBp+szEaIyn18="
	|-id="+5Nz6E9tqqOIC4E8Eej3mw7J/xKKPigbm5IxgGPkFlE="
	|-id="A9WD9sh3SYZSPiQ9FjCBsx0iMFElJRwDiKGDazRWMvo="
	|-id="XaBnrI3zZ5TcJtHglifmwuoDmwPbEzaHVByHdsFpbpU="
	|-id="m6HxeLHUpUEE6TO7aIH45u3lG2bPhvQ+X2r3l2tkExY="

		2b) Get collection [Mrm1f0gfzmZElD8u1FDSf6HPZA3iJUWtu2jb2wf/IgY=] payloads to calculate gas cost of proposed block.

		*** GetCollectionsRequest ***
		|-id="Mrm1f0gfzmZElD8u1FDSf6HPZA3iJUWtu2jb2wf/IgY="

		Found 24425 transactions with a total size of 12505600 bytes
		Adding 24425 transactions to the proposed block, increasing the block gas cost to 269652

		2b) Get collection [QsTGmD/+CMPYYajy0SaSZ1upI5dPLlekb8fSoq8ncDE=] payloads to calculate gas cost of proposed block.

		*** GetCollectionsRequest ***
		|-id="QsTGmD/+CMPYYajy0SaSZ1upI5dPLlekb8fSoq8ncDE="

		Found 25402 transactions with a total size of 13005824 bytes
		Adding 25402 transactions to the proposed block, increasing the block gas cost to 295054

		2b) Get collection [yCYy1OveQReBSVQCBu3WHG2uehp72cQtRNunxdsnHGA=] payloads to calculate gas cost of proposed block.

		*** GetCollectionsRequest ***
		|-id="yCYy1OveQReBSVQCBu3WHG2uehp72cQtRNunxdsnHGA="

		Found 25402 transactions with a total size of 13005824 bytes
		*Not adding 25402 transactions to the proposed block as it would increase the block gas cost to 320456 which is greater than block gas limit of 300000
		We added 2 extra collections to the block proposal from round 5
		Deduped 0 collections

		***********************************************************************
		* Will not continue on more rounds as gas limit 300000 has been reached
		***********************************************************************

2c) Find the first collection returned from node read causal for round 4

---- Use NodeReadCausal endpoint ----

	**** NodeReadCausalRequest ***
	|-Request for round 4
	|-Authority: jguVU0r+77F2+JayjOj957jUfzbJMx0MqASK1kkC45I=

	*** NodeReadCausalResponse ***
	|-id="5Z1r39oIPK+3INvw1tbPz6kb2UFuMq0//r7ORs8g2bg="
	|-id="UjaqQtME6AjDloUUDGjNlpSXdxBTortvJ/3K6MR3cL0="
	|-id="xa4oHLn8e48nZLzoe1QL7SSfPE2wuavd4MMvN/Z+CRc="
	|-id="+kC7wvvKvBXGKjy5XLtye6KsbS35UegOU78ATfwdxnA="
	|-id="GVpgkeqUm1BLhMCyjSBU0RVylMYQ+Xtw+OQZXAU9SJc="
	|-id="UeOtqE1H9Gyp7vPqRoXBBqFECDZSG/UBp+szEaIyn18="
	|-id="+5Nz6E9tqqOIC4E8Eej3mw7J/xKKPigbm5IxgGPkFlE="
	|-id="A9WD9sh3SYZSPiQ9FjCBsx0iMFElJRwDiKGDazRWMvo="
	|-id="XaBnrI3zZ5TcJtHglifmwuoDmwPbEzaHVByHdsFpbpU="
	|-id="m6HxeLHUpUEE6TO7aIH45u3lG2bPhvQ+X2r3l2tkExY="

	Proposing a block with 12 collections starting from collection 5Z1r39oIPK+3INvw1tbPz6kb2UFuMq0//r7ORs8g2bg=!

	Broadcasting block proposal with starting certificate `H` 5Z1r39oIPK+3INvw1tbPz6kb2UFuMq0//r7ORs8g2bg= from round 5 in DAG + 2 extra collections that fit in the block proposal.
	Validators should call ReadCausal(H) which will return [collections] and call GetCollections([collections] + [2 extra_collections]) 

******************************** Validator Service ********************************


Connecting to http://127.0.0.1:60259 as the validator

3) Find all causal collections from the starting collection 5Z1r39oIPK+3INvw1tbPz6kb2UFuMq0//r7ORs8g2bg= in block proposal.


	---- Use ReadCausal endpoint ----

	**** ReadCausalRequest ***
	|-Request for collection 5Z1r39oIPK+3INvw1tbPz6kb2UFuMq0//r7ORs8g2bg=

	*** ReadCausalResponse ***
	id="5Z1r39oIPK+3INvw1tbPz6kb2UFuMq0//r7ORs8g2bg="
	id="UjaqQtME6AjDloUUDGjNlpSXdxBTortvJ/3K6MR3cL0="
	id="xa4oHLn8e48nZLzoe1QL7SSfPE2wuavd4MMvN/Z+CRc="
	id="+kC7wvvKvBXGKjy5XLtye6KsbS35UegOU78ATfwdxnA="
	id="GVpgkeqUm1BLhMCyjSBU0RVylMYQ+Xtw+OQZXAU9SJc="
	id="UeOtqE1H9Gyp7vPqRoXBBqFECDZSG/UBp+szEaIyn18="
	id="+5Nz6E9tqqOIC4E8Eej3mw7J/xKKPigbm5IxgGPkFlE="
	id="A9WD9sh3SYZSPiQ9FjCBsx0iMFElJRwDiKGDazRWMvo="
	id="XaBnrI3zZ5TcJtHglifmwuoDmwPbEzaHVByHdsFpbpU="
	id="m6HxeLHUpUEE6TO7aIH45u3lG2bPhvQ+X2r3l2tkExY="

	Found 10 collections from read causal which will be combined with the 2 extra collections from the block proposal

4) Obtain the data payload for 12 collections in block proposal.


	---- Use GetCollections endpoint ----

	*** GetCollectionsRequest ***
		|-id="5Z1r39oIPK+3INvw1tbPz6kb2UFuMq0//r7ORs8g2bg="
		|-id="UjaqQtME6AjDloUUDGjNlpSXdxBTortvJ/3K6MR3cL0="
		|-id="xa4oHLn8e48nZLzoe1QL7SSfPE2wuavd4MMvN/Z+CRc="
		|-id="+kC7wvvKvBXGKjy5XLtye6KsbS35UegOU78ATfwdxnA="
		|-id="GVpgkeqUm1BLhMCyjSBU0RVylMYQ+Xtw+OQZXAU9SJc="
		|-id="UeOtqE1H9Gyp7vPqRoXBBqFECDZSG/UBp+szEaIyn18="
		|-id="+5Nz6E9tqqOIC4E8Eej3mw7J/xKKPigbm5IxgGPkFlE="
		|-id="A9WD9sh3SYZSPiQ9FjCBsx0iMFElJRwDiKGDazRWMvo="
		|-id="XaBnrI3zZ5TcJtHglifmwuoDmwPbEzaHVByHdsFpbpU="
		|-id="m6HxeLHUpUEE6TO7aIH45u3lG2bPhvQ+X2r3l2tkExY="
		|-id="Mrm1f0gfzmZElD8u1FDSf6HPZA3iJUWtu2jb2wf/IgY="
		|-id="QsTGmD/+CMPYYajy0SaSZ1upI5dPLlekb8fSoq8ncDE="

	*** GetCollectionsResponse ***
	|-Batch id CiSuaww9k+rXd9lniHd+bxtQqbxzBqIXnJQJNbb8XE8=, transactions 977, size: 500224 bytes
	|-Batch id FlzIPZnmWIZV1Y93JZxvFzxUVFwCJAv/VSDukkWA7HA=, transactions 977, size: 500224 bytes
	|-Batch id H6GkywDfiYP0LhMUd7q0siSaQeWc33xo9+Ia5TTHGJI=, transactions 977, size: 500224 bytes
	|-Batch id IKlpWZbSHkA/XvK7wDCG+jZanElHLpRxYJllbAxqTe8=, transactions 977, size: 500224 bytes
	|-Batch id MigvcRVolu3DzF5PMD2WGGi0kb95gG2saYSy5LEzlH0=, transactions 977, size: 500224 bytes
	|-Batch id O1VAv4Jq29lX0ZBhehrs3Fh2uv4cN8gKPU/yCz3FHus=, transactions 977, size: 500224 bytes
	|-Batch id XWHs4umY5POvXdB2Bt3cSziHGJ00SLgXNl4RIlOxH+0=, transactions 977, size: 500224 bytes
	|-Batch id XfmfHLu40tTGHmbd20fQmrZPzA8Vsv4VdRWtu8z03VE=, transactions 977, size: 500224 bytes
	|-Batch id a0t4PR4yjQoKpqJ0+68wAo9K4K+2JEu2XNX3ZGfiGjY=, transactions 977, size: 500224 bytes
	|-Batch id cXw6EZXMh4plxsctr2MzhGudhu6EMaxhcndyFlcZJ3M=, transactions 977, size: 500224 bytes
	|-Batch id cp64zLpT2SrfrIedgg0rsTl+V1I9UFKwmEm99967jdM=, transactions 977, size: 500224 bytes
	|-Batch id gJD2X7fSf5IkpkN8qrhoNyfqKMSPURTsV4DSPesaMdE=, transactions 977, size: 500224 bytes
	|-Batch id hNko4Kz0M+mQW3om8rAbaJj09ylzIzbHMRMIGO29eLI=, transactions 977, size: 500224 bytes
	|-Batch id jEw0SFNt44jHuqnCzrEQVQS0rlvWf9Ig2Y791GJCfYI=, transactions 977, size: 500224 bytes
	|-Batch id osXr6rDfXqCu98a9uVIz5m+eGzpkFxvsF9aBAGom0tw=, transactions 977, size: 500224 bytes
	|-Batch id pi5e+fX69dK+H25waLky941Lw+zzWTYFUn1HcGl7UCM=, transactions 977, size: 500224 bytes
	|-Batch id s8RM12+UHld6yKWWziqnmv6uiiaOKeCNagJyOGFaFoU=, transactions 977, size: 500224 bytes
	|-Batch id u6kQOaEhKJUuUJjrV17Id/Yxk0OXPFMfsTxg095kFF8=, transactions 977, size: 500224 bytes
	|-Batch id x4rjh9zkxaqAjymdKelcmtFjNT/+DTzDUiyFqKzTbkQ=, transactions 977, size: 500224 bytes
	|-Batch id 4O4xf4p2yMjqYuG8H8NrA8ypAsr1PU2iZ2V3Fq8F5vw=, transactions 977, size: 500224 bytes
	|-Batch id 5uTmK1SkNY1F5LOHYnr7mArVTQyWiTz5wc8lXyHDho0=, transactions 977, size: 500224 bytes
	|-Batch id 6nuwiO0tZ5fS6sh3WyHCAXaRPEn6LOmQJ9q4n4WC+oI=, transactions 977, size: 500224 bytes
	|-Batch id 8pQJPwJtueOwl2TInNTalLz2ipFo7HWmcBvZVg/qkoM=, transactions 977, size: 500224 bytes
	|-Batch id /F8h6diH1zCPsv7p5vsZlFnaVh/KrfQHJ9oSIpSTPK0=, transactions 977, size: 500224 bytes
	|-Batch id /N459l+sKTEYR5h2QNSaeQ32DDq6XWGgLLlfMtMx29U=, transactions 977, size: 500224 bytes
	|-Batch id /jQbpOqkMvGXAAdhaRR+qvi56sU0LMCzrZMsMfSr0n0=, transactions 977, size: 500224 bytes
	|-Batch id CGspt0TADOQPcE5B37YnRJmEb+m/qIpKI6UR/A75VO4=, transactions 977, size: 500224 bytes
	|-Batch id GZkblk4cdDOl5oYeoxclkT4zZaHeOamXZKHx3u/7m/I=, transactions 977, size: 500224 bytes
	|-Batch id GefiHhvwmlD6fcqJlD9Dyrjgv0B1b5ivnxPO84cUxXc=, transactions 977, size: 500224 bytes
	|-Batch id IM7KqrJpIeMj8RfNZLtGNJ8SaQPkgKED3GunekKLHwU=, transactions 977, size: 500224 bytes
	|-Batch id JGAhX8xrphInCeyFN8bJE6VZwJ3nTUQYaUauTua11wE=, transactions 977, size: 500224 bytes
	|-Batch id LfrPT8THlc2TZrBJMd7R8zV5kMlJ+7TlPpz5sTa/zbw=, transactions 977, size: 500224 bytes
	|-Batch id OatVEjwNnCnEfUSvXjZtaoLvoQNQxBIawST0j6/X+jU=, transactions 977, size: 500224 bytes
	|-Batch id O4VjXfRXFt/kfXZYk1Pls7cJ5SufSjjchTD1+XmuTjw=, transactions 977, size: 500224 bytes
	|-Batch id O6tOeWHUfF6os2OZ84AThq9f5xiaVH8klv6EdoSdNk4=, transactions 977, size: 500224 bytes
	|-Batch id QxrfxwUbv4IMZxv9U/RKM8JeOW1n7abQT+cSvvqOT7Q=, transactions 977, size: 500224 bytes
	|-Batch id SSuhZYSIKeC4/dX91L0+7EsextejED5HTUKZfWQW0n8=, transactions 977, size: 500224 bytes
	|-Batch id UVXOGj9O2+gKqJOrOsWczxMewsv5txsHuOHE3smUQpI=, transactions 977, size: 500224 bytes
	|-Batch id Umafy8PFKZGJxMZGmKVutYrJ6QlHe6R7AeiNfHq1rXI=, transactions 977, size: 500224 bytes
	|-Batch id X/QWnBxSfyJ36J2ooIoTq9rK+voI4QvNV2j434YIuTA=, transactions 977, size: 500224 bytes
	|-Batch id bBiI6WwTIYeDRvnryY1uBgEXC0oRjEin3W83qvTL/vo=, transactions 977, size: 500224 bytes
	|-Batch id cnE1UHCWWYFMH2HKmgt6G+mFtJDXBNnkFRiS80RPRQc=, transactions 977, size: 500224 bytes
	|-Batch id eSMxRTAhdczfKWjkos+NcxRhvrehTU5//JPFvpSjcPc=, transactions 977, size: 500224 bytes
	|-Batch id m3cvDG701+h8D6d/Y7Z3lnmzgRv7KoXpX54Uz1k1Kmk=, transactions 977, size: 500224 bytes
	|-Batch id npaxRRaBgzi86lFAdRajqXYLf+3wuX+605hHcHbGn8M=, transactions 977, size: 500224 bytes
	|-Batch id pIyJWuxXHzLUB8fYoM1NOIXNL7kA2PqnyV1TvT4XXUk=, transactions 977, size: 500224 bytes
	|-Batch id qNizadBBLNlq+RvsgwXNxLTPrSRDp83VydqZPH1aafQ=, transactions 977, size: 500224 bytes
	|-Batch id 1FhPl23+L1wnuoYfEnPtTfFbn277/2/W0W+FcwBZbs4=, transactions 977, size: 500224 bytes
	|-Batch id 4SWeG52Lvx9krW+Dj6wTVNhAYOkFztjOfyg+yXRuc8I=, transactions 977, size: 500224 bytes
	|-Batch id 6xXi5NkxrPMkzZCopEF12dfkckAyMeI0p/VQhzYd6HM=, transactions 977, size: 500224 bytes
	|-Batch id /Iz2tKEWfS8l8Rqf0fv4ZGR/sgau4WwD33bURoYUgtg=, transactions 977, size: 500224 bytes
	|-Batch id /ZzUJDte2/xtSv6jnSzN1oJnfudCCgEXWl/ZnjeA6/M=, transactions 977, size: 500224 bytes
	|-Batch id AFuoaeV7j7bWo9OYpzy0WvdGsEUdxjYgSDJO6Mn4AxY=, transactions 977, size: 500224 bytes
	|-Batch id Ec0s01zNO2gGCtub1JyPWvqExmqb8pFtH5XlNIDMmeA=, transactions 977, size: 500224 bytes
	|-Batch id FTpvZRqLMt9NHYMVB2qLY6Ja6wdCXbW5gzcRVuZWvhU=, transactions 977, size: 500224 bytes
	|-Batch id Iorlb8uiSKQnuu9VJ7jHRVdz7kqNXwzY2u3nL6FvSko=, transactions 977, size: 500224 bytes
	|-Batch id JhFEgQxSIgQcNeLyH613SIC5OVrrCxE1a2HSMj38lus=, transactions 977, size: 500224 bytes
	|-Batch id MOYSTk4HNSuJsPkAfxFlz4UlQIN3Q/l6AWd5TWMBKvk=, transactions 977, size: 500224 bytes
	|-Batch id P7cwDQ5JO2myf4+GJUOgzf+08uVS4g5wU/66GcK4Jdw=, transactions 977, size: 500224 bytes
	|-Batch id W5h+XbGOXJokP0mStQ7czs5TYdkDei8DajUgQ6Qnwn8=, transactions 977, size: 500224 bytes
	|-Batch id YLmZt9ybkHYQ3XwtxSul+Ccl2L5Z1fOoTcoeHvPSh/o=, transactions 977, size: 500224 bytes
	|-Batch id Z28uNfBkH8LP/ITuuRoBs27q5JQQatx1zXVC/Z8R51Q=, transactions 977, size: 500224 bytes
	|-Batch id bl+ai3feWU/dk9/+MBe69At8UTN0aAXjGhbgU5v4p8w=, transactions 977, size: 500224 bytes
	|-Batch id krPldrp3zfb9b/q+1tPeOP2LKjleJaY3lxWiouEYEDE=, transactions 977, size: 500224 bytes
	|-Batch id k8InJjBLEAugp4ejP/++2DYqQDcxlN4zEFGRV/h2hA4=, transactions 977, size: 500224 bytes
	|-Batch id nTr2NVMJiMK/E6yNTWUC/uVWLOyhJf6bF1puqNqRByU=, transactions 977, size: 500224 bytes
	|-Batch id pv1qBx+Mfx3iXbHspd1pKSGF5v7tuhFzrfFFEipw2NU=, transactions 977, size: 500224 bytes
	|-Batch id qkLIUBSU7ObYV9Jn++dIlLyBf8KticHADVbaE1j59/Y=, transactions 977, size: 500224 bytes
	|-Batch id rwxxEMvoRExeIsuSE6DfkEdRfQc5TaAskR6xM4qTCz0=, transactions 977, size: 500224 bytes
	|-Batch id uZYBqD+nDXTLOPz50C6ymSVG1Kk1Qit21tIqsfYeK8A=, transactions 977, size: 500224 bytes
	|-Batch id vyHioJBQE6Mh84xjNzBxD//DRl/EhrgbryZDCU+Twhg=, transactions 977, size: 500224 bytes
	|-Batch id zAHr4igWKG4ZM5pNyhAIhJgwjLGexToqMjh2D0XoVcA=, transactions 977, size: 500224 bytes
	|-Batch id 0rkPfYsfmBSu6ZB/ZxOKpg3ixwS4XFc+oNhub8Px7Y8=, transactions 977, size: 500224 bytes
	|-Batch id 06k9ClWytNk96u5UksFB3QHJexRC76GQd16qbZb+fbQ=, transactions 977, size: 500224 bytes
	|-Batch id 08C42CRv/XQ83XgZir5tL5/T7BQJ67nE6km4McnmzXU=, transactions 977, size: 500224 bytes
	|-Batch id 6xCWwWc2FXeUOj4kru+hel0AzUjEJChKxUjqMjOAcBg=, transactions 977, size: 500224 bytes
	|-Batch id 7WHSaROcCCTsLD7uCJGcJqnWoFtwkr9RUc2tOm6imDU=, transactions 977, size: 500224 bytes
	|-Batch id 8/MZFfIZ8pHuU0LhherGgHDF9ararlkXAXQ1TqIbqPg=, transactions 977, size: 500224 bytes
	|-Batch id CrS3d5joTGIdIlOOi4UVx3NRpDPPIgp8F7NVsxql1q4=, transactions 977, size: 500224 bytes
	|-Batch id ErhWOLMLXy8pqCZe6cABJ5FDhhjGJEHot16cokE3oLw=, transactions 977, size: 500224 bytes
	|-Batch id ILKQck6NdAuUygD0LzkaPnbHStgT4ngg72eH5ut/J+w=, transactions 977, size: 500224 bytes
	|-Batch id JWhs7v3sFUR/U9IrcsrQv8iFz6GwJjXrPKZ/Y/pv8sg=, transactions 977, size: 500224 bytes
	|-Batch id M+gJqTrd+nC4o9y01veKTptK1BqgoDuRqO720kkhhh0=, transactions 977, size: 500224 bytes
	|-Batch id N6kSXtyIHsyYE1aqS/mGg1rxuhkaPr/4JWJ3DTCYm8k=, transactions 977, size: 500224 bytes
	|-Batch id UwuvZy3klPS+O2qB8Y9jjc4fGM47nM31FGvMxyal32o=, transactions 977, size: 500224 bytes
	|-Batch id VUKpvIHbmJBxu+kFqNpAlkfK6kiB7lTU8fNAoqYcEAI=, transactions 977, size: 500224 bytes
	|-Batch id XcU4K9q1qRoscZZM3Magyuk7sXgPX+H4fp4vX0Cg//Y=, transactions 977, size: 500224 bytes
	|-Batch id ZaadVT3S2NmkSV0nFxu2BmVoArra3fRBQsb1x/4mh2I=, transactions 977, size: 500224 bytes
	|-Batch id aAgq/O5GLu0FuNHoocjLU0ai1sP0yIvkpfCKmicH+GM=, transactions 977, size: 500224 bytes
	|-Batch id caawa3RqYW+OtoKvZEKJFxyRdARsHADXTJasNg5K7cQ=, transactions 977, size: 500224 bytes
	|-Batch id d8g/GaPUBWecf9T23cvjCwxwVKW1sK3JNxdp9PFOxpU=, transactions 977, size: 500224 bytes
	|-Batch id enqyUZ/uB+/CjIJQZF3X6jrMhV+NfwIAZP/qezRo5ao=, transactions 977, size: 500224 bytes
	|-Batch id f1nNK/yMkEapoSFtFrEKFwsSgbmFqTZ/7KrhI/qjL0o=, transactions 977, size: 500224 bytes
	|-Batch id hlFApTxUmo9YSSou6aoMqc14cwS5i2K25slbLfTgkv0=, transactions 977, size: 500224 bytes
	|-Batch id h+7Zotl85ONMokiwgiFT3wKIs3tmCImFx9waZEddPRY=, transactions 977, size: 500224 bytes
	|-Batch id i93bV1MxpD3Bgj2ELpv9O2duW8Ji2+AdmxLe052o81k=, transactions 977, size: 500224 bytes
	|-Batch id qnMEt/Pf5u8OB2jv1sJlDobR6BW/Siy+lGSebpKQ5Bg=, transactions 977, size: 500224 bytes
	|-Batch id 26f1be8x4Y4dN7SE6bOsOYebFpUAFVbvkwsDSPjUtwo=, transactions 977, size: 500224 bytes
	|-Batch id 4Up1pJSD1uma7hiEd/xrfaBlHSoNslyz/sZlunpPOxM=, transactions 977, size: 500224 bytes
	|-Batch id 5zlaaG3BunI6++yn4dRMPvSXg04n0orlcsTgdzo7Umo=, transactions 977, size: 500224 bytes
	|-Batch id +Zlpnm0sEzt/d+O6911gC7BlK8/9MsOtuSp0jVSqfrg=, transactions 977, size: 500224 bytes
	|-Batch id +d87s2omnmn1bBqw1jJdpgL3mtgViYAcWoD9SuFAi0M=, transactions 977, size: 500224 bytes
	|-Batch id /dtbhJiGCXfYx6J7Y1BSf/s2Xt9LTUI/rE3AdNy5C0s=, transactions 977, size: 500224 bytes
	|-Batch id /7mDJY0XhVCUWXbkKTXPV/OMEJo8Bjo2zFSoWKY7AnU=, transactions 977, size: 500224 bytes
	|-Batch id Ainjm40uERipm8hfcZNgVEwzYrs4MdChOLN/UFRx4aU=, transactions 977, size: 500224 bytes
	|-Batch id DfFSGWjElszpxK2E98/Ym1yryPDPIpQNq078lehuGfc=, transactions 977, size: 500224 bytes
	|-Batch id DiwgeixyxnwC9yk+BRHuAir0K+hS0leqCH3fvdjR0/4=, transactions 977, size: 500224 bytes
	|-Batch id D/HOPG+eRSgyLlGX/rQ3NgzrRDCwkQhvWVlw+YVOZzQ=, transactions 977, size: 500224 bytes
	|-Batch id HEWLLqkqkQH3rLzHoZOmNYkMPRuM4m2JvzIQ/chLITs=, transactions 977, size: 500224 bytes
	|-Batch id L8x4UXAv6gBK6CM6ZzH2DVEZ8pk5U2GcBnqhFo3h2Mw=, transactions 977, size: 500224 bytes
	|-Batch id Nd9ojRn4sdF+vqI53PPONaEphrw52eAlXGPcGBpwyms=, transactions 977, size: 500224 bytes
	|-Batch id VWYHdnxdivxG7csWhVB1RlqUaOjZy8ugAw7EHOWdrnQ=, transactions 977, size: 500224 bytes
	|-Batch id V/mUqw67a+m6j4HJ4dvu2cqltw+CeVFvVpEyulvQel8=, transactions 977, size: 500224 bytes
	|-Batch id ZvdJwmDd9mmpeoBOOR/37UhvmdTPXwp8Zrz8wZ6C750=, transactions 977, size: 500224 bytes
	|-Batch id aGBWY8+X8CNLI/nQLtSNjmRzCcXHOXm95/pSCANr44Y=, transactions 977, size: 500224 bytes
	|-Batch id aRODdvgskYyDOQZCOm+hDQjguAg/rj79LA7PdfH8GvU=, transactions 977, size: 500224 bytes
	|-Batch id bkB5v5AoM3NN1YLlRwGdoz/MOWKWxv9B7oEXNW7/xwg=, transactions 977, size: 500224 bytes
	|-Batch id jdQY6OJ5SzWo/VG7zbmXFHtPkIP6oh7f3x/yH0E1Rew=, transactions 977, size: 500224 bytes
	|-Batch id kHme6KClhVwkBNYRcXjzsjd71kcfJvSs+zMDGDEuVyE=, transactions 977, size: 500224 bytes
	|-Batch id m/EP8P0IfUfbP/G0XvIrGhhjY6c2Fs5y+aga7cxo5pA=, transactions 977, size: 500224 bytes
	|-Batch id rxFD8oq3U9HT9Q+/RqK5GVtiaGy1ZPTd85yZyisnHM8=, transactions 977, size: 500224 bytes
	|-Batch id yrwe8/J6iFiCxxkC6mQssvutUW/oXxYI5QZyw7yeX3Q=, transactions 977, size: 500224 bytes
	|-Batch id zQ7Axx5ITzRDYQAQ3Pc62apX/qgpytZEdmUPu48lzZk=, transactions 977, size: 500224 bytes
	|-Batch id zjr5ueJGSqPKFgPI9G/kumAiHKV8Nym3tm7oPnBP6uQ=, transactions 977, size: 500224 bytes
	|-Batch id 1B6D7sig2eUD4j6B+1OB7EBcVtmIXnxKiniJ9htwNVg=, transactions 977, size: 500224 bytes
	|-Batch id 1bTSgc4QtmFy0WFZv+sD1nMkDjEJAlOEBkj9GMU8jmA=, transactions 977, size: 500224 bytes
	|-Batch id 2IXKkpsJOsDUL0TXeZoHF4iXICFwmtV2Pr+zJA5n+ss=, transactions 977, size: 500224 bytes
	|-Batch id 2QxiQrwGqIdFLbjx8GqXh8e5exdoHp1lMYJiz+Hoho4=, transactions 977, size: 500224 bytes
	|-Batch id 9Ro2kJqMOUNBykzMxleV5NoJ5l/7LaUqZQvJwzXv7Ug=, transactions 977, size: 500224 bytes
	|-Batch id CoJu7fMPzzXfGrI+xhvRTqxL7vd9HwRKLjMxgjLmbA0=, transactions 977, size: 500224 bytes
	|-Batch id CzjnzygY0RKUkM0TVfOSfJHoVBvCzrtbqDHIT1cPZQ4=, transactions 977, size: 500224 bytes
	|-Batch id FDEFI1aXEXLjMbpmNi6QjNehhfd1X2HbioiNsD2zwj0=, transactions 977, size: 500224 bytes
	|-Batch id FbkeBE/0IBsrFJtxYNpNj5GKCXqZiVuw2dM/m6pAlRU=, transactions 977, size: 500224 bytes
	|-Batch id GByVeUJf1266IzmcqeSxwvUxHObcS+mzVTHz/Q7yk4Q=, transactions 977, size: 500224 bytes
	|-Batch id Ixk0N9qtrAzIMmDSrDbRmPsbOwp4F4cZKJiyC9cFXaQ=, transactions 977, size: 500224 bytes
	|-Batch id JUjLa6ylwj2c/zlKdJbNdn9L3vhsHEU5tCkwuD6U7YQ=, transactions 977, size: 500224 bytes
	|-Batch id KsqWAODwXDL9O/AO3LMuymb3Z7cDGOMOqnSBjz9WNTM=, transactions 977, size: 500224 bytes
	|-Batch id MwGwtmpfK4PPTEWm92L9MY2LbMRChD59/0ZP7+fCygE=, transactions 977, size: 500224 bytes
	|-Batch id QSQgA3fU4HOmV9nykVZ79BpOHC2OZL5HZ1JfG77pkeA=, transactions 977, size: 500224 bytes
	|-Batch id SDett0hU1hhQ9mjKJJng2FQO/y6HCSfbTSoKdvMq6js=, transactions 977, size: 500224 bytes
	|-Batch id Yw4R/aBAvAT5/Dy/phTGZqdOT1+5M+4o1q16xZaQjiM=, transactions 977, size: 500224 bytes
	|-Batch id ZsD2keQaaBSITZb2c/n6KEPAUY4qbVuAhkufOyzWGwg=, transactions 977, size: 500224 bytes
	|-Batch id cLZC5d0XGynmZi8f9zxoEbMTCHlRGhQ0lYCN5XnZErU=, transactions 977, size: 500224 bytes
	|-Batch id has/Fs1yfgIaHl2r0PHV6RKR8qyIHdIeEuLOyN7dFoA=, transactions 977, size: 500224 bytes
	|-Batch id hgXh9vI0Vh8ZqWfBsepJQsgq1yhaidJErWJvhJ5A4aE=, transactions 977, size: 500224 bytes
	|-Batch id kFJddJD9gGRxN9VyfyherrS7OuBh8i0JiVRdJRiZA8g=, transactions 977, size: 500224 bytes
	|-Batch id qoo+OxXYMzOfxQAbFKKdJn7hSiVr34gjDjlMj2qlOg4=, transactions 977, size: 500224 bytes
	|-Batch id u5VHFie2AtIGSxW01A8oU2A9gF1tm+M2uj1ZEAS2TyA=, transactions 977, size: 500224 bytes
	|-Batch id zDCtZDoyFXSNDIkkypf6Qja0ZBS0wN6pkHCwl1fIbn0=, transactions 977, size: 500224 bytes
	|-Batch id 1i2haaWUNyWOedZIdFCfz92BGiVOt9La1AM5Z8BcX8E=, transactions 977, size: 500224 bytes
	|-Batch id 2p4KjGO1aC0yZnu3kTkiL+qrgd1ODdGMBZjR7t+air0=, transactions 977, size: 500224 bytes
	|-Batch id 36Zo0CQqTyW0k1o5nXflq7VXQsqlK3hAAv/b/wz0K80=, transactions 977, size: 500224 bytes
	|-Batch id 4J4me5hpF2KdRnCPU/0fVTjrjj/JQiPXvmM0vkahZEk=, transactions 977, size: 500224 bytes
	|-Batch id 97kLolDUxKzMnbZKsBQoeS10P76fCCdNkXMjnU77FOM=, transactions 977, size: 500224 bytes
	|-Batch id DkHATN/t5mBIfseZiUSULIhCUQgFUsOZfuqadm5lNZk=, transactions 977, size: 500224 bytes
	|-Batch id ED7dpH5DCd90cRYQgITyd+72ObvWaKadj/gDkSCmY4U=, transactions 977, size: 500224 bytes
	|-Batch id EL65E3yJWCMJnaOqWSVHinjtTMFgpQpGSUU0R0eRguA=, transactions 977, size: 500224 bytes
	|-Batch id EXTGvs/w95YI5WYPT97Ltolt1uODbn1r8705ZgMbSe4=, transactions 977, size: 500224 bytes
	|-Batch id Fyk+UoXd5eDYpVpdBDSmOWKwR5tJGxG4JG+iJzpaTl0=, transactions 977, size: 500224 bytes
	|-Batch id Jlc/BckUr7+RuhVujUbtTPkodRJR8UlyeQ09pJ20TuI=, transactions 977, size: 500224 bytes
	|-Batch id Pis2YeOEPMgJxYK1+Ns+QwOlg/rosBfwHfBm1hPQbSM=, transactions 977, size: 500224 bytes
	|-Batch id RxDtb3nZVi2KJQZj+5BNbfsiJ9UuBPIsZbh2Oumgil0=, transactions 977, size: 500224 bytes
	|-Batch id XhItUEweM1r1xMRT0/PEmCDY+H/Vah+YKzzeTnmkX1k=, transactions 977, size: 500224 bytes
	|-Batch id YAI5OCdne+oXuftpQTeUx+7Fg04J3LD6Ky7sA1LNfdA=, transactions 977, size: 500224 bytes
	|-Batch id YX7NheWO5NXNI6EYtrAGqRB5pD3YTEeXQ0fIsUMrXss=, transactions 977, size: 500224 bytes
	|-Batch id ZapTxoDh7vpRiLVXkNSE05VKzzV2tIjKRDy5oRBoKNs=, transactions 977, size: 500224 bytes
	|-Batch id aqtV6VL+GfZ3CTXNZDILqCukgnW1FQ9MVAd7CMe9akQ=, transactions 977, size: 500224 bytes
	|-Batch id cbQbz0Kw3rtpAKFpl9fPfhu4amujTcb/b1oP4s5lQ8U=, transactions 977, size: 500224 bytes
	|-Batch id cpwb3iCsVMfY4UUBhHr45esySODJD9aAwBiDOETlwiA=, transactions 977, size: 500224 bytes
	|-Batch id emhYdfWIUPAiMmFL7oE2eX5wMt+TdXjFpsVZjpogFdc=, transactions 977, size: 500224 bytes
	|-Batch id ixo+MyBErPV/deJ/nLbIekCJ3gs+8i3olO0cvTXv56U=, transactions 977, size: 500224 bytes
	|-Batch id jbw362iw9plD5k722fi2EPFzURIS3cZo4tdhwwBY5I8=, transactions 977, size: 500224 bytes
	|-Batch id qLCQ4+rLBJr5VquhAtdnXgfCLKHwPPb+d8iCSNaYT98=, transactions 977, size: 500224 bytes
	|-Batch id rORfmjEGWfUNtKpoPxYlXe5RKF/brY4iCQ39o1cdaWg=, transactions 977, size: 500224 bytes
	|-Batch id vicxi/EfglYhAaq5AggJBr13l0BduMYzjBRSyLbNdhM=, transactions 977, size: 500224 bytes
	|-Batch id yZ3yvwNwuzAQDF3viIfxw9ldduvP4folV0s4n5w+tRo=, transactions 977, size: 500224 bytes
	|-Batch id zRtsUCmqQAymbC5hFNnFXIHX6o2BSFtKVGC77rmiccY=, transactions 977, size: 500224 bytes
	|-Batch id 18iqYfI44kyyxKzJn5R7zBZ0lbBSAoGpZakfn8sbYeA=, transactions 977, size: 500224 bytes
	|-Batch id +vxxZTqAjFyN5X6I1XDwkAi7et5RprvRClM9u+OQdKE=, transactions 977, size: 500224 bytes
	|-Batch id B+6nKVCX9P3dfZRa3Yt2Kb9miJj5zyqN1HtpGS+/JPU=, transactions 977, size: 500224 bytes
	|-Batch id GcbPP1aYgKYSDde0QATsiBUbYE0hsGVQVoWoGiDzfx4=, transactions 977, size: 500224 bytes
	|-Batch id Qfo0DDTxYyWaqgA8WyOh1mUKp3K/MivEKDfqhxaZeI0=, transactions 977, size: 500224 bytes
	|-Batch id ScsrcIuburYKeoGlr1Ct8AT+AIOv5o/EAdi4Del6jOU=, transactions 977, size: 500224 bytes
	|-Batch id T1zslYVP7KeZkKAV15DNlxLUKpDsC5AIJ6wMqxmJd9Q=, transactions 977, size: 500224 bytes
	|-Batch id UalsJcpN+OhhfJyzV/1AW4u3UupQVGiV9YlwaNIglG8=, transactions 977, size: 500224 bytes
	|-Batch id VpIChzNtLwvQ6OI2sjeDJ+ihDe0UKNjGjf7GKKnlI/8=, transactions 977, size: 500224 bytes
	|-Batch id XJHQjsEhW2CG1iDYUsiD4eqQ19NMEmwxZTvuD9YDyZY=, transactions 977, size: 500224 bytes
	|-Batch id iPMrDUIU+xgtxlQga6SHvY1rlMvlvlm+4t8iMslinG0=, transactions 977, size: 500224 bytes
	|-Batch id iRLJaAwnY46l1P0i85sJZOpDj5gnXAxvV+tkQ65mal4=, transactions 977, size: 500224 bytes
	|-Batch id kinLJlbmLnptLuwKrjUEw0et3ekiQmHedR0oOfrqpu0=, transactions 977, size: 500224 bytes
	|-Batch id kl/FG6tXtza/qnVcV4pe5vmgegcElOkB1dKRiSeWylc=, transactions 977, size: 500224 bytes
	|-Batch id laL3+2wZMYNi12nv/m5+qh7uTFxQFbpiR+hnLBjVGck=, transactions 977, size: 500224 bytes
	|-Batch id mFnKKdGVN8KkCR7p1qRUib5PHuSkWe5iNE30ox1YXpY=, transactions 977, size: 500224 bytes
	|-Batch id nKJtb1g5ZG7EKfZ5Yg3pIOvBjC54IJoojBgXLyobkYM=, transactions 977, size: 500224 bytes
	|-Batch id pbdBwVz/J9yQxYM+8oIyStD1ZQ0BZadG097ToKIF/UE=, transactions 977, size: 500224 bytes
	|-Batch id rIegIz2PlV9r39/OTEfhgmRZq95xNqjD7tClt3VGbcI=, transactions 977, size: 500224 bytes
	|-Batch id wzXuECkAGhY+S0ahnycEsTsMqxDdOhDd0JgjnS8JEN4=, transactions 977, size: 500224 bytes
	|-Batch id xBDe0o9vlogWpoljrPRVk0cdHuWMaJRvO1cFduMdKBs=, transactions 977, size: 500224 bytes
	|-Batch id yLlMDM9vEP1IJYZh3RjAHzGZmrE406V/4ZYkFc/Ghmc=, transactions 977, size: 500224 bytes
	|-Batch id zJBZTVybgZNunHgyAA8u9gafj6GffwlnuB0kmubaJAg=, transactions 977, size: 500224 bytes
	|-Batch id zuqAwncGD6P6chp9eZep1yYdWANU0Acxo9i6NMV/oz8=, transactions 977, size: 500224 bytes
	|-Batch id 67LGst2APSPPkn0DM47uStAs1rRu8KmrSYLRqiMRq2w=, transactions 977, size: 500224 bytes
	|-Batch id +odB1WCiugiF13yay6QTwB7qFUu13e6gZ7bxu+bbS98=, transactions 977, size: 500224 bytes
	|-Batch id Ce/P/UOa5zYSLMK2L4w+neHALCHyKAtj/ADvuirDexU=, transactions 977, size: 500224 bytes
	|-Batch id DJmH285R/P9tQAUpfiUtjASkGxGq9jOYP/dd99wQyjw=, transactions 977, size: 500224 bytes
	|-Batch id D8jlTdqwWk2dKpCeda9KXx2mA41Q7QEgLMCP4cAm6Ro=, transactions 977, size: 500224 bytes
	|-Batch id HQ6TuATe4+pjpkmVoC7pP3XbZ1Eb9MgGYDcF++bBRWI=, transactions 977, size: 500224 bytes
	|-Batch id HuSSQB6Z7qg35180qiKpFp8J2Nv00gOiKa90WARNTRg=, transactions 977, size: 500224 bytes
	|-Batch id I5vmAK8+SKv7bSjlgLhXLQYbZ+6ZWygQ8PqcZL/IKmM=, transactions 977, size: 500224 bytes
	|-Batch id I6vB5JcRxHx1UtF6q8ocKknoFZoQnsdQ9ONkKuCavAE=, transactions 977, size: 500224 bytes
	|-Batch id RA6WlM7CGDp53l6FCzXuMT72Kz6budQKzJbVsGed0aY=, transactions 977, size: 500224 bytes
	|-Batch id RB65pwLbexdYtADsjRj0l707P+KLN2URW2D5FMFYiMg=, transactions 977, size: 500224 bytes
	|-Batch id SM0EHJHaAvMx3jwRDrVCCbwXdHb7nZ9LG5lZ7OC2UZY=, transactions 977, size: 500224 bytes
	|-Batch id UH+Tj8beABn/HEbp54Wnq/eZeq1hzx3lz13atyn7utY=, transactions 977, size: 500224 bytes
	|-Batch id VFN9CYKdjybAWGSJre4ciLVW7goDHrANaGjhHD7qTUg=, transactions 977, size: 500224 bytes
	|-Batch id fPzrqOEhUvPvyK44FQLgmeeQZ/J2UL9lopPedm3VWKw=, transactions 977, size: 500224 bytes
	|-Batch id jty25c6NXO/2JlaK0CUqIBTnoPjjbVaG5K6gGN6Miq8=, transactions 977, size: 500224 bytes
	|-Batch id oFkRWZ52oroU0e+wv+Xu0J7gSVkfaH4TWpgBzKEKw4E=, transactions 977, size: 500224 bytes
	|-Batch id pPXXB1t12qV+LKj5zGS+Q259I5TfMCg9v9TfdETDhmk=, transactions 977, size: 500224 bytes
	|-Batch id rPnNDEa62qnXcmnwrFBY+/+KjHayV3bMW+Crs9Al25E=, transactions 977, size: 500224 bytes
	|-Batch id rRj3L+bp4WYnZt46X7JrVAevFv3eezQUeFEgrBUnTl0=, transactions 977, size: 500224 bytes
	|-Batch id t8FMKZA3PJ7a5azd13P7+e5/KS+srb+SAnO47xiHVBI=, transactions 977, size: 500224 bytes
	|-Batch id uFZNGjblJpU3lVqp9V1FE5ElWhiFqzuz/dSKM6S6mDs=, transactions 977, size: 500224 bytes
	|-Batch id w1xaLbQn54xk8jhP4bz3koOpDDzO9b1XR/MdAi4ufKA=, transactions 977, size: 500224 bytes
	|-Batch id yxVLrF+teliQzyPgVJILsUnPQ9NNjeGxMgiF+KrgpfM=, transactions 977, size: 500224 bytes
	|-Batch id zzqsZlwbjcAfLUhrpQaoHwVgxQv/Hsx0Zci1efMulDM=, transactions 977, size: 500224 bytes
	|-Batch id 3xt2fT6e0mH3IbZwPnEC7uHjoeM1u5jwMSW64FoCiSI=, transactions 977, size: 500224 bytes
	|-Batch id CbOlm33KL6s2umHrjEry73fr3E1r55TErIVFHGgM/UE=, transactions 977, size: 500224 bytes
	|-Batch id C9byf5EzgtT4fTjKNbz+Rczb4Ojrg+0fVKirtv1e08k=, transactions 977, size: 500224 bytes
	|-Batch id Dx4D0su431q4QJDVaw6FppSmDVxZPagK2BnMUHTJJrA=, transactions 977, size: 500224 bytes
	|-Batch id EdeDJDVAjZc6TYpikDCafzrUVgwscLdJK6alM19xZPI=, transactions 977, size: 500224 bytes
	|-Batch id H6wONQl8jf4a9ZbVgJb0LkVxVPdfMGJZOHYIn92yBzM=, transactions 977, size: 500224 bytes
	|-Batch id Jo9s1tHqHTa7R/W+QKFxFG14X3vyVwT29eiLbknTS1U=, transactions 977, size: 500224 bytes
	|-Batch id MZ+EXVe9rX0A+y6pUswLD978Wy7Xy4wn+EzcFX9joTc=, transactions 977, size: 500224 bytes
	|-Batch id WL8faxQnMdPHtQ7pHx4FxxGH7nZsm3MSOttvhWDQuAY=, transactions 977, size: 500224 bytes
	|-Batch id XO0k3gCsUsIpy9F6Y4gDXZot+tx3HAQQCSM2K+OxFv0=, transactions 977, size: 500224 bytes
	|-Batch id aR3E5u7Sf+7YT2uGZLXN8SSeSi7hZOcSvYi4RkOBLTs=, transactions 977, size: 500224 bytes
	|-Batch id bf+iRjB7Q2y2p3FlfVc/jh5A8YfCl9ViWWtOlyLzBaI=, transactions 977, size: 500224 bytes
	|-Batch id dknPhktxgSC7sbRxPHxfhayUj/QQKfJSzq4DHuGxhCg=, transactions 977, size: 500224 bytes
	|-Batch id ekkhDT20gtuHRAzuoW9EAl73ww5knvC1QN9fCBQw2ME=, transactions 977, size: 500224 bytes
	|-Batch id jWxsGA1BdPPMTifoByGOeY961xtShTQuxsvBfCsCfOc=, transactions 977, size: 500224 bytes
	|-Batch id rEBdmRNIR+YxJTJ01RmujsoWsBanP1XapocJotZj4l8=, transactions 977, size: 500224 bytes
	|-Batch id uL8h5VXoy4AP+XNo32jzab9/SFsNh/DUnDDi8xv/E30=, transactions 977, size: 500224 bytes
	|-Batch id vFe3sqFcev+WuF05I8DNBlVuI2dAV/AKyDE7rumpegY=, transactions 977, size: 500224 bytes
	|-Batch id yENKi/+noZBI96dbOir4pd4IvHLw1UPpcUxNHTVqB00=, transactions 977, size: 500224 bytes
	|-Batch id zfMQdG/2gOhofY1DfRqs0hnLhKNsMZkurgW4cj61erg=, transactions 977, size: 500224 bytes
	|-Batch id 0uPfMtC26dLzm0mW4MRWGdvM90oL7qnGcRsbzZYXDyA=, transactions 977, size: 500224 bytes
	|-Batch id 3wgz+JcWpNI2jhgXER8kiZrgUs8GrGSEbGC+TR2TXeI=, transactions 977, size: 500224 bytes
	|-Batch id 4+VcGn+148+7spSGUVVawtRN0EP8XklqZLueaZPGSd4=, transactions 977, size: 500224 bytes
	|-Batch id 8l+5GvBHMPnXYm7WIXz8svOoMHMA1Reqn+nTbUkigg8=, transactions 977, size: 500224 bytes
	|-Batch id +fxQHNhjNl3rkLZ3FCt5I5hahKkFzjVeb5axhgsFX40=, transactions 977, size: 500224 bytes
	|-Batch id CEc4JMjuXMWeR6KvMM68R7W02KayUMW6ih7GO9GrrvE=, transactions 977, size: 500224 bytes
	|-Batch id GfE5LPSkaSn3ShgJ7wDoMtRlxj8RqLMKQriOgAMoMds=, transactions 977, size: 500224 bytes
	|-Batch id G84kSEtovCDEc+Ek3EIvcC+DX6/gnvpvpxgYXH/kjQc=, transactions 977, size: 500224 bytes
	|-Batch id HRmx1HV3L84UFG5blwHaEbe7G3I0UY4iKMRgbS2k4qU=, transactions 977, size: 500224 bytes
	|-Batch id Oa12vOve+C8gEK+xU9KPUEZaSpnDp44DZ66lpL1yZZc=, transactions 977, size: 500224 bytes
	|-Batch id PU/ata2WB8XafbT9X+c+cemA5EgC0gmwedF9HvJq73I=, transactions 977, size: 500224 bytes
	|-Batch id QpBd4akqTQcULHZQhVMXmMToRdKYY+fKskjYoRtNkIA=, transactions 977, size: 500224 bytes
	|-Batch id Q8GnpvdUG8QtCGb/g630Vx8KQepB7ML93/dg/eehcgg=, transactions 977, size: 500224 bytes
	|-Batch id Uwn7XYyC2RKVobrOE3g81L+1WdsMfFDEbpqizSkGanA=, transactions 977, size: 500224 bytes
	|-Batch id aw+jHFWCJuVo88jnqfBndm+TVsjNq47VPxvIIN/iwto=, transactions 977, size: 500224 bytes
	|-Batch id bPoR6CNOFAsHRCR1xZTg27tGAh5IoK3VyZ017JAmCpo=, transactions 977, size: 500224 bytes
	|-Batch id f09zNUK1Pmtt7KOK/jMz6Paz+s4cc7XgIGJFQ7/ZtYs=, transactions 977, size: 500224 bytes
	|-Batch id hn9sq9q98wE4qNt1db4zGxMWeqVE7jnk56csPLEkW58=, transactions 977, size: 500224 bytes
	|-Batch id iqJsHkRzp15qVpCSWkJFrbDseLOERtkHEz9LMweM0mU=, transactions 977, size: 500224 bytes
	|-Batch id log98aT+IVR9LJx5FljHvgpqzlen9v11c0byKrMkkv0=, transactions 977, size: 500224 bytes
	|-Batch id mPWUuCJrcm1bBiUgxZ7lWB5s17dxvIAUFAtYW13aR/s=, transactions 977, size: 500224 bytes
	|-Batch id oHI/D4ACKbnxxgpeOLu/Aq8D3tXe2YwXBKsrRCOXuYI=, transactions 977, size: 500224 bytes
	|-Batch id oqCnwdf3vQXdDl9XiV+5Z8t6vYMcj+Ih1rA6WEy5O8Y=, transactions 977, size: 500224 bytes
	|-Batch id o2bLuAp/EzuuSdt5THucYE7Shbzx8BKs5YqxuMW2UBI=, transactions 977, size: 500224 bytes
	|-Batch id u3VYUq9NQfFNO8xtN3jmM4178npYDxbx5v0AXkfnNhg=, transactions 977, size: 500224 bytes
	|-Batch id vVO7UuxqIBFaf+urYMPG828m3jbi6AGLkjTywg60Qqg=, transactions 977, size: 500224 bytes
	|-Batch id 3ZR88ncNimVF67ntlKc6eJpv/Uz23DhL2zQZE3ChBTQ=, transactions 977, size: 500224 bytes
	|-Batch id 8KTCAfwQO+sgIfnzbuw2xVhOtHyxHI9MrCMlBgrFpZU=, transactions 977, size: 500224 bytes
	|-Batch id 8hO/ICK/jFC8s/Yu8bFijjkgnAI3s9p3yyphEuZgEqs=, transactions 977, size: 500224 bytes
	|-Batch id 9j2BBlnJAY9XO0l/8+HhnJ81md/cA/BDrLv1jqRPvNs=, transactions 977, size: 500224 bytes
	|-Batch id CIu0szGxgW3uKWgZsN0KCcZ343HqP+GRHTNipL+ZNus=, transactions 977, size: 500224 bytes
	|-Batch id CKmVtyFV4WGcIXTkR7rFLtVGAzVEeMuvwperXbGEgCg=, transactions 977, size: 500224 bytes
	|-Batch id DQj40p7K2rYVuRTfsbO3Uuq8PW05ALuGtmBrbWB8ZKE=, transactions 977, size: 500224 bytes
	|-Batch id GLTLIp2CqXUUzUujQ09w58CpxV9QerARmIMLhrkBpqA=, transactions 977, size: 500224 bytes
	|-Batch id HIqEZsfIi6eRbgFMAGNR052/KpKErch0L+z8tF9X0io=, transactions 977, size: 500224 bytes
	|-Batch id JPeSEDenUuvc/W27Sgndl/K5VCAkI1wzQttMmMLLF58=, transactions 977, size: 500224 bytes
	|-Batch id K8aaWzBi6/QtcR8k1DT32c8VP7TBERqN/m47i+x0u5c=, transactions 977, size: 500224 bytes
	|-Batch id Mz3UwKxSXG71/BStn30FIccehAABQEct5JIbXsHzLW8=, transactions 977, size: 500224 bytes
	|-Batch id NBTkMwzzKvvaZUorp0LphYQ+aLqxvHIlDl4I61sZDQY=, transactions 977, size: 500224 bytes
	|-Batch id NzCwnkPjuVs1FLmfHiILY71qxCuE0UiTS52qWOaiDj8=, transactions 977, size: 500224 bytes
	|-Batch id Pkqr/VenVZCriXOiKJtCEFgd3NecCVUYH8tGfm02y0A=, transactions 977, size: 500224 bytes
	|-Batch id WlfDSPxAgafhPLulVTkmzl9wsWCH61vAUzP/vUaUE6M=, transactions 977, size: 500224 bytes
	|-Batch id Y9lxlYeoWM/hNYHunctYLG5lk1zjDOqro7SSa/cSw1E=, transactions 977, size: 500224 bytes
	|-Batch id dm8KJYrSJ9R9XPBQfvw3ycR6d4HHSKsIuR9I0JYo5MA=, transactions 977, size: 500224 bytes
	|-Batch id eKUoKDLth942sZVVT7q91FDCNcthF3+L/4FvVsLR1+w=, transactions 977, size: 500224 bytes
	|-Batch id jf7l7MBJkFc3/e7z97JQiE/IRNNE0ir8Lptg0KtEt1I=, transactions 977, size: 500224 bytes
	|-Batch id joNE5Hi1Hd7oXWkAHZRqd0NJ+Dp0rj/sbBhHu+WUjtI=, transactions 977, size: 500224 bytes
	|-Batch id tgGeyokBroNjiw/fOORu6FF8q91cRIytTwSgZYQgD6Y=, transactions 977, size: 500224 bytes
	|-Batch id uFYYD93iD1uoDdPOLdXUl7XmV3KO/6/rx+AoM8EX+Fk=, transactions 977, size: 500224 bytes
	|-Batch id u58XVJFMW3LRrn99i1j/LPYmj8YAEucxmFe+KJFkTT4=, transactions 977, size: 500224 bytes
	|-Batch id wV7FGpbBS5cxduC4IOPMj05G40s0TkjS/3xGNbM8pvk=, transactions 977, size: 500224 bytes
	|-Batch id 3gJFgrEq4jirK6ZUiq4lnS2BlWktwFUdbRzdut2Vm5g=, transactions 977, size: 500224 bytes
	|-Batch id 3h7kgfC5nNIJbiAbjQet0y4kmCaTLNVjyp47qfew7AQ=, transactions 977, size: 500224 bytes
	|-Batch id 3nfCWaPYZg/x/KdHVq61hSzfU8EI2jg3Eq29nxClUkg=, transactions 977, size: 500224 bytes
	|-Batch id 8iOpsXy0OmWTDIVBGDP2aoGrgNUxYEEoW7vgfcXopZc=, transactions 977, size: 500224 bytes
	|-Batch id /590SgQDkU5JSgYcB3TQyk+gXIGl+96EJeqYmBbrUb8=, transactions 977, size: 500224 bytes

	Found 295054 transactions with a total size of 151067648 bytes

	Waiting for validators to decide wheter to vote for the block...

	Vote completed successfully, block can be removed!


4) Remove collections that have been voted on and committed.


	---- Test RemoveCollections endpoint ----

	*** RemoveCollectionsRequest ***
	|-id="A9WD9sh3SYZSPiQ9FjCBsx0iMFElJRwDiKGDazRWMvo="
	|-id="GVpgkeqUm1BLhMCyjSBU0RVylMYQ+Xtw+OQZXAU9SJc="
	|-id="XaBnrI3zZ5TcJtHglifmwuoDmwPbEzaHVByHdsFpbpU="
	|-id="m6HxeLHUpUEE6TO7aIH45u3lG2bPhvQ+X2r3l2tkExY="
	|-id="+kC7wvvKvBXGKjy5XLtye6KsbS35UegOU78ATfwdxnA="
	|-id="UeOtqE1H9Gyp7vPqRoXBBqFECDZSG/UBp+szEaIyn18="
	|-id="+5Nz6E9tqqOIC4E8Eej3mw7J/xKKPigbm5IxgGPkFlE="
	|-id="5Z1r39oIPK+3INvw1tbPz6kb2UFuMq0//r7ORs8g2bg="
	|-id="UjaqQtME6AjDloUUDGjNlpSXdxBTortvJ/3K6MR3cL0="
	|-id="xa4oHLn8e48nZLzoe1QL7SSfPE2wuavd4MMvN/Z+CRc="
	|-id="Mrm1f0gfzmZElD8u1FDSf6HPZA3iJUWtu2jb2wf/IgY="
	|-id="QsTGmD/+CMPYYajy0SaSZ1upI5dPLlekb8fSoq8ncDE="

	Successfully removed committed collections


```