### PR TITLE
fix: broken benchmark output

### DIFF
--- a/worker/src/batch_maker.rs
+++ b/worker/src/batch_maker.rs
@@ -121,18 +121,19 @@ impl<PublicKey: VerifyingKey> BatchMaker<PublicKey> {
         #[cfg(feature = "benchmark")]
         {
             // NOTE: This is one extra hash that is only needed to print the following log entries.
-            let digest = serialized_batch_digest(&serialized);
-            for id in tx_ids {
-                // NOTE: This log entry is used to compute performance.
-                info!(
-                    "Batch {:?} contains sample tx {}",
-                    digest,
-                    u64::from_be_bytes(id)
-                );
-            }
+            if let Ok(digest) = serialized_batch_digest(&serialized) {
+                for id in tx_ids {
+                    // NOTE: This log entry is used to compute performance.
+                    info!(
+                        "Batch {:?} contains sample tx {}",
+                        digest,
+                        u64::from_be_bytes(id)
+                    );
+                }
 
-            // NOTE: This log entry is used to compute performance.
-            info!("Batch {:?} contains {} B", digest, size);
+                // NOTE: This log entry is used to compute performance.
+                info!("Batch {:?} contains {} B", digest, size);
+            }
         }
 
         // Broadcast the batch through the network.


### PR DESCRIPTION
Resolves: https://github.com/MystenLabs/narwhal/issues/374

Fixing a bug that was making the benchmark metrics come out as zero (see issue). It turns out that the `serialized_batch_digest` output changed to a `Result` making the digest be printed with the `OK` word wrapped around it. 

So instead of outputting ex `Batch PKLUIRPnBxxxfS7XJ1PQbghU/S22ZSjSkD+Rgd2cTYw=` the output changed to `Batch OK(PKLUIRPnBxxxfS7XJ1PQbghU/S22ZSjSkD+Rgd2cTYw=)` making the logs evade the [parser regex](https://github.com/MystenLabs/narwhal/blob/3257759165a2f9ec09157509294146adcc0c2393/benchmark/benchmark/logs.py#L150). With this fix now the output is back to normal:

```

 + RESULTS:
 Consensus TPS: 44,885 tx/s
 Consensus BPS: 22,981,085 B/s
 Consensus latency: 903 ms

 End-to-end TPS: 44,602 tx/s
 End-to-end BPS: 22,836,145 B/s
 End-to-end latency: 1,050 ms
-----------------------------------------
```