### PR TITLE
[test] Extend dag removal test

### DIFF
--- a/dag/src/lib.rs
+++ b/dag/src/lib.rs
@@ -57,6 +57,12 @@ impl<T> From<Arc<Node<T>>> for NodeRef<T> {
     }
 }
 
+impl<T> From<Node<T>> for NodeRef<T> {
+    fn from(node: Node<T>) -> Self {
+        NodeRef::from_pointee(node)
+    }
+}
+
 impl<T> NodeRef<T> {
     /// Returns a NodeRef pointing at the Node passed as argument
     ///
@@ -76,12 +82,6 @@ impl<T> NodeRef<T> {
 
 /// Non reference-counted pointers to a Node
 pub type WeakNodeRef<T> = Weak<Node<T>>;
-
-impl<T> From<Node<T>> for NodeRef<T> {
-    fn from(node: Node<T>) -> Self {
-        NodeRef(Arc::new(node))
-    }
-}
 
 /// The Dag node, aka vertex.
 #[derive(Debug)]

--- a/dag/src/node_dag.rs
+++ b/dag/src/node_dag.rs
@@ -204,11 +204,11 @@ impl<T: Affiliated> NodeDag<T> {
             value,
             compressible,
         };
-        let strong_node_ref = Arc::new(node);
+        let strong_node_ref = NodeRef::from_pointee(node);
         // important: do this first, before downgrading the head references
         self.node_table
-            .insert(digest, Either::Right(strong_node_ref.into()));
-        // maintain the header invariant
+            .insert(digest, Either::Right(strong_node_ref));
+        // maintain the head invariant: the node table should no longer have a strong reference to the head
         for mut parent in parent_digests
             .into_iter()
             .flat_map(|digest| self.node_table.get_mut(&digest))


### PR DESCRIPTION
Fixes bug in test which was adding additional certificates at the wrong round. 
Cosmetic changes to build `NodeRef`s less manually (i.e. using `NodeRef::from_pointee` rather than `Arc::new`).

This gives us more confidence DAG compression is working as intended (see assert circa "`// certificates are gone`")