### PR TITLE
Hookup NewNetworkInfo endpoint with backend

### DIFF
--- a/examples/doc/docs.md
+++ b/examples/doc/docs.md
@@ -15,9 +15,11 @@
     - [GetCollectionsRequest](#narwhal-GetCollectionsRequest)
     - [GetCollectionsResponse](#narwhal-GetCollectionsResponse)
     - [MultiAddr](#narwhal-MultiAddr)
+    - [NewEpochRequest](#narwhal-NewEpochRequest)
     - [NewNetworkInfoRequest](#narwhal-NewNetworkInfoRequest)
     - [NodeReadCausalRequest](#narwhal-NodeReadCausalRequest)
     - [NodeReadCausalResponse](#narwhal-NodeReadCausalResponse)
+    - [PrimaryAddresses](#narwhal-PrimaryAddresses)
     - [PublicKey](#narwhal-PublicKey)
     - [ReadCausalRequest](#narwhal-ReadCausalRequest)
     - [ReadCausalResponse](#narwhal-ReadCausalResponse)
@@ -213,6 +215,22 @@ Empty message for when we don&#39;t have anything to return
 
 
 
+<a name="narwhal-NewEpochRequest"></a>
+
+### NewEpochRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| epoch_number | [uint32](#uint32) |  |  |
+| validators | [ValidatorData](#narwhal-ValidatorData) | repeated |  |
+
+
+
+
+
+
 <a name="narwhal-NewNetworkInfoRequest"></a>
 
 ### NewNetworkInfoRequest
@@ -254,6 +272,22 @@ Empty message for when we don&#39;t have anything to return
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | collection_ids | [CertificateDigest](#narwhal-CertificateDigest) | repeated | Resulting sequence of collections from DAG walk. |
+
+
+
+
+
+
+<a name="narwhal-PrimaryAddresses"></a>
+
+### PrimaryAddresses
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| primary_to_primary | [MultiAddr](#narwhal-MultiAddr) |  |  |
+| worker_to_primary | [MultiAddr](#narwhal-MultiAddr) |  |  |
 
 
 
@@ -376,7 +410,7 @@ Empty message for when we don&#39;t have anything to return
 | ----- | ---- | ----- | ----------- |
 | public_key | [PublicKey](#narwhal-PublicKey) |  |  |
 | stake_weight | [int64](#int64) |  |  |
-| address | [MultiAddr](#narwhal-MultiAddr) |  |  |
+| primary_addresses | [PrimaryAddresses](#narwhal-PrimaryAddresses) |  |  |
 
 
 
@@ -409,6 +443,7 @@ Empty message for when we don&#39;t have anything to return
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
+| NewEpoch | [NewEpochRequest](#narwhal-NewEpochRequest) | [Empty](#narwhal-Empty) | Signals a new epoch |
 | NewNetworkInfo | [NewNetworkInfoRequest](#narwhal-NewNetworkInfoRequest) | [Empty](#narwhal-Empty) | Signals a change in networking info |
 
 

--- a/examples/protos/narwhal.proto
+++ b/examples/protos/narwhal.proto
@@ -32,9 +32,14 @@ message CollectionError {
     CollectionErrorType error = 2;
 }
 
- message BatchMessage {
+message BatchMessage {
     BatchDigest id = 1;
     Batch transactions = 2;
+}
+
+message PrimaryAddresses {
+    MultiAddr primary_to_primary = 1;
+    MultiAddr worker_to_primary = 2;
 }
 
 message MultiAddr {
@@ -48,7 +53,7 @@ message PublicKey {
 message ValidatorData {
     PublicKey public_key = 1;
     int64 stake_weight = 2;
-    MultiAddr address = 3;
+    PrimaryAddresses primary_addresses = 3;
 }
 
 message CollectionRetrievalResult {
@@ -115,6 +120,11 @@ message NewNetworkInfoRequest {
     repeated ValidatorData validators = 2;
 }
 
+message NewEpochRequest {
+    uint32 epoch_number = 1;
+    repeated ValidatorData validators = 2;
+}
+
 // A bincode encoded payload. This is intended to be used in the short-term
 // while we don't have good protobuf definitions for Narwhal types
 message BincodeEncodedPayload {
@@ -145,6 +155,8 @@ service Proposer {
 }
 
 service Configuration {
+    // Signals a new epoch
+    rpc NewEpoch (NewEpochRequest) returns (Empty);
     // Signals a change in networking info
     rpc NewNetworkInfo (NewNetworkInfoRequest) returns (Empty);
 }

--- a/primary/src/grpc_server/configuration.rs
+++ b/primary/src/grpc_server/configuration.rs
@@ -1,9 +1,8 @@
-use std::collections::BTreeMap;
-
-use config::{PrimaryAddresses, SharedCommittee};
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
+use config::{PrimaryAddresses, SharedCommittee};
 use crypto::traits::VerifyingKey;
+use std::collections::BTreeMap;
 use tonic::{Request, Response, Status};
 use types::{Configuration, Empty, NewEpochRequest, NewNetworkInfoRequest, PublicKeyProto};
 

--- a/primary/src/grpc_server/configuration.rs
+++ b/primary/src/grpc_server/configuration.rs
@@ -1,8 +1,9 @@
-use config::SharedCommittee;
+use std::collections::BTreeMap;
+
+use config::{PrimaryAddresses, SharedCommittee};
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use crypto::traits::VerifyingKey;
-use multiaddr::Multiaddr;
 use tonic::{Request, Response, Status};
 use types::{Configuration, Empty, NewEpochRequest, NewNetworkInfoRequest, PublicKeyProto};
 
@@ -51,18 +52,35 @@ impl<PublicKey: VerifyingKey> Configuration for NarwhalConfiguration<PublicKey> 
             let public_key = self.get_public_key(validator.public_key.as_ref())?;
 
             let stake_weight = validator.stake_weight;
-            let address: Multiaddr = validator
-                .address
+            let primary_addresses = validator
+                .primary_addresses
                 .as_ref()
-                .ok_or_else(|| Status::invalid_argument("Missing address"))?
+                .ok_or_else(|| Status::invalid_argument("Missing primary addresses"))?;
+            let primary_to_primary = primary_addresses
+                .primary_to_primary
+                .as_ref()
+                .ok_or_else(|| Status::invalid_argument("Missing primary to primary address"))?
                 .address
                 .parse()
                 .map_err(|err| {
                     Status::invalid_argument(format!("Could not serialize: {:?}", err))
                 })?;
+            let worker_to_primary = primary_addresses
+                .primary_to_primary
+                .as_ref()
+                .ok_or_else(|| Status::invalid_argument("Missing worker to primary address"))?
+                .address
+                .parse()
+                .map_err(|err| {
+                    Status::invalid_argument(format!("Could not serialize: {:?}", err))
+                })?;
+            let primary = PrimaryAddresses {
+                primary_to_primary,
+                worker_to_primary,
+            };
             parsed_input.push(format!(
-                "public_key: {:?} stake_weight: {:?} address: {:?}",
-                public_key, stake_weight, address
+                "public_key: {:?} stake_weight: {:?} primary addresses: {:?}",
+                public_key, stake_weight, primary
             ));
         }
         Err(Status::internal(format!(
@@ -76,30 +94,49 @@ impl<PublicKey: VerifyingKey> Configuration for NarwhalConfiguration<PublicKey> 
         request: Request<NewNetworkInfoRequest>,
     ) -> Result<Response<Empty>, Status> {
         let new_network_info_request = request.into_inner();
-        let epoch_number = new_network_info_request.epoch_number;
+        // TODO: Figure out how to verify network data against current epoch.
+        let _epoch_number = new_network_info_request.epoch_number;
         let validators = new_network_info_request.validators;
-        let mut parsed_input = vec![];
+        let mut new_network_info = BTreeMap::new();
         for validator in validators.iter() {
             let public_key = self.get_public_key(validator.public_key.as_ref())?;
 
-            let stake_weight = validator.stake_weight;
-            let address: Multiaddr = validator
-                .address
+            let stake_weight: u32 = validator
+                .stake_weight
+                .try_into()
+                .map_err(|_| Status::invalid_argument("Invalid stake weight"))?;
+            let primary_addresses = validator
+                .primary_addresses
                 .as_ref()
-                .ok_or_else(|| Status::invalid_argument("Missing address"))?
+                .ok_or_else(|| Status::invalid_argument("Missing primary addresses"))?;
+            let primary_to_primary = primary_addresses
+                .primary_to_primary
+                .as_ref()
+                .ok_or_else(|| Status::invalid_argument("Missing primary to primary address"))?
                 .address
                 .parse()
                 .map_err(|err| {
                     Status::invalid_argument(format!("Could not serialize: {:?}", err))
                 })?;
-            parsed_input.push(format!(
-                "public_key: {:?} stake_weight: {:?} address: {:?}",
-                public_key, stake_weight, address
-            ));
+            let worker_to_primary = primary_addresses
+                .primary_to_primary
+                .as_ref()
+                .ok_or_else(|| Status::invalid_argument("Missing worker to primary address"))?
+                .address
+                .parse()
+                .map_err(|err| {
+                    Status::invalid_argument(format!("Could not serialize: {:?}", err))
+                })?;
+            let primary = PrimaryAddresses {
+                primary_to_primary,
+                worker_to_primary,
+            };
+            new_network_info.insert(public_key, (stake_weight, primary));
         }
-        Err(Status::internal(format!(
-            "Not Implemented! But parsed input - epoch_number: {:?} & validator_data: {:?}",
-            epoch_number, parsed_input
-        )))
+        self.committee
+            .update_primary_network_info(new_network_info)
+            .map_err(|err| Status::internal(format!("Could not update network info: {:?}", err)))?;
+
+        Ok(Response::new(Empty {}))
     }
 }

--- a/primary/src/grpc_server/configuration.rs
+++ b/primary/src/grpc_server/configuration.rs
@@ -93,8 +93,13 @@ impl<PublicKey: VerifyingKey> Configuration for NarwhalConfiguration<PublicKey> 
         request: Request<NewNetworkInfoRequest>,
     ) -> Result<Response<Empty>, Status> {
         let new_network_info_request = request.into_inner();
-        // TODO: Figure out how to verify network data against current epoch.
-        let _epoch_number = new_network_info_request.epoch_number;
+        let epoch_number: u64 = new_network_info_request.epoch_number.into();
+        if epoch_number != self.committee.epoch {
+            return Err(Status::invalid_argument(format!(
+                "Passed in epoch {epoch_number} does not match current epoch {}",
+                self.committee.epoch
+            )));
+        }
         let validators = new_network_info_request.validators;
         let mut new_network_info = BTreeMap::new();
         for validator in validators.iter() {

--- a/primary/tests/integration_tests_configuration_api.rs
+++ b/primary/tests/integration_tests_configuration_api.rs
@@ -144,6 +144,17 @@ async fn test_new_network_info() {
     }
 
     let request = tonic::Request::new(NewNetworkInfoRequest {
+        epoch_number: 1,
+        validators: validators.clone(),
+    });
+
+    let status = client.new_network_info(request).await.unwrap_err();
+
+    assert!(status
+        .message()
+        .contains("Passed in epoch 1 does not match current epoch 0"));
+
+    let request = tonic::Request::new(NewNetworkInfoRequest {
         epoch_number: 0,
         validators,
     });

--- a/primary/tests/integration_tests_configuration_api.rs
+++ b/primary/tests/integration_tests_configuration_api.rs
@@ -11,8 +11,8 @@ use test_utils::{committee, keys, temp_dir};
 use tokio::sync::mpsc::channel;
 use tonic::transport::Channel;
 use types::{
-    ConfigurationClient, MultiAddrProto, NewEpochRequest, NewNetworkInfoRequest, PublicKeyProto,
-    ValidatorData,
+    ConfigurationClient, Empty, MultiAddrProto, NewEpochRequest, NewNetworkInfoRequest,
+    PrimaryAddressesProto, PublicKeyProto, ValidatorData,
 };
 
 #[tokio::test]
@@ -55,16 +55,22 @@ async fn test_new_epoch() {
 
     let public_key = PublicKeyProto::from(name);
     let stake_weight = 1;
-    let address = MultiAddrProto {
+    let primary_to_primary = Some(MultiAddrProto {
         address: "/ip4/127.0.0.1".to_string(),
-    };
+    });
+    let worker_to_primary = Some(MultiAddrProto {
+        address: "/ip4/127.0.0.1".to_string(),
+    });
 
     let request = tonic::Request::new(NewEpochRequest {
         epoch_number: 0,
         validators: vec![ValidatorData {
             public_key: Some(public_key),
             stake_weight,
-            address: Some(address),
+            primary_addresses: Some(PrimaryAddressesProto {
+                primary_to_primary,
+                worker_to_primary,
+            }),
         }],
     });
 
@@ -114,27 +120,37 @@ async fn test_new_network_info() {
     // Test gRPC server with client call
     let mut client = connect_to_configuration_client(parameters.clone());
 
-    let public_key = PublicKeyProto::from(name);
-    let stake_weight = 1;
-    let address = MultiAddrProto {
-        address: "/ip4/127.0.0.1".to_string(),
-    };
+    let public_keys: Vec<_> = committee.authorities.load().keys().cloned().collect();
+
+    let mut validators = Vec::new();
+    for public_key in public_keys.iter() {
+        let public_key_proto = PublicKeyProto::from(public_key.clone());
+        let stake_weight = 1;
+        let primary_to_primary = Some(MultiAddrProto {
+            address: "/ip4/127.0.0.1".to_string(),
+        });
+        let worker_to_primary = Some(MultiAddrProto {
+            address: "/ip4/127.0.0.1".to_string(),
+        });
+
+        validators.push(ValidatorData {
+            public_key: Some(public_key_proto),
+            stake_weight,
+            primary_addresses: Some(PrimaryAddressesProto {
+                primary_to_primary,
+                worker_to_primary,
+            }),
+        });
+    }
 
     let request = tonic::Request::new(NewNetworkInfoRequest {
         epoch_number: 0,
-        validators: vec![ValidatorData {
-            public_key: Some(public_key),
-            stake_weight,
-            address: Some(address),
-        }],
+        validators,
     });
 
-    let status = client.new_network_info(request).await.unwrap_err();
-
-    println!("message: {:?}", status.message());
-
-    // Not fully implemented but a 'Not Implemented!' message indicates no parsing errors.
-    assert!(status.message().contains("Not Implemented!"));
+    let response = client.new_network_info(request).await.unwrap();
+    let actual_result = response.into_inner();
+    assert_eq!(Empty {}, actual_result);
 }
 
 fn connect_to_configuration_client(parameters: Parameters) -> ConfigurationClient<Channel> {

--- a/types/proto/narwhal.proto
+++ b/types/proto/narwhal.proto
@@ -32,9 +32,14 @@ message CollectionError {
     CollectionErrorType error = 2;
 }
 
- message BatchMessage {
+message BatchMessage {
     BatchDigest id = 1;
     Batch transactions = 2;
+}
+
+message PrimaryAddresses {
+    MultiAddr primary_to_primary = 1;
+    MultiAddr worker_to_primary = 2;
 }
 
 message MultiAddr {
@@ -48,7 +53,7 @@ message PublicKey {
 message ValidatorData {
     PublicKey public_key = 1;
     int64 stake_weight = 2;
-    MultiAddr address = 3;
+    PrimaryAddresses primary_addresses = 3;
 }
 
 message CollectionRetrievalResult {

--- a/types/src/generated/narwhal.rs
+++ b/types/src/generated/narwhal.rs
@@ -35,6 +35,13 @@ pub struct BatchMessage {
     pub transactions: ::core::option::Option<Batch>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PrimaryAddresses {
+    #[prost(message, optional, tag="1")]
+    pub primary_to_primary: ::core::option::Option<MultiAddr>,
+    #[prost(message, optional, tag="2")]
+    pub worker_to_primary: ::core::option::Option<MultiAddr>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MultiAddr {
     #[prost(string, tag="1")]
     pub address: ::prost::alloc::string::String,
@@ -51,7 +58,7 @@ pub struct ValidatorData {
     #[prost(int64, tag="2")]
     pub stake_weight: i64,
     #[prost(message, optional, tag="3")]
-    pub address: ::core::option::Option<MultiAddr>,
+    pub primary_addresses: ::core::option::Option<PrimaryAddresses>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CollectionRetrievalResult {

--- a/types/src/proto.rs
+++ b/types/src/proto.rs
@@ -35,9 +35,9 @@ pub use narwhal::{
     BincodeEncodedPayload, CertificateDigest as CertificateDigestProto, CollectionError,
     CollectionErrorType, CollectionRetrievalResult, Empty, GetCollectionsRequest,
     GetCollectionsResponse, MultiAddr as MultiAddrProto, NewEpochRequest, NewNetworkInfoRequest,
-    NodeReadCausalRequest, NodeReadCausalResponse, PublicKey as PublicKeyProto, ReadCausalRequest,
-    ReadCausalResponse, RemoveCollectionsRequest, RoundsRequest, RoundsResponse,
-    Transaction as TransactionProto, ValidatorData,
+    NodeReadCausalRequest, NodeReadCausalResponse, PrimaryAddresses as PrimaryAddressesProto,
+    PublicKey as PublicKeyProto, ReadCausalRequest, ReadCausalResponse, RemoveCollectionsRequest,
+    RoundsRequest, RoundsResponse, Transaction as TransactionProto, ValidatorData,
 };
 
 impl<PublicKey: VerifyingKey> From<PublicKey> for PublicKeyProto {


### PR DESCRIPTION
PR for [Issue#250](https://github.com/MystenLabs/sui/issues/5294). Backend work was completed by Francois to handle the following 

> `new_network_info` is meant to convey change in validator URIs only. The validators array can include only the changed elements. Any element in the validators array which PublicKey and stake weight do not match those recorded for the epoch number will result in an error.

Just needed to hook it up with the gRPC endpoint.

Pending Tasks
- Figure out if we need to add any special logic to verify network info for a specific epoch. Will monitor @sadhansood's epoch work before adding any logic to handle that case.
- Verify addresses are reachable with some wait logic
- Investigate if any connections need to be closed and updated with new addresses. Assumption is that any connections made are done by checking the shared committee information first which will be updated with the new addresses. 