### PR TITLE
Add skeleton for NewEpoch endpoint

### DIFF
--- a/primary/src/grpc_server/configuration.rs
+++ b/primary/src/grpc_server/configuration.rs
@@ -3,7 +3,7 @@
 use crypto::{ed25519::Ed25519PublicKey, traits::ToFromBytes};
 use multiaddr::Multiaddr;
 use tonic::{Request, Response, Status};
-use types::{Configuration, Empty, NewNetworkInfoRequest};
+use types::{Configuration, Empty, NewEpochRequest, NewNetworkInfoRequest};
 
 #[derive(Debug)]
 pub struct NarwhalConfiguration {}
@@ -16,6 +16,45 @@ impl NarwhalConfiguration {
 
 #[tonic::async_trait]
 impl Configuration for NarwhalConfiguration {
+    async fn new_epoch(
+        &self,
+        request: Request<NewEpochRequest>,
+    ) -> Result<Response<Empty>, Status> {
+        let new_epoch_request = request.into_inner();
+        let epoch_number = new_epoch_request.epoch_number;
+        let validators = new_epoch_request.validators;
+        let mut parsed_input = vec![];
+        for validator in validators.iter() {
+            let proto_key = validator
+                .public_key
+                .as_ref()
+                .ok_or_else(|| Status::invalid_argument("Missing public key"))?;
+            let public_key: Ed25519PublicKey =
+                Ed25519PublicKey::from_bytes(proto_key.bytes.as_ref()).map_err(|err| {
+                    Status::invalid_argument(format!("Could not serialize: {:?}", err))
+                })?;
+
+            let stake_weight = validator.stake_weight;
+            let address: Multiaddr = validator
+                .address
+                .as_ref()
+                .ok_or_else(|| Status::invalid_argument("Missing address"))?
+                .address
+                .parse()
+                .map_err(|err| {
+                    Status::invalid_argument(format!("Could not serialize: {:?}", err))
+                })?;
+            parsed_input.push(format!(
+                "public_key: {:?} stake_weight: {:?} address: {:?}",
+                public_key, stake_weight, address
+            ));
+        }
+        Err(Status::internal(format!(
+            "Not Implemented! But parsed input - epoch_number: {:?} & validator_data: {:?}",
+            epoch_number, parsed_input
+        )))
+    }
+
     async fn new_network_info(
         &self,
         request: Request<NewNetworkInfoRequest>,

--- a/primary/src/grpc_server/configuration.rs
+++ b/primary/src/grpc_server/configuration.rs
@@ -1,21 +1,44 @@
+use config::SharedCommittee;
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use crypto::{ed25519::Ed25519PublicKey, traits::ToFromBytes};
+use crypto::traits::VerifyingKey;
 use multiaddr::Multiaddr;
 use tonic::{Request, Response, Status};
-use types::{Configuration, Empty, NewEpochRequest, NewNetworkInfoRequest};
+use types::{Configuration, Empty, NewEpochRequest, NewNetworkInfoRequest, PublicKeyProto};
 
-#[derive(Debug)]
-pub struct NarwhalConfiguration {}
+pub struct NarwhalConfiguration<PublicKey: VerifyingKey> {
+    /// The committee
+    committee: SharedCommittee<PublicKey>,
+}
 
-impl NarwhalConfiguration {
-    pub fn new() -> Self {
-        Self {}
+impl<PublicKey: VerifyingKey> NarwhalConfiguration<PublicKey> {
+    pub fn new(committee: SharedCommittee<PublicKey>) -> Self {
+        Self { committee }
+    }
+
+    /// Extracts and verifies the public key provided from the RoundsRequest.
+    /// The method will return a result where the OK() will hold the
+    /// parsed public key. The Err() will hold a Status message with the
+    /// specific error description.
+    fn get_public_key(&self, request: Option<&PublicKeyProto>) -> Result<PublicKey, Status> {
+        let proto_key = request
+            .ok_or_else(|| Status::invalid_argument("Invalid public key: no key provided"))?;
+        let key = PublicKey::from_bytes(proto_key.bytes.as_ref())
+            .map_err(|_| Status::invalid_argument("Invalid public key: couldn't parse"))?;
+
+        // ensure provided key is part of the committee
+        if self.committee.primary(&key).is_err() {
+            return Err(Status::invalid_argument(
+                "Invalid public key: unknown authority",
+            ));
+        }
+
+        Ok(key)
     }
 }
 
 #[tonic::async_trait]
-impl Configuration for NarwhalConfiguration {
+impl<PublicKey: VerifyingKey> Configuration for NarwhalConfiguration<PublicKey> {
     async fn new_epoch(
         &self,
         request: Request<NewEpochRequest>,
@@ -25,14 +48,7 @@ impl Configuration for NarwhalConfiguration {
         let validators = new_epoch_request.validators;
         let mut parsed_input = vec![];
         for validator in validators.iter() {
-            let proto_key = validator
-                .public_key
-                .as_ref()
-                .ok_or_else(|| Status::invalid_argument("Missing public key"))?;
-            let public_key: Ed25519PublicKey =
-                Ed25519PublicKey::from_bytes(proto_key.bytes.as_ref()).map_err(|err| {
-                    Status::invalid_argument(format!("Could not serialize: {:?}", err))
-                })?;
+            let public_key = self.get_public_key(validator.public_key.as_ref())?;
 
             let stake_weight = validator.stake_weight;
             let address: Multiaddr = validator
@@ -64,14 +80,7 @@ impl Configuration for NarwhalConfiguration {
         let validators = new_network_info_request.validators;
         let mut parsed_input = vec![];
         for validator in validators.iter() {
-            let proto_key = validator
-                .public_key
-                .as_ref()
-                .ok_or_else(|| Status::invalid_argument("Missing public key"))?;
-            let public_key: Ed25519PublicKey =
-                Ed25519PublicKey::from_bytes(proto_key.bytes.as_ref()).map_err(|err| {
-                    Status::invalid_argument(format!("Could not serialize: {:?}", err))
-                })?;
+            let public_key = self.get_public_key(validator.public_key.as_ref())?;
 
             let stake_weight = validator.stake_weight;
             let address: Multiaddr = validator

--- a/primary/src/grpc_server/mod.rs
+++ b/primary/src/grpc_server/mod.rs
@@ -75,7 +75,7 @@ impl<PublicKey: VerifyingKey, SynchronizerHandler: Handler<PublicKey> + Send + S
 
         let narwhal_proposer = NarwhalProposer::new(self.dag.clone(), Arc::clone(&self.committee));
 
-        let narwhal_configuration = NarwhalConfiguration::new();
+        let narwhal_configuration = NarwhalConfiguration::new(Arc::clone(&self.committee));
 
         let config = mysten_network::config::Config::default();
         let server = config

--- a/primary/tests/integration_tests_configuration_api.rs
+++ b/primary/tests/integration_tests_configuration_api.rs
@@ -11,8 +11,68 @@ use test_utils::{committee, keys, temp_dir};
 use tokio::sync::mpsc::channel;
 use tonic::transport::Channel;
 use types::{
-    ConfigurationClient, MultiAddrProto, NewNetworkInfoRequest, PublicKeyProto, ValidatorData,
+    ConfigurationClient, MultiAddrProto, NewEpochRequest, NewNetworkInfoRequest, PublicKeyProto,
+    ValidatorData,
 };
+
+#[tokio::test]
+async fn test_new_epoch() {
+    let parameters = Parameters {
+        batch_size: 200, // Two transactions.
+        ..Parameters::default()
+    };
+    let keypair = keys(None).pop().unwrap();
+    let name = keypair.public().clone();
+    let signer = keypair;
+    let committee = committee(None);
+
+    // Make the data store.
+    let store = NodeStorage::reopen(temp_dir());
+
+    let (tx_new_certificates, rx_new_certificates) = channel(CHANNEL_CAPACITY);
+    let (_tx_feedback, rx_feedback) = channel(CHANNEL_CAPACITY);
+
+    Primary::spawn(
+        name.clone(),
+        signer,
+        committee.clone(),
+        parameters.clone(),
+        store.header_store.clone(),
+        store.certificate_store.clone(),
+        store.payload_store.clone(),
+        /* tx_consensus */ tx_new_certificates,
+        /* rx_consensus */ rx_feedback,
+        /* dag */ Some(Arc::new(Dag::new(&committee, rx_new_certificates).1)),
+    );
+
+    // Wait for tasks to start
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    // Test gRPC server with client call
+    let mut client = connect_to_configuration_client(parameters.clone());
+
+    let public_key = PublicKeyProto::from(name);
+    let stake_weight = 1;
+    let address = MultiAddrProto {
+        address: "/ip4/127.0.0.1".to_string(),
+    };
+
+    let request = tonic::Request::new(NewEpochRequest {
+        epoch_number: 0,
+        validators: vec![ValidatorData {
+            public_key: Some(public_key),
+            stake_weight,
+            address: Some(address),
+        }],
+    });
+
+    let status = client.new_epoch(request).await.unwrap_err();
+
+    println!("message: {:?}", status.message());
+
+    // Not fully implemented but a 'Not Implemented!' message indicates no parsing errors.
+    assert!(status.message().contains("Not Implemented!"));
+}
 
 #[tokio::test]
 async fn test_new_network_info() {

--- a/types/proto/narwhal.proto
+++ b/types/proto/narwhal.proto
@@ -115,6 +115,11 @@ message NewNetworkInfoRequest {
     repeated ValidatorData validators = 2;
 }
 
+message NewEpochRequest {
+    uint32 epoch_number = 1;
+    repeated ValidatorData validators = 2;
+}
+
 // A bincode encoded payload. This is intended to be used in the short-term
 // while we don't have good protobuf definitions for Narwhal types
 message BincodeEncodedPayload {
@@ -145,6 +150,8 @@ service Proposer {
 }
 
 service Configuration {
+    // Signals a new epoch
+    rpc NewEpoch (NewEpochRequest) returns (Empty);
     // Signals a change in networking info
     rpc NewNetworkInfo (NewNetworkInfoRequest) returns (Empty);
 }

--- a/types/src/proto.rs
+++ b/types/src/proto.rs
@@ -34,7 +34,7 @@ pub use narwhal::{
     Batch as BatchProto, BatchDigest as BatchDigestProto, BatchMessage as BatchMessageProto,
     BincodeEncodedPayload, CertificateDigest as CertificateDigestProto, CollectionError,
     CollectionErrorType, CollectionRetrievalResult, Empty, GetCollectionsRequest,
-    GetCollectionsResponse, MultiAddr as MultiAddrProto, NewNetworkInfoRequest,
+    GetCollectionsResponse, MultiAddr as MultiAddrProto, NewEpochRequest, NewNetworkInfoRequest,
     NodeReadCausalRequest, NodeReadCausalResponse, PublicKey as PublicKeyProto, ReadCausalRequest,
     ReadCausalResponse, RemoveCollectionsRequest, RoundsRequest, RoundsResponse,
     Transaction as TransactionProto, ValidatorData,


### PR DESCRIPTION
This endpoint is used to signal a new epoch. More info can be found in API [docs](https://docs.google.com/document/d/1ogieB-Y-PkvINJLfpS9G5Tga4RrmBef3OO0RSHa1fyU/edit#).

```
struct ValidatorData {
    public_key: PublicKey,
    stake_weight: u64,
    address: Multiaddr,
}
```

```
/// signals a new epoch
fn new_epoch(epoch_number: u32, validators: Vec<ValidatorData>) -> Result((), Error);
```


This PR just tests serializing and deserializing the new epoch data that will be required. Once the backend to handle an epoch change is completed I will complete this work.