### PR TITLE
[garbage_collection] link remove_collections endpoint to garbage collection process

### DIFF
--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -115,7 +115,7 @@ impl Node {
         State: ExecutionState + Send + Sync + 'static,
     {
         let (tx_new_certificates, rx_new_certificates) = channel(Self::CHANNEL_CAPACITY);
-        let (tx_feedback, rx_feedback) = channel(Self::CHANNEL_CAPACITY);
+        let (tx_consensus, rx_consensus) = channel(Self::CHANNEL_CAPACITY);
 
         // Compute the public key of this authority.
         let name = keypair.public().clone();
@@ -132,7 +132,7 @@ impl Node {
                 parameters.clone(),
                 execution_state,
                 rx_new_certificates,
-                tx_feedback,
+                tx_consensus.clone(),
                 tx_confirmation,
             )
             .await?;
@@ -149,9 +149,10 @@ impl Node {
             store.certificate_store.clone(),
             store.payload_store.clone(),
             /* tx_consensus */ tx_new_certificates,
-            /* rx_consensus */ rx_feedback,
+            /* rx_consensus */ rx_consensus,
             /* dag */ dag,
             network_model,
+            tx_consensus,
         );
 
         Ok(primary_handle)

--- a/primary/src/primary.rs
+++ b/primary/src/primary.rs
@@ -101,6 +101,7 @@ impl Primary {
         rx_consensus: Receiver<Certificate<PublicKey>>,
         dag: Option<Arc<Dag<PublicKey>>>,
         network_model: NetworkModel,
+        tx_committed_certificates: Sender<Certificate<PublicKey>>,
     ) -> JoinHandle<()> {
         let (tx_others_digests, rx_others_digests) = channel(CHANNEL_CAPACITY);
         let (tx_our_digests, rx_our_digests) = channel(CHANNEL_CAPACITY);
@@ -244,6 +245,7 @@ impl Primary {
             PrimaryToWorkerNetwork::default(),
             rx_block_removal_commands,
             rx_batch_removal,
+            tx_committed_certificates,
         );
 
         // Responsible for finding missing blocks (certificates) and fetching

--- a/primary/tests/integration_tests_configuration_api.rs
+++ b/primary/tests/integration_tests_configuration_api.rs
@@ -30,7 +30,7 @@ async fn test_new_epoch() {
     let store = NodeStorage::reopen(temp_dir());
 
     let (tx_new_certificates, rx_new_certificates) = channel(CHANNEL_CAPACITY);
-    let (_tx_feedback, rx_feedback) = channel(CHANNEL_CAPACITY);
+    let (tx_feedback, rx_feedback) = channel(CHANNEL_CAPACITY);
 
     Primary::spawn(
         name.clone(),
@@ -44,6 +44,7 @@ async fn test_new_epoch() {
         /* rx_consensus */ rx_feedback,
         /* dag */ Some(Arc::new(Dag::new(&committee, rx_new_certificates).1)),
         NetworkModel::Asynchronous,
+        tx_feedback,
     );
 
     // Wait for tasks to start
@@ -90,7 +91,7 @@ async fn test_new_network_info() {
     let store = NodeStorage::reopen(temp_dir());
 
     let (tx_new_certificates, rx_new_certificates) = channel(CHANNEL_CAPACITY);
-    let (_tx_feedback, rx_feedback) = channel(CHANNEL_CAPACITY);
+    let (tx_feedback, rx_feedback) = channel(CHANNEL_CAPACITY);
 
     Primary::spawn(
         name.clone(),
@@ -104,6 +105,7 @@ async fn test_new_network_info() {
         /* rx_consensus */ rx_feedback,
         /* dag */ Some(Arc::new(Dag::new(&committee, rx_new_certificates).1)),
         NetworkModel::Asynchronous,
+        /* tx_committed_certificates */ tx_feedback,
     );
 
     // Wait for tasks to start

--- a/primary/tests/integration_tests_proposer_api.rs
+++ b/primary/tests/integration_tests_proposer_api.rs
@@ -69,7 +69,7 @@ async fn test_rounds_errors() {
 
     // Spawn the primary
     let (tx_new_certificates, rx_new_certificates) = channel(CHANNEL_CAPACITY);
-    let (_tx_feedback, rx_feedback) = channel(CHANNEL_CAPACITY);
+    let (tx_feedback, rx_feedback) = channel(CHANNEL_CAPACITY);
 
     // AND create a committee passed exclusively to the DAG that does not include the name public key
     // In this way, the genesis certificate is not run for that authority and is absent when we try to fetch it
@@ -108,6 +108,7 @@ async fn test_rounds_errors() {
             Dag::new(&no_name_committee, rx_new_certificates).1,
         )),
         NetworkModel::Asynchronous,
+        tx_feedback,
     );
 
     // AND Wait for tasks to start
@@ -156,7 +157,7 @@ async fn test_rounds_return_successful_response() {
 
     // Spawn the primary
     let (tx_new_certificates, rx_new_certificates) = channel(CHANNEL_CAPACITY);
-    let (_tx_feedback, rx_feedback) = channel(CHANNEL_CAPACITY);
+    let (tx_feedback, rx_feedback) = channel(CHANNEL_CAPACITY);
 
     // AND setup the DAG
     let dag = Arc::new(Dag::new(&committee, rx_new_certificates).1);
@@ -173,6 +174,7 @@ async fn test_rounds_return_successful_response() {
         /* rx_consensus */ rx_feedback,
         /* external_consensus */ Some(dag.clone()),
         NetworkModel::Asynchronous,
+        tx_feedback,
     );
 
     // AND Wait for tasks to start
@@ -286,7 +288,7 @@ async fn test_node_read_causal_signed_certificates() {
         .await
         .unwrap();
 
-    let (_tx_feedback, rx_feedback) = channel(CHANNEL_CAPACITY);
+    let (tx_feedback, rx_feedback) = channel(CHANNEL_CAPACITY);
 
     let primary_1_parameters = Parameters {
         batch_size: 200, // Two transactions.
@@ -308,10 +310,11 @@ async fn test_node_read_causal_signed_certificates() {
         /* rx_consensus */ rx_feedback,
         /* dag */ Some(dag.clone()),
         NetworkModel::Asynchronous,
+        tx_feedback,
     );
 
     let (tx_new_certificates_2, rx_new_certificates_2) = channel(CHANNEL_CAPACITY);
-    let (_tx_feedback_2, rx_feedback_2) = channel(CHANNEL_CAPACITY);
+    let (tx_feedback_2, rx_feedback_2) = channel(CHANNEL_CAPACITY);
 
     let primary_2_parameters = Parameters {
         batch_size: 200, // Two transactions.
@@ -334,6 +337,7 @@ async fn test_node_read_causal_signed_certificates() {
         /* external_consensus */
         Some(Arc::new(Dag::new(&committee, rx_new_certificates_2).1)),
         NetworkModel::Asynchronous,
+        tx_feedback_2,
     );
 
     // Wait for tasks to start

--- a/primary/tests/integration_tests_validator_api.rs
+++ b/primary/tests/integration_tests_validator_api.rs
@@ -99,7 +99,7 @@ async fn test_get_collections() {
     }
 
     let (tx_new_certificates, rx_new_certificates) = channel(CHANNEL_CAPACITY);
-    let (_tx_feedback, rx_feedback) = channel(CHANNEL_CAPACITY);
+    let (tx_feedback, rx_feedback) = channel(CHANNEL_CAPACITY);
 
     Primary::spawn(
         name.clone(),
@@ -113,6 +113,7 @@ async fn test_get_collections() {
         /* rx_consensus */ rx_feedback,
         /* dag */ Some(Arc::new(Dag::new(&committee, rx_new_certificates).1)),
         NetworkModel::Asynchronous,
+        tx_feedback,
     );
 
     // Spawn a `Worker` instance.
@@ -264,7 +265,7 @@ async fn test_remove_collections() {
         }
     }
 
-    let (_tx_feedback, rx_feedback) = channel(CHANNEL_CAPACITY);
+    let (tx_feedback, rx_feedback) = channel(CHANNEL_CAPACITY);
 
     Primary::spawn(
         name.clone(),
@@ -278,6 +279,7 @@ async fn test_remove_collections() {
         /* rx_consensus */ rx_feedback,
         /* dag */ Some(dag.clone()),
         NetworkModel::Asynchronous,
+        tx_feedback,
     );
 
     // Wait for tasks to start
@@ -452,7 +454,7 @@ async fn test_read_causal_signed_certificates() {
         .await
         .unwrap();
 
-    let (_tx_feedback, rx_feedback) = channel(CHANNEL_CAPACITY);
+    let (tx_feedback, rx_feedback) = channel(CHANNEL_CAPACITY);
 
     let primary_1_parameters = Parameters {
         batch_size: 200, // Two transactions.
@@ -474,10 +476,11 @@ async fn test_read_causal_signed_certificates() {
         /* rx_consensus */ rx_feedback,
         /* dag */ Some(dag.clone()),
         NetworkModel::Asynchronous,
+        tx_feedback,
     );
 
     let (tx_new_certificates_2, rx_new_certificates_2) = channel(CHANNEL_CAPACITY);
-    let (_tx_feedback_2, rx_feedback_2) = channel(CHANNEL_CAPACITY);
+    let (tx_feedback_2, rx_feedback_2) = channel(CHANNEL_CAPACITY);
 
     let primary_2_parameters = Parameters {
         batch_size: 200, // Two transactions.
@@ -500,6 +503,7 @@ async fn test_read_causal_signed_certificates() {
         /* external_consensus */
         Some(Arc::new(Dag::new(&committee, rx_new_certificates_2).1)),
         NetworkModel::Asynchronous,
+        tx_feedback_2,
     );
 
     // Wait for tasks to start
@@ -643,7 +647,7 @@ async fn test_read_causal_unsigned_certificates() {
         .await
         .unwrap();
 
-    let (_tx_feedback, rx_feedback) = channel(CHANNEL_CAPACITY);
+    let (tx_feedback, rx_feedback) = channel(CHANNEL_CAPACITY);
 
     // Spawn Primary 1 that we will be interacting with.
     Primary::spawn(
@@ -658,10 +662,11 @@ async fn test_read_causal_unsigned_certificates() {
         /* rx_consensus */ rx_feedback,
         /* dag */ Some(dag.clone()),
         NetworkModel::Asynchronous,
+        tx_feedback,
     );
 
     let (tx_new_certificates_2, rx_new_certificates_2) = channel(CHANNEL_CAPACITY);
-    let (_tx_feedback_2, rx_feedback_2) = channel(CHANNEL_CAPACITY);
+    let (tx_feedback_2, rx_feedback_2) = channel(CHANNEL_CAPACITY);
 
     // Spawn Primary 2
     Primary::spawn(
@@ -677,6 +682,7 @@ async fn test_read_causal_unsigned_certificates() {
         /* external_consensus */
         Some(Arc::new(Dag::new(&committee, rx_new_certificates_2).1)),
         NetworkModel::Asynchronous,
+        tx_feedback_2,
     );
 
     // Wait for tasks to start
@@ -794,7 +800,7 @@ async fn test_get_collections_with_missing_certificates() {
 
     // Spawn the primary 1 (which will be the one that we'll interact with)
     let (tx_new_certificates_1, rx_new_certificates_1) = channel(CHANNEL_CAPACITY);
-    let (_tx_feedback_1, rx_feedback_1) = channel(CHANNEL_CAPACITY);
+    let (tx_feedback_1, rx_feedback_1) = channel(CHANNEL_CAPACITY);
 
     Primary::spawn(
         name_1.clone(),
@@ -809,6 +815,7 @@ async fn test_get_collections_with_missing_certificates() {
         /* external_consensus */
         Some(Arc::new(Dag::new(&committee, rx_new_certificates_1).1)),
         NetworkModel::Asynchronous,
+        tx_feedback_1,
     );
 
     // Spawn a `Worker` instance for primary 1.
@@ -822,7 +829,7 @@ async fn test_get_collections_with_missing_certificates() {
 
     // Spawn the primary 2 - a peer to fetch missing certificates from
     let (tx_new_certificates_2, _) = channel(CHANNEL_CAPACITY);
-    let (_tx_feedback_2, rx_feedback_2) = channel(CHANNEL_CAPACITY);
+    let (tx_feedback_2, rx_feedback_2) = channel(CHANNEL_CAPACITY);
 
     Primary::spawn(
         name_2.clone(),
@@ -837,6 +844,7 @@ async fn test_get_collections_with_missing_certificates() {
         /* external_consensus */
         None,
         NetworkModel::Asynchronous,
+        tx_feedback_2,
     );
 
     // Spawn a `Worker` instance for primary 2.


### PR DESCRIPTION
resolves: https://github.com/MystenLabs/narwhal/issues/229

So far when using Narwhal without Tusk, the existing garbage collection process was not running as this depends on the `consensus_index` being updated via the last committed certificate - which do don't do.

As part of this PR, we are using the `remove_collections` endpoint as a signal to update the `garbage_collector`. Whenever a certificate is removed, we are sending this to and output channel which is consumed from the [garbage_collector](https://github.com/MystenLabs/narwhal/blob/1a06209f5c59a9b1030cc468edadc1ee7a7f376e/primary/src/garbage_collector.rs#L56), who's in turn updating the `consensus_index` value to set the baseline for the garbage collection processes across the modules.

More information about the design of this can be found [here](https://www.notion.so/mystenlabs/Design-doc-Disk-Cleanup-GC-41c4eab651334ec2bbfd822a0c412c88#b17113f9f0854f8ba985ec22de4e0f2f).

**Note:** there are some known issues with this approach which should be evaluated, but at least for now is providing some way to garbage collect our internal structures.


