### PR TITLE
fix: reduce Committee management to a single ArcSwap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4054,6 +4054,7 @@ name = "worker"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "async-trait",
  "bincode",
  "blake2",

--- a/benchmark/benchmark/full_demo.py
+++ b/benchmark/benchmark/full_demo.py
@@ -88,8 +88,8 @@ class Demo:
             self.node_parameters.print(PathMaker.parameters_file())
 
             # Run the clients (they will wait for the nodes to be ready).
-            workers_addresses = committee.workers_addresses(self.faults)
-            rate_share = ceil(rate / committee.workers())
+            workers_addresses = committee.load().workers_addresses(self.faults)
+            rate_share = ceil(rate / committee.load().workers())
             for i, addresses in enumerate(workers_addresses):
                 for (id, address) in addresses:
                     cmd = CommandMaker.run_client(
@@ -102,7 +102,7 @@ class Demo:
                     self._background_run(cmd, log_file)
 
             # Run the primaries (except the faulty ones).
-            for i, address in enumerate(committee.primary_addresses(self.faults)):
+            for i, address in enumerate(committee.load().primary_addresses(self.faults)):
                 cmd = CommandMaker.run_no_consensus_primary(
                     PathMaker.key_file(i),
                     PathMaker.committee_file(),

--- a/benchmark/benchmark/remote.py
+++ b/benchmark/benchmark/remote.py
@@ -221,8 +221,8 @@ class Bench:
         # Filter all faulty nodes from the client addresses (or they will wait
         # for the faulty nodes to be online).
         Print.info('Booting clients...')
-        workers_addresses = committee.workers_addresses(faults)
-        rate_share = ceil(rate / committee.workers())
+        workers_addresses = committee.load().workers_addresses(faults)
+        rate_share = ceil(rate / committee.load().workers())
         for i, addresses in enumerate(workers_addresses):
             for (id, address) in addresses:
                 host = Committee.ip(address)
@@ -237,7 +237,7 @@ class Bench:
 
         # Run the primaries (except the faulty ones).
         Print.info('Booting primaries...')
-        for i, address in enumerate(committee.primary_addresses(faults)):
+        for i, address in enumerate(committee.load().primary_addresses(faults)):
             host = Committee.ip(address)
             cmd = CommandMaker.run_primary(
                 PathMaker.key_file(i),
@@ -277,7 +277,7 @@ class Bench:
         subprocess.run([cmd], shell=True, stderr=subprocess.DEVNULL)
 
         # Download log files.
-        workers_addresses = committee.workers_addresses(faults)
+        workers_addresses = committee.load().workers_addresses(faults)
         progress = progress_bar(workers_addresses, prefix='Downloading workers logs:')
         for i, addresses in enumerate(progress):
             for id, address in addresses:
@@ -292,7 +292,7 @@ class Bench:
                     local=PathMaker.worker_log_file(i, id)
                 )
 
-        primary_addresses = committee.primary_addresses(faults)
+        primary_addresses = committee.load().primary_addresses(faults)
         progress = progress_bar(primary_addresses, prefix='Downloading primaries logs:')
         for i, address in enumerate(progress):
             host = Committee.ip(address)

--- a/config/tests/config_tests.rs
+++ b/config/tests/config_tests.rs
@@ -11,6 +11,7 @@ use rand::seq::SliceRandom;
 fn update_primary_network_info_test() {
     let committee = test_utils::committee(None);
     let res = committee
+        .clone()
         .update_primary_network_info(BTreeMap::new())
         .unwrap_err();
     for err in res {
@@ -23,11 +24,11 @@ fn update_primary_network_info_test() {
     let committee2 = test_utils::committee(42);
     let invalid_new_info = committee2
         .authorities
-        .load()
         .iter()
         .map(|(pk, a)| (pk.clone(), (a.stake, a.primary.clone())))
         .collect::<BTreeMap<_, (Stake, PrimaryAddresses)>>();
     let res2 = committee
+        .clone()
         .update_primary_network_info(invalid_new_info)
         .unwrap_err();
     for err in res2 {
@@ -42,12 +43,12 @@ fn update_primary_network_info_test() {
     let committee3 = test_utils::committee(None);
     let invalid_new_info = committee3
         .authorities
-        .load()
         .iter()
         // change the stake
         .map(|(pk, a)| (pk.clone(), (a.stake + 1, a.primary.clone())))
         .collect::<BTreeMap<_, (Stake, PrimaryAddresses)>>();
     let res2 = committee
+        .clone()
         .update_primary_network_info(invalid_new_info)
         .unwrap_err();
     for err in res2 {
@@ -61,7 +62,7 @@ fn update_primary_network_info_test() {
     let mut pk_n_stake = Vec::new();
     let mut addresses = Vec::new();
 
-    committee4.authorities.load().iter().for_each(|(pk, a)| {
+    committee4.authorities.iter().for_each(|(pk, a)| {
         pk_n_stake.push((pk.clone(), a.stake));
         addresses.push(a.primary.clone())
     });
@@ -74,9 +75,11 @@ fn update_primary_network_info_test() {
         .zip(addresses)
         .map(|((pk, stk), addr)| (pk, (stk, addr)))
         .collect::<BTreeMap<Ed25519PublicKey, (Stake, PrimaryAddresses)>>();
-    let res = committee.update_primary_network_info(new_info.clone());
+
+    let mut comm = committee;
+    let res = comm.update_primary_network_info(new_info.clone());
     assert!(res.is_ok());
-    for (pk, a) in committee.authorities.load().iter() {
+    for (pk, a) in comm.authorities.iter() {
         assert_eq!(a.primary, new_info.get(pk).unwrap().1);
     }
 }

--- a/consensus/src/bullshark.rs
+++ b/consensus/src/bullshark.rs
@@ -10,7 +10,7 @@ use crypto::{
     traits::{EncodeDecodeBase64, VerifyingKey},
     Hash,
 };
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, ops::Deref, sync::Arc};
 use tracing::debug;
 use types::{Certificate, CertificateDigest, ConsensusStore, Round, SequenceNumber, StoreResult};
 
@@ -60,11 +60,11 @@ impl<PublicKey: VerifyingKey> ConsensusProtocol<PublicKey> for Bullshark<PublicK
         if leader_round <= state.last_committed_round {
             return Ok(Vec::new());
         }
-        let (leader_digest, leader) = match Self::leader(&self.committee, leader_round, &state.dag)
-        {
-            Some(x) => x,
-            None => return Ok(Vec::new()),
-        };
+        let (leader_digest, leader) =
+            match Self::leader(self.committee.load().deref(), leader_round, &state.dag) {
+                Some(x) => x,
+                None => return Ok(Vec::new()),
+            };
 
         // Check if the leader has f+1 support from its children (ie. round r-1).
         let stake: Stake = state
@@ -73,13 +73,13 @@ impl<PublicKey: VerifyingKey> ConsensusProtocol<PublicKey> for Bullshark<PublicK
             .expect("We should have the whole history by now")
             .values()
             .filter(|(_, x)| x.header.parents.contains(leader_digest))
-            .map(|(_, x)| self.committee.stake(&x.origin()))
+            .map(|(_, x)| self.committee.load().stake(&x.origin()))
             .sum();
 
         // If it is the case, we can commit the leader. But first, we need to recursively go back to
         // the last committed leader, and commit all preceding leaders in the right order. Committing
         // a leader block means committing all its dependencies.
-        if stake < self.committee.validity_threshold() {
+        if stake < self.committee.load().validity_threshold() {
             debug!("Leader {:?} does not have enough support", leader);
             return Ok(Vec::new());
         }
@@ -87,9 +87,10 @@ impl<PublicKey: VerifyingKey> ConsensusProtocol<PublicKey> for Bullshark<PublicK
         // Get an ordered list of past leaders that are linked to the current leader.
         debug!("Leader {:?} has enough support", leader);
         let mut sequence = Vec::new();
-        for leader in utils::order_leaders(&self.committee, leader, state, Self::leader)
-            .iter()
-            .rev()
+        for leader in
+            utils::order_leaders(self.committee.load().deref(), leader, state, Self::leader)
+                .iter()
+                .rev()
         {
             // Starting from the oldest leader, flatten the sub-dag referenced by the leader.
             for x in utils::order_dag(self.gc_depth, leader, state) {

--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -2,7 +2,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use crate::{metrics::ConsensusMetrics, ConsensusOutput, SequenceNumber};
-use config::SharedCommittee;
+use config::{Committee, SharedCommittee};
 use crypto::{traits::VerifyingKey, Hash};
 use std::{cmp::max, collections::HashMap, sync::Arc};
 use tokio::{
@@ -137,7 +137,8 @@ where
     ) -> JoinHandle<StoreResult<()>> {
         tokio::spawn(async move {
             let consensus_index = store.read_last_consensus_index()?;
-            let genesis = Certificate::genesis(&committee);
+            let committee: &Committee<PublicKey> = &committee.load();
+            let genesis = Certificate::genesis(committee);
             Self {
                 rx_primary,
                 tx_primary,

--- a/consensus/src/tests/bullshark_tests.rs
+++ b/consensus/src/tests/bullshark_tests.rs
@@ -55,7 +55,7 @@ async fn commit_one() {
         .into_iter()
         .map(|kp| kp.public().clone())
         .collect();
-    let genesis = Certificate::genesis(&mock_committee(&keys[..]))
+    let genesis = Certificate::genesis(&mock_committee(&keys[..]).load())
         .iter()
         .map(|x| x.digest())
         .collect::<BTreeSet<_>>();
@@ -119,7 +119,7 @@ async fn dead_node() {
     keys.sort(); // Ensure we don't remove one of the leaders.
     let _ = keys.pop().unwrap();
 
-    let genesis = Certificate::genesis(&mock_committee(&keys[..]))
+    let genesis = Certificate::genesis(mock_committee(&keys[..]).load().deref())
         .iter()
         .map(|x| x.digest())
         .collect::<BTreeSet<_>>();
@@ -177,7 +177,7 @@ async fn not_enough_support() {
         .collect();
     keys.sort();
 
-    let genesis = Certificate::genesis(&mock_committee(&keys[..]))
+    let genesis = Certificate::genesis(mock_committee(&keys[..]).load().deref())
         .iter()
         .map(|x| x.digest())
         .collect::<BTreeSet<_>>();
@@ -288,7 +288,7 @@ async fn missing_leader() {
         .collect();
     keys.sort();
 
-    let genesis = Certificate::genesis(&mock_committee(&keys[..]))
+    let genesis = Certificate::genesis(mock_committee(&keys[..]).load().deref())
         .iter()
         .map(|x| x.digest())
         .collect::<BTreeSet<_>>();

--- a/consensus/src/tests/dag_tests.rs
+++ b/consensus/src/tests/dag_tests.rs
@@ -24,7 +24,7 @@ async fn inner_dag_insert_one() {
         .map(|kp| kp.public().clone())
         .collect();
     let committee = mock_committee(&keys.clone()[..]);
-    let genesis_certs = Certificate::genesis(&committee);
+    let genesis_certs = Certificate::genesis(&*committee.load());
     let genesis = genesis_certs
         .iter()
         .map(|x| x.digest())
@@ -34,7 +34,7 @@ async fn inner_dag_insert_one() {
     // set up a Dag
     let (tx_cert, rx_cert) = channel(1);
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
-    Dag::new(&committee, rx_cert, metrics);
+    Dag::new(&*committee.load(), rx_cert, metrics);
 
     // Feed the certificates to the Dag
     while let Some(certificate) = certificates.pop_front() {
@@ -49,7 +49,7 @@ async fn test_dag_new_has_genesis_and_its_not_live() {
         .map(|kp| kp.public().clone())
         .collect();
     let committee = mock_committee(&keys.clone()[..]);
-    let genesis_certs = Certificate::genesis(&committee);
+    let genesis_certs = Certificate::genesis(&*committee.load());
     let genesis = genesis_certs
         .iter()
         .map(|x| x.digest())
@@ -58,7 +58,7 @@ async fn test_dag_new_has_genesis_and_its_not_live() {
     // set up a Dag
     let (_tx_cert, rx_cert) = channel(1);
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
-    let (_, dag) = Dag::new(&committee, rx_cert, metrics);
+    let (_, dag) = Dag::new(&*committee.load(), rx_cert, metrics);
 
     for certificate in genesis.clone() {
         assert!(dag.contains(certificate).await);
@@ -100,7 +100,7 @@ async fn test_dag_compresses_empty_blocks() {
         .map(|kp| kp.public().clone())
         .collect();
     let committee = mock_committee(&keys.clone()[..]);
-    let genesis_certs = Certificate::genesis(&committee);
+    let genesis_certs = Certificate::genesis(&*committee.load());
     let genesis = genesis_certs
         .iter()
         .map(|x| x.digest())
@@ -109,7 +109,7 @@ async fn test_dag_compresses_empty_blocks() {
     // set up a Dag
     let (_tx_cert, rx_cert) = channel(1);
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
-    let (_, dag) = Dag::new(&committee, rx_cert, metrics);
+    let (_, dag) = Dag::new(&*committee.load(), rx_cert, metrics);
 
     // insert one round of empty certificates
     let (mut certificates, next_parents) =
@@ -168,7 +168,7 @@ async fn test_dag_rounds_after_compression() {
         .map(|kp| kp.public().clone())
         .collect();
     let committee = mock_committee(&keys.clone()[..]);
-    let genesis_certs = Certificate::genesis(&committee);
+    let genesis_certs = Certificate::genesis(&*committee.load());
     let genesis = genesis_certs
         .iter()
         .map(|x| x.digest())
@@ -177,7 +177,7 @@ async fn test_dag_rounds_after_compression() {
     // set up a Dag
     let (_tx_cert, rx_cert) = channel(1);
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
-    let (_, dag) = Dag::new(&committee, rx_cert, metrics);
+    let (_, dag) = Dag::new(&*committee.load(), rx_cert, metrics);
 
     // insert one round of empty certificates
     let (mut certificates, next_parents) =
@@ -217,7 +217,7 @@ async fn dag_mutation_failures() {
         .map(|kp| kp.public().clone())
         .collect();
     let committee = mock_committee(&keys.clone()[..]);
-    let genesis_certs = Certificate::genesis(&committee);
+    let genesis_certs = Certificate::genesis(&*committee.load());
     let genesis = genesis_certs
         .iter()
         .map(|x| x.digest())
@@ -227,7 +227,7 @@ async fn dag_mutation_failures() {
     // set up a Dag
     let (_tx_cert, rx_cert) = channel(1);
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
-    let (_handle, dag) = Dag::new(&committee, rx_cert, metrics);
+    let (_handle, dag) = Dag::new(&*committee.load(), rx_cert, metrics);
     let mut certs_to_insert = certificates.clone();
     let mut certs_to_insert_in_reverse = certs_to_insert.clone();
     let mut certs_to_remove_before_insert = certs_to_insert.clone();
@@ -286,7 +286,7 @@ async fn dag_insert_one_and_rounds_node_read() {
         .map(|kp| kp.public().clone())
         .collect();
     let committee = mock_committee(&keys.clone()[..]);
-    let genesis_certs = Certificate::genesis(&committee);
+    let genesis_certs = Certificate::genesis(&*committee.load());
     let genesis = genesis_certs
         .iter()
         .map(|x| x.digest())
@@ -296,7 +296,7 @@ async fn dag_insert_one_and_rounds_node_read() {
     // set up a Dag
     let (_tx_cert, rx_cert) = channel(1);
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
-    let (_handle, dag) = Dag::new(&committee, rx_cert, metrics);
+    let (_handle, dag) = Dag::new(&*committee.load(), rx_cert, metrics);
     let mut certs_to_insert = certificates.clone();
 
     // Feed the certificates to the Dag
@@ -334,7 +334,7 @@ async fn dag_insert_and_remove_reads() {
         .map(|kp| kp.public().clone())
         .collect();
     let committee = mock_committee(&keys.clone()[..]);
-    let mut genesis_certs = Certificate::genesis(&committee);
+    let mut genesis_certs = Certificate::genesis(&*committee.load());
     let genesis = genesis_certs
         .iter()
         .map(|x| x.digest())
@@ -344,7 +344,7 @@ async fn dag_insert_and_remove_reads() {
     // set up a Dag
     let (_tx_cert, rx_cert) = channel(1);
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
-    let (_handle, dag) = Dag::new(&committee, rx_cert, metrics);
+    let (_handle, dag) = Dag::new(&*committee.load(), rx_cert, metrics);
 
     // Feed the certificates to the Dag
     while let Some(certificate) = certificates.pop_front() {

--- a/consensus/src/tests/subscriber_tests.rs
+++ b/consensus/src/tests/subscriber_tests.rs
@@ -19,7 +19,7 @@ pub fn commit_certificates() -> VecDeque<Certificate<Ed25519PublicKey>> {
         .into_iter()
         .map(|kp| kp.public().clone())
         .collect();
-    let genesis = Certificate::genesis(&mock_committee(&keys[..]))
+    let genesis = Certificate::genesis(&*mock_committee(&keys[..]).load())
         .iter()
         .map(|x| x.digest())
         .collect::<BTreeSet<_>>();

--- a/consensus/src/tests/tusk_tests.rs
+++ b/consensus/src/tests/tusk_tests.rs
@@ -55,7 +55,7 @@ async fn commit_one() {
         .into_iter()
         .map(|kp| kp.public().clone())
         .collect();
-    let genesis = Certificate::genesis(&mock_committee(&keys[..]))
+    let genesis = Certificate::genesis(&*mock_committee(&keys[..]).load())
         .iter()
         .map(|x| x.digest())
         .collect::<BTreeSet<_>>();
@@ -118,7 +118,7 @@ async fn dead_node() {
     keys.sort(); // Ensure we don't remove one of the leaders.
     let _ = keys.pop().unwrap();
 
-    let genesis = Certificate::genesis(&mock_committee(&keys[..]))
+    let genesis = Certificate::genesis(&*mock_committee(&keys[..]).load())
         .iter()
         .map(|x| x.digest())
         .collect::<BTreeSet<_>>();
@@ -176,7 +176,7 @@ async fn not_enough_support() {
         .collect();
     keys.sort();
 
-    let genesis = Certificate::genesis(&mock_committee(&keys[..]))
+    let genesis = Certificate::genesis(&*mock_committee(&keys[..]).load())
         .iter()
         .map(|x| x.digest())
         .collect::<BTreeSet<_>>();
@@ -285,7 +285,7 @@ async fn missing_leader() {
         .collect();
     keys.sort();
 
-    let genesis = Certificate::genesis(&mock_committee(&keys[..]))
+    let genesis = Certificate::genesis(&*mock_committee(&keys[..]).load())
         .iter()
         .map(|x| x.digest())
         .collect::<BTreeSet<_>>();

--- a/executor/src/lib.rs
+++ b/executor/src/lib.rs
@@ -129,8 +129,8 @@ impl Executor {
 
         // Spawn the batch loader.
         let worker_addresses = committee
-            .authorities
             .load()
+            .authorities
             .iter()
             .find(|(x, _)| *x == &name)
             .map(|(_, authority)| authority)

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -130,7 +130,8 @@ impl Node {
         let (dag, network_model) = if !internal_consensus {
             debug!("Consensus is disabled: the primary will run w/o Tusk");
             let consensus_metrics = Arc::new(ConsensusMetrics::new(registry));
-            let (_handle, dag) = Dag::new(&committee, rx_new_certificates, consensus_metrics);
+            let (_handle, dag) =
+                Dag::new(&*committee.load(), rx_new_certificates, consensus_metrics);
             (Some(Arc::new(dag)), NetworkModel::Asynchronous)
         } else {
             Self::spawn_consensus(

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -9,6 +9,7 @@
 )]
 
 use anyhow::{Context, Result};
+use arc_swap::ArcSwap;
 use async_trait::async_trait;
 use clap::{crate_name, crate_version, App, AppSettings, ArgMatches, SubCommand};
 use config::{Committee, Import, Parameters, WorkerId};
@@ -126,9 +127,9 @@ async fn run(matches: &ArgMatches<'_>) -> Result<()> {
 
     // Read the committee and node's keypair from file.
     let keypair = Ed25519KeyPair::import(key_file).context("Failed to load the node's keypair")?;
-    let committee = Arc::new(
+    let committee = Arc::new(ArcSwap::from_pointee(
         Committee::import(committee_file).context("Failed to load the committee information")?,
-    );
+    ));
 
     // Load default parameters if none are specified.
     let parameters = match parameters_file {

--- a/primary/src/block_remover.rs
+++ b/primary/src/block_remover.rs
@@ -123,7 +123,7 @@ pub struct DeleteBatchMessage {
 ///     let (tx_delete_block_result, mut rx_delete_block_result) = channel(1);
 ///
 ///     let name = Ed25519PublicKey::default();
-///     let committee = Committee{ epoch: ArcSwap::new(Arc::new(0)), authorities: ArcSwap::from_pointee(BTreeMap::new()) };
+///     let committee = Committee{ epoch: 0, authorities: BTreeMap::new() };
 ///     let (_tx_reconfigure, rx_reconfigure) = watch::channel(Reconfigure::NewCommittee(committee.clone()));
 ///     let consensus_metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
 ///     // A dag with genesis for the committee

--- a/primary/src/block_synchronizer/tests/block_synchronizer_tests.rs
+++ b/primary/src/block_synchronizer/tests/block_synchronizer_tests.rs
@@ -42,7 +42,7 @@ async fn test_successful_headers_synchronization() {
     let (name, committee) = resolve_name_and_committee();
 
     let (_tx_reconfigure, rx_reconfigure) =
-        watch::channel(Reconfigure::NewCommittee((*committee).clone()));
+        watch::channel(Reconfigure::NewCommittee(committee.clone()));
     let (tx_commands, rx_commands) = channel(10);
     let (tx_certificate_responses, rx_certificate_responses) = channel(10);
     let (_, rx_payload_availability_responses) = channel(10);
@@ -74,7 +74,7 @@ async fn test_successful_headers_synchronization() {
     // AND create the synchronizer
     BlockSynchronizer::spawn(
         name.clone(),
-        (*committee).clone(),
+        committee.clone(),
         rx_reconfigure,
         rx_commands,
         rx_certificate_responses,
@@ -201,7 +201,7 @@ async fn test_successful_payload_synchronization() {
     let (name, committee) = resolve_name_and_committee();
 
     let (_tx_reconfigure, rx_reconfigure) =
-        watch::channel(Reconfigure::NewCommittee((*committee).clone()));
+        watch::channel(Reconfigure::NewCommittee(committee.clone()));
     let (tx_commands, rx_commands) = channel(10);
     let (_tx_certificate_responses, rx_certificate_responses) = channel(10);
     let (tx_payload_availability_responses, rx_payload_availability_responses) = channel(10);
@@ -233,7 +233,7 @@ async fn test_successful_payload_synchronization() {
     // AND create the synchronizer
     BlockSynchronizer::spawn(
         name.clone(),
-        (*committee).clone(),
+        committee.clone(),
         rx_reconfigure,
         rx_commands,
         rx_certificate_responses,
@@ -401,7 +401,7 @@ async fn test_multiple_overlapping_requests() {
     let (_, certificate_store, payload_store) = create_db_stores();
     let (name, committee) = resolve_name_and_committee();
 
-    let (_, rx_reconfigure) = watch::channel(Reconfigure::NewCommittee((*committee).clone()));
+    let (_, rx_reconfigure) = watch::channel(Reconfigure::NewCommittee(committee.clone()));
     let (_, rx_commands) = channel(10);
     let (_, rx_certificate_responses) = channel(10);
     let (_, rx_payload_availability_responses) = channel(10);
@@ -428,7 +428,7 @@ async fn test_multiple_overlapping_requests() {
 
     let mut block_synchronizer = BlockSynchronizer {
         name,
-        committee: (*committee).clone(),
+        committee: committee.clone(),
         rx_reconfigure,
         rx_commands,
         rx_certificate_responses,
@@ -521,7 +521,7 @@ async fn test_timeout_while_waiting_for_certificates() {
     let key = keys(None).pop().unwrap();
 
     let (_tx_reconfigure, rx_reconfigure) =
-        watch::channel(Reconfigure::NewCommittee((*committee).clone()));
+        watch::channel(Reconfigure::NewCommittee(committee.clone()));
     let (tx_commands, rx_commands) = channel(10);
     let (_, rx_certificate_responses) = channel(10);
     let (_, rx_payload_availability_responses) = channel(10);
@@ -542,7 +542,7 @@ async fn test_timeout_while_waiting_for_certificates() {
     // AND create the synchronizer
     BlockSynchronizer::spawn(
         name.clone(),
-        (*committee).clone(),
+        committee.clone(),
         rx_reconfigure,
         rx_commands,
         rx_certificate_responses,
@@ -611,14 +611,14 @@ async fn test_reply_with_certificates_already_in_storage() {
     let (name, committee) = resolve_name_and_committee();
     let key = keys(None).pop().unwrap();
 
-    let (_, rx_reconfigure) = watch::channel(Reconfigure::NewCommittee((*committee).clone()));
+    let (_, rx_reconfigure) = watch::channel(Reconfigure::NewCommittee(committee.clone()));
     let (_, rx_commands) = channel(10);
     let (_, rx_certificate_responses) = channel(10);
     let (_, rx_payload_availability_responses) = channel(10);
 
     let synchronizer = BlockSynchronizer {
         name,
-        committee: (*committee).clone(),
+        committee: committee.clone(),
         rx_reconfigure,
         rx_commands,
         rx_certificate_responses,
@@ -705,14 +705,14 @@ async fn test_reply_with_payload_already_in_storage() {
     let (name, committee) = resolve_name_and_committee();
     let key = keys(None).pop().unwrap();
 
-    let (_, rx_reconfigure) = watch::channel(Reconfigure::NewCommittee((*committee).clone()));
+    let (_, rx_reconfigure) = watch::channel(Reconfigure::NewCommittee(committee.clone()));
     let (_, rx_commands) = channel(10);
     let (_, rx_certificate_responses) = channel(10);
     let (_, rx_payload_availability_responses) = channel(10);
 
     let synchronizer = BlockSynchronizer {
         name,
-        committee: (*committee).clone(),
+        committee: committee.clone(),
         rx_reconfigure,
         rx_commands,
         rx_certificate_responses,
@@ -807,14 +807,14 @@ async fn test_reply_with_payload_already_in_storage_for_own_certificates() {
     // be used to create the headers.
     let name = key.public().clone();
 
-    let (_, rx_reconfigure) = watch::channel(Reconfigure::NewCommittee((*committee).clone()));
+    let (_, rx_reconfigure) = watch::channel(Reconfigure::NewCommittee(committee.clone()));
     let (_, rx_commands) = channel(10);
     let (_, rx_certificate_responses) = channel(10);
     let (_, rx_payload_availability_responses) = channel(10);
 
     let synchronizer = BlockSynchronizer {
         name: name.clone(),
-        committee: (*committee).clone(),
+        committee: committee.clone(),
         rx_reconfigure,
         rx_commands,
         rx_certificate_responses,

--- a/primary/src/block_waiter.rs
+++ b/primary/src/block_waiter.rs
@@ -155,7 +155,7 @@ type RequestKey = Vec<u8>;
 ///     let (tx_get_block, mut rx_get_block) = oneshot::channel();
 ///
 ///     let name = Ed25519PublicKey::default();
-///     let committee = Committee{ epoch: ArcSwap::new(Arc::new(0)), authorities: ArcSwap::from_pointee(BTreeMap::new()) };
+///     let committee = Committee{ epoch: 0, authorities: BTreeMap::new() };
 ///     let (_tx_reconfigure, rx_reconfigure) = watch::channel(Reconfigure::NewCommittee(committee.clone()));
 ///
 ///     // A dummy certificate

--- a/primary/src/grpc_server/proposer.rs
+++ b/primary/src/grpc_server/proposer.rs
@@ -34,7 +34,7 @@ impl<PublicKey: VerifyingKey> NarwhalProposer<PublicKey> {
             .map_err(|_| Status::invalid_argument("Invalid public key: couldn't parse"))?;
 
         // ensure provided key is part of the committee
-        if self.committee.primary(&key).is_err() {
+        if self.committee.load().primary(&key).is_err() {
             return Err(Status::invalid_argument(
                 "Invalid public key: unknown authority",
             ));

--- a/primary/src/state_handler.rs
+++ b/primary/src/state_handler.rs
@@ -69,6 +69,7 @@ impl<PublicKey: VerifyingKey> StateHandler<PublicKey> {
             // Trigger cleanup on the workers..
             let addresses = self
                 .committee
+                .load()
                 .our_workers(&self.name)
                 .expect("Our public key or worker id is not in the committee")
                 .into_iter()
@@ -80,7 +81,7 @@ impl<PublicKey: VerifyingKey> StateHandler<PublicKey> {
     }
 
     fn update_committee(&mut self, new_committee: Committee<PublicKey>) {
-        self.committee.update_committee(new_committee);
+        self.committee.swap(Arc::new(new_committee));
     }
 
     async fn run(&mut self) {

--- a/primary/src/tests/block_remover_tests.rs
+++ b/primary/src/tests/block_remover_tests.rs
@@ -47,7 +47,7 @@ async fn test_successful_blocks_delete() {
     // AND the necessary keys
     let (name, committee) = resolve_name_and_committee();
     let (_tx_reconfigure, rx_reconfigure) =
-        watch::channel(Reconfigure::NewCommittee((*committee).clone()));
+        watch::channel(Reconfigure::NewCommittee(committee.clone()));
     // AND a Dag with genesis populated
     let consensus_metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
     let dag = Arc::new(Dag::new(&committee, rx_consensus, consensus_metrics).1);
@@ -55,7 +55,7 @@ async fn test_successful_blocks_delete() {
 
     BlockRemover::spawn(
         name.clone(),
-        (*committee).clone(),
+        committee.clone(),
         certificate_store.clone(),
         header_store.clone(),
         payload_store.clone(),
@@ -219,7 +219,7 @@ async fn test_timeout() {
     // AND the necessary keys
     let (name, committee) = resolve_name_and_committee();
     let (_tx_reconfigure, rx_reconfigure) =
-        watch::channel(Reconfigure::NewCommittee((*committee).clone()));
+        watch::channel(Reconfigure::NewCommittee(committee.clone()));
     // AND a Dag with genesis populated
     let consensus_metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
     let dag = Arc::new(Dag::new(&committee, rx_consensus, consensus_metrics).1);
@@ -227,7 +227,7 @@ async fn test_timeout() {
 
     BlockRemover::spawn(
         name.clone(),
-        (*committee).clone(),
+        committee.clone(),
         certificate_store.clone(),
         header_store.clone(),
         payload_store.clone(),
@@ -355,7 +355,7 @@ async fn test_unlocking_pending_requests() {
 
     // AND the necessary keys
     let (name, committee) = resolve_name_and_committee();
-    let (_, rx_reconfigure) = watch::channel(Reconfigure::NewCommittee((*committee).clone()));
+    let (_, rx_reconfigure) = watch::channel(Reconfigure::NewCommittee(committee.clone()));
 
     // AND a Dag with genesis populated
     let consensus_metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
@@ -364,7 +364,7 @@ async fn test_unlocking_pending_requests() {
 
     let mut remover = BlockRemover {
         name,
-        committee: (*committee).clone(),
+        committee: committee.clone(),
         certificate_store: certificate_store.clone(),
         header_store: header_store.clone(),
         payload_store: payload_store.clone(),

--- a/primary/src/tests/block_waiter_tests.rs
+++ b/primary/src/tests/block_waiter_tests.rs
@@ -39,7 +39,7 @@ async fn test_successfully_retrieve_block() {
 
     // AND spawn a new blocks waiter
     let (_tx_reconfigure, rx_reconfigure) =
-        watch::channel(Reconfigure::NewCommittee((*committee).clone()));
+        watch::channel(Reconfigure::NewCommittee(committee.clone()));
     let (tx_commands, rx_commands) = channel(1);
     let (tx_get_block, rx_get_block) = oneshot::channel();
     let (tx_batch_messages, rx_batch_messages) = channel(10);
@@ -85,7 +85,7 @@ async fn test_successfully_retrieve_block() {
 
     BlockWaiter::spawn(
         name.clone(),
-        (*committee).clone(),
+        committee.clone(),
         rx_reconfigure,
         rx_commands,
         rx_batch_messages,
@@ -210,7 +210,7 @@ async fn test_successfully_retrieve_multiple_blocks() {
 
     // AND spawn a new blocks waiter
     let (_tx_reconfigure, rx_reconfigure) =
-        watch::channel(Reconfigure::NewCommittee((*committee).clone()));
+        watch::channel(Reconfigure::NewCommittee(committee.clone()));
     let (tx_commands, rx_commands) = channel(1);
     let (tx_get_blocks, rx_get_blocks) = oneshot::channel();
     let (tx_batch_messages, rx_batch_messages) = channel(10);
@@ -250,7 +250,7 @@ async fn test_successfully_retrieve_multiple_blocks() {
 
     BlockWaiter::spawn(
         name.clone(),
-        (*committee).clone(),
+        committee.clone(),
         rx_reconfigure,
         rx_commands,
         rx_batch_messages,
@@ -299,7 +299,7 @@ async fn test_one_pending_request_for_block_at_time() {
     let block_id = certificate.digest();
 
     // AND
-    let (_, rx_reconfigure) = watch::channel(Reconfigure::NewCommittee((*committee).clone()));
+    let (_, rx_reconfigure) = watch::channel(Reconfigure::NewCommittee(committee.clone()));
     let (_, rx_commands) = channel(1);
     let (_, rx_batch_messages) = channel(1);
 
@@ -324,7 +324,7 @@ async fn test_one_pending_request_for_block_at_time() {
 
     let mut waiter = BlockWaiter {
         name: name.clone(),
-        committee: (*committee).clone(),
+        committee: committee.clone(),
         rx_commands,
         pending_get_block: HashMap::new(),
         worker_network: PrimaryToWorkerNetwork::default(),
@@ -376,7 +376,7 @@ async fn test_unlocking_pending_get_block_request_after_response() {
     let block_id = certificate.digest();
 
     // AND spawn a new blocks waiter
-    let (_, rx_reconfigure) = watch::channel(Reconfigure::NewCommittee((*committee).clone()));
+    let (_, rx_reconfigure) = watch::channel(Reconfigure::NewCommittee(committee.clone()));
     let (_, rx_commands) = channel(1);
     let (_, rx_batch_messages) = channel(1);
 
@@ -396,7 +396,7 @@ async fn test_unlocking_pending_get_block_request_after_response() {
 
     let mut waiter = BlockWaiter {
         name: name.clone(),
-        committee: (*committee).clone(),
+        committee: committee.clone(),
         rx_commands,
         pending_get_block: HashMap::new(),
         worker_network: PrimaryToWorkerNetwork::default(),
@@ -445,7 +445,7 @@ async fn test_batch_timeout() {
 
     // AND spawn a new blocks waiter
     let (_tx_reconfigure, rx_reconfigure) =
-        watch::channel(Reconfigure::NewCommittee((*committee).clone()));
+        watch::channel(Reconfigure::NewCommittee(committee.clone()));
     let (tx_commands, rx_commands) = channel(1);
     let (tx_get_block, rx_get_block) = oneshot::channel();
     let (_, rx_batch_messages) = channel(10);
@@ -466,7 +466,7 @@ async fn test_batch_timeout() {
 
     BlockWaiter::spawn(
         name.clone(),
-        (*committee).clone(),
+        committee.clone(),
         rx_reconfigure,
         rx_commands,
         rx_batch_messages,
@@ -512,7 +512,7 @@ async fn test_return_error_when_certificate_is_missing() {
 
     // AND spawn a new blocks waiter
     let (_tx_reconfigure, rx_reconfigure) =
-        watch::channel(Reconfigure::NewCommittee((*committee).clone()));
+        watch::channel(Reconfigure::NewCommittee(committee.clone()));
     let (tx_commands, rx_commands) = channel(1);
     let (tx_get_block, rx_get_block) = oneshot::channel();
     let (_, rx_batch_messages) = channel(10);
@@ -527,7 +527,7 @@ async fn test_return_error_when_certificate_is_missing() {
 
     BlockWaiter::spawn(
         name.clone(),
-        (*committee).clone(),
+        committee.clone(),
         rx_reconfigure,
         rx_commands,
         rx_batch_messages,
@@ -573,7 +573,7 @@ async fn test_return_error_when_certificate_is_missing_when_get_blocks() {
 
     // AND spawn a new blocks waiter
     let (_tx_reconfigure, rx_reconfigure) =
-        watch::channel(Reconfigure::NewCommittee((*committee).clone()));
+        watch::channel(Reconfigure::NewCommittee(committee.clone()));
     let (tx_commands, rx_commands) = channel(1);
     let (tx_get_blocks, rx_get_blocks) = oneshot::channel();
     let (_, rx_batch_messages) = channel(10);
@@ -596,7 +596,7 @@ async fn test_return_error_when_certificate_is_missing_when_get_blocks() {
 
     BlockWaiter::spawn(
         name.clone(),
-        (*committee).clone(),
+        committee.clone(),
         rx_reconfigure,
         rx_commands,
         rx_batch_messages,

--- a/primary/src/tests/core_tests.rs
+++ b/primary/src/tests/core_tests.rs
@@ -23,7 +23,7 @@ async fn process_header() {
     let committee = committee(None);
 
     let (_tx_reconfigure, rx_reconfigure) =
-        watch::channel(Reconfigure::NewCommittee((*committee).clone()));
+        watch::channel(Reconfigure::NewCommittee(committee.clone()));
     let (tx_sync_headers, _rx_sync_headers) = channel(1);
     let (tx_sync_certificates, _rx_sync_certificates) = channel(1);
     let (tx_primary_messages, rx_primary_messages) = channel(1);
@@ -61,7 +61,7 @@ async fn process_header() {
     // Spawn the core.
     Core::spawn(
         name,
-        (*committee).clone(),
+        committee.clone(),
         header_store.clone(),
         certificates_store.clone(),
         synchronizer,
@@ -110,7 +110,7 @@ async fn process_header_missing_parent() {
     let name = kp.public().clone();
     let signature_service = SignatureService::new(kp);
 
-    let (_, rx_reconfigure) = watch::channel(Reconfigure::NewCommittee((*committee(None)).clone()));
+    let (_, rx_reconfigure) = watch::channel(Reconfigure::NewCommittee(committee(None)));
     let (tx_sync_headers, _rx_sync_headers) = channel(1);
     let (tx_sync_certificates, _rx_sync_certificates) = channel(1);
     let (tx_primary_messages, rx_primary_messages) = channel(1);
@@ -138,7 +138,7 @@ async fn process_header_missing_parent() {
     // Spawn the core.
     Core::spawn(
         name.clone(),
-        (*committee(None)).clone(),
+        committee(None),
         header_store.clone(),
         certificates_store.clone(),
         synchronizer,
@@ -183,7 +183,7 @@ async fn process_header_missing_payload() {
     let name = kp.public().clone();
     let signature_service = SignatureService::new(kp);
 
-    let (_, rx_reconfigure) = watch::channel(Reconfigure::NewCommittee((*committee(None)).clone()));
+    let (_, rx_reconfigure) = watch::channel(Reconfigure::NewCommittee(committee(None)));
     let (tx_sync_headers, _rx_sync_headers) = channel(1);
     let (tx_sync_certificates, _rx_sync_certificates) = channel(1);
     let (tx_primary_messages, rx_primary_messages) = channel(1);
@@ -211,7 +211,7 @@ async fn process_header_missing_payload() {
     // Spawn the core.
     Core::spawn(
         name.clone(),
-        (*committee(None)).clone(),
+        committee(None),
         header_store.clone(),
         certificates_store.clone(),
         synchronizer,
@@ -269,7 +269,7 @@ async fn process_votes() {
     let committee = committee(None);
 
     let (_tx_reconfigure, rx_reconfigure) =
-        watch::channel(Reconfigure::NewCommittee((*committee).clone()));
+        watch::channel(Reconfigure::NewCommittee(committee.clone()));
     let (tx_sync_headers, _rx_sync_headers) = channel(1);
     let (tx_sync_certificates, _rx_sync_certificates) = channel(1);
     let (tx_primary_messages, rx_primary_messages) = channel(1);
@@ -297,7 +297,7 @@ async fn process_votes() {
     // Spawn the core.
     Core::spawn(
         name.clone(),
-        (*committee).clone(),
+        committee.clone(),
         header_store.clone(),
         certificates_store.clone(),
         synchronizer,
@@ -360,7 +360,7 @@ async fn process_certificates() {
     let signature_service = SignatureService::new(kp);
 
     let (_tx_reconfigure, rx_reconfigure) =
-        watch::channel(Reconfigure::NewCommittee((*committee(None)).clone()));
+        watch::channel(Reconfigure::NewCommittee(committee(None)));
     let (tx_sync_headers, _rx_sync_headers) = channel(1);
     let (tx_sync_certificates, _rx_sync_certificates) = channel(1);
     let (tx_primary_messages, rx_primary_messages) = channel(3);
@@ -388,7 +388,7 @@ async fn process_certificates() {
     // Spawn the core.
     Core::spawn(
         name,
-        (*committee(None)).clone(),
+        committee(None),
         header_store.clone(),
         certificates_store.clone(),
         synchronizer,
@@ -455,7 +455,7 @@ async fn shutdown_core() {
     let committee = committee(None);
 
     let (tx_reconfigure, rx_reconfigure) =
-        watch::channel(Reconfigure::NewCommittee((*committee).clone()));
+        watch::channel(Reconfigure::NewCommittee(committee.clone()));
     let (tx_sync_headers, _rx_sync_headers) = channel(1);
     let (tx_sync_certificates, _rx_sync_certificates) = channel(1);
     let (_tx_primary_messages, rx_primary_messages) = channel(1);
@@ -481,7 +481,7 @@ async fn shutdown_core() {
     // Spawn the core.
     let handle = Core::spawn(
         name,
-        (*committee).clone(),
+        committee.clone(),
         header_store,
         certificates_store,
         synchronizer,
@@ -515,12 +515,12 @@ async fn reconfigure_core() {
 
     // Make the current and new committee.
     let committee = committee(None);
-    let new_committee = test_utils::committee(None);
-    new_committee.epoch.swap(Arc::new(1));
+    let mut new_committee = test_utils::committee(None);
+    new_committee.epoch = 1;
 
     // All the channels to interface with the core.
     let (tx_reconfigure, rx_reconfigure) =
-        watch::channel(Reconfigure::NewCommittee((*committee).clone()));
+        watch::channel(Reconfigure::NewCommittee(committee.clone()));
     let (tx_sync_headers, _rx_sync_headers) = channel(1);
     let (tx_sync_certificates, _rx_sync_certificates) = channel(1);
     let (tx_primary_messages, rx_primary_messages) = channel(1);
@@ -557,7 +557,7 @@ async fn reconfigure_core() {
     // Spawn the core.
     Core::spawn(
         name,
-        (*committee).clone(),
+        committee.clone(),
         header_store.clone(),
         certificates_store.clone(),
         synchronizer,
@@ -575,7 +575,7 @@ async fn reconfigure_core() {
     );
 
     // Change committee
-    let message = Reconfigure::NewCommittee((*new_committee).clone());
+    let message = Reconfigure::NewCommittee(new_committee.clone());
     tx_reconfigure.send(message).unwrap();
 
     // Send a header to the core.

--- a/primary/src/tests/header_waiter_tests.rs
+++ b/primary/src/tests/header_waiter_tests.rs
@@ -26,14 +26,14 @@ async fn successfully_synchronize_batches() {
     let consensus_round = Arc::new(AtomicU64::new(0));
     let gc_depth: Round = 1;
     let (_tx_reconfigure, rx_reconfigure) =
-        watch::channel(Reconfigure::NewCommittee((*committee).clone()));
+        watch::channel(Reconfigure::NewCommittee(committee.clone()));
     let (tx_synchronizer, rx_synchronizer) = channel(10);
     let (tx_core, mut rx_core) = channel(10);
     let metrics = Arc::new(PrimaryMetrics::new(&Registry::new()));
 
     HeaderWaiter::spawn(
         name.clone(),
-        (*committee).clone(),
+        committee.clone(),
         certificate_store,
         payload_store.clone(),
         consensus_round,

--- a/primary/src/tests/helper_tests.rs
+++ b/primary/src/tests/helper_tests.rs
@@ -34,13 +34,13 @@ async fn test_process_certificates_stream_mode() {
     let key = keys(None).pop().unwrap();
     let (name, committee) = resolve_name_and_committee();
     let (_tx_reconfigure, rx_reconfigure) =
-        watch::channel(Reconfigure::NewCommittee((*committee).clone()));
+        watch::channel(Reconfigure::NewCommittee(test_utils::committee(None)));
     let (tx_primaries, rx_primaries) = channel(10);
 
     // AND a helper
     Helper::spawn(
         name.clone(),
-        (*committee).clone(),
+        committee.clone(),
         certificate_store.clone(),
         payload_store.clone(),
         rx_reconfigure,
@@ -108,13 +108,13 @@ async fn test_process_certificates_batch_mode() {
     let key = keys(None).pop().unwrap();
     let (name, committee) = resolve_name_and_committee();
     let (_tx_reconfigure, rx_reconfigure) =
-        watch::channel(Reconfigure::NewCommittee((*committee).clone()));
+        watch::channel(Reconfigure::NewCommittee(test_utils::committee(None)));
     let (tx_primaries, rx_primaries) = channel(10);
 
     // AND a helper
     Helper::spawn(
         name.clone(),
-        (*committee).clone(),
+        committee.clone(),
         certificate_store.clone(),
         payload_store.clone(),
         rx_reconfigure,
@@ -203,13 +203,13 @@ async fn test_process_payload_availability_success() {
     let key = keys(None).pop().unwrap();
     let (name, committee) = resolve_name_and_committee();
     let (_tx_reconfigure, rx_reconfigure) =
-        watch::channel(Reconfigure::NewCommittee((*committee).clone()));
+        watch::channel(Reconfigure::NewCommittee(test_utils::committee(None)));
     let (tx_primaries, rx_primaries) = channel(10);
 
     // AND a helper
     Helper::spawn(
         name.clone(),
-        (*committee).clone(),
+        committee.clone(),
         certificate_store.clone(),
         payload_store.clone(),
         rx_reconfigure,
@@ -318,13 +318,13 @@ async fn test_process_payload_availability_when_failures() {
     let key = keys(None).pop().unwrap();
     let (name, committee) = resolve_name_and_committee();
     let (_tx_reconfigure, rx_reconfigure) =
-        watch::channel(Reconfigure::NewCommittee((*committee).clone()));
+        watch::channel(Reconfigure::NewCommittee(test_utils::committee(None)));
     let (tx_primaries, rx_primaries) = channel(10);
 
     // AND a helper
     Helper::spawn(
         name.clone(),
-        (*committee).clone(),
+        committee.clone(),
         certificate_store.clone(),
         payload_store.clone(),
         rx_reconfigure,

--- a/primary/src/tests/proposer_tests.rs
+++ b/primary/src/tests/proposer_tests.rs
@@ -14,7 +14,7 @@ async fn propose_empty() {
     let signature_service = SignatureService::new(kp);
 
     let (_tx_reconfigure, rx_reconfigure) =
-        watch::channel(Reconfigure::NewCommittee((*committee(None)).clone()));
+        watch::channel(Reconfigure::NewCommittee(committee(None)));
     let (_tx_parents, rx_parents) = channel(1);
     let (_tx_our_digests, rx_our_digests) = channel(1);
     let (tx_headers, mut rx_headers) = channel(1);
@@ -24,7 +24,7 @@ async fn propose_empty() {
     // Spawn the proposer.
     Proposer::spawn(
         name,
-        (*committee(None)).clone(),
+        committee(None),
         signature_service,
         /* header_size */ 1_000,
         /* max_header_delay */ Duration::from_millis(20),
@@ -50,7 +50,7 @@ async fn propose_payload() {
     let signature_service = SignatureService::new(kp);
 
     let (_tx_reconfigure, rx_reconfigure) =
-        watch::channel(Reconfigure::NewCommittee((*committee(None)).clone()));
+        watch::channel(Reconfigure::NewCommittee(committee(None)));
     let (_tx_parents, rx_parents) = channel(1);
     let (tx_our_digests, rx_our_digests) = channel(1);
     let (tx_headers, mut rx_headers) = channel(1);
@@ -60,7 +60,7 @@ async fn propose_payload() {
     // Spawn the proposer.
     Proposer::spawn(
         name.clone(),
-        (*committee(None)).clone(),
+        committee(None),
         signature_service,
         /* header_size */ 32,
         /* max_header_delay */

--- a/primary/tests/integration_tests_configuration_api.rs
+++ b/primary/tests/integration_tests_configuration_api.rs
@@ -1,3 +1,4 @@
+use arc_swap::ArcSwap;
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use config::Parameters;
@@ -36,7 +37,7 @@ async fn test_new_epoch() {
     Primary::spawn(
         name.clone(),
         signer,
-        committee.clone(),
+        Arc::new(ArcSwap::from_pointee(committee.clone())),
         parameters.clone(),
         store.header_store.clone(),
         store.certificate_store.clone(),
@@ -108,7 +109,7 @@ async fn test_new_network_info() {
     Primary::spawn(
         name.clone(),
         signer,
-        committee.clone(),
+        Arc::new(ArcSwap::from_pointee(committee.clone())),
         parameters.clone(),
         store.header_store.clone(),
         store.certificate_store.clone(),
@@ -130,7 +131,7 @@ async fn test_new_network_info() {
     // Test gRPC server with client call
     let mut client = connect_to_configuration_client(parameters.clone());
 
-    let public_keys: Vec<_> = committee.authorities.load().keys().cloned().collect();
+    let public_keys: Vec<_> = committee.authorities.keys().cloned().collect();
 
     let mut validators = Vec::new();
     for public_key in public_keys.iter() {

--- a/primary/tests/integration_tests_proposer_api.rs
+++ b/primary/tests/integration_tests_proposer_api.rs
@@ -76,17 +76,12 @@ async fn test_rounds_errors() {
     // AND create a committee passed exclusively to the DAG that does not include the name public key
     // In this way, the genesis certificate is not run for that authority and is absent when we try to fetch it
     let no_name_committee = config::Committee {
-        epoch: ArcSwap::new(Arc::new(Epoch::default())),
-        authorities: {
-            let no_name_authorities = committee
-                .authorities
-                .load()
-                .iter()
-                .filter_map(|(pk, a)| (*pk != name).then_some((pk.clone(), a.clone())))
-                .collect::<BTreeMap<_, _>>();
-
-            arc_swap::ArcSwap::from_pointee(no_name_authorities)
-        },
+        epoch: Epoch::default(),
+        authorities: committee
+            .authorities
+            .iter()
+            .filter_map(|(pk, a)| (*pk != name).then_some((pk.clone(), a.clone())))
+            .collect::<BTreeMap<_, _>>(),
     };
 
     let consensus_metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
@@ -94,7 +89,7 @@ async fn test_rounds_errors() {
     Primary::spawn(
         name.clone(),
         keypair,
-        committee.clone(),
+        Arc::new(ArcSwap::from_pointee(committee.clone())),
         parameters.clone(),
         store_primary.header_store,
         store_primary.certificate_store,
@@ -165,7 +160,7 @@ async fn test_rounds_return_successful_response() {
     Primary::spawn(
         name.clone(),
         keypair,
-        committee.clone(),
+        Arc::new(ArcSwap::from_pointee(committee.clone())),
         parameters.clone(),
         store_primary.header_store,
         store_primary.certificate_store,
@@ -303,7 +298,7 @@ async fn test_node_read_causal_signed_certificates() {
     Primary::spawn(
         name_1.clone(),
         keypair_1,
-        committee.clone(),
+        Arc::new(ArcSwap::from_pointee(committee.clone())),
         primary_1_parameters.clone(),
         primary_store_1.header_store.clone(),
         primary_store_1.certificate_store.clone(),
@@ -331,7 +326,7 @@ async fn test_node_read_causal_signed_certificates() {
     Primary::spawn(
         name_2.clone(),
         keypair_2,
-        committee.clone(),
+        Arc::new(ArcSwap::from_pointee(committee.clone())),
         primary_2_parameters.clone(),
         primary_store_2.header_store,
         primary_store_2.certificate_store,

--- a/primary/tests/integration_tests_validator_api.rs
+++ b/primary/tests/integration_tests_validator_api.rs
@@ -1,3 +1,4 @@
+use arc_swap::ArcSwap;
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use config::{Parameters, WorkerId};
@@ -108,7 +109,7 @@ async fn test_get_collections() {
     Primary::spawn(
         name.clone(),
         signer,
-        committee.clone(),
+        Arc::new(ArcSwap::from_pointee(committee.clone())),
         parameters.clone(),
         store.header_store.clone(),
         store.certificate_store.clone(),
@@ -132,7 +133,7 @@ async fn test_get_collections() {
     Worker::spawn(
         name.clone(),
         worker_id,
-        committee.clone(),
+        Arc::new(ArcSwap::from_pointee(committee.clone())),
         parameters.clone(),
         store.batch_store.clone(),
         metrics,
@@ -284,7 +285,7 @@ async fn test_remove_collections() {
     Primary::spawn(
         name.clone(),
         signer,
-        committee.clone(),
+        Arc::new(ArcSwap::from_pointee(committee.clone())),
         parameters.clone(),
         store.header_store.clone(),
         store.certificate_store.clone(),
@@ -333,7 +334,7 @@ async fn test_remove_collections() {
     Worker::spawn(
         name.clone(),
         worker_id,
-        committee.clone(),
+        Arc::new(ArcSwap::from_pointee(committee.clone())),
         parameters.clone(),
         store.batch_store.clone(),
         metrics,
@@ -488,7 +489,7 @@ async fn test_read_causal_signed_certificates() {
     Primary::spawn(
         name_1.clone(),
         keypair_1,
-        committee.clone(),
+        Arc::new(ArcSwap::from_pointee(committee.clone())),
         primary_1_parameters.clone(),
         primary_store_1.header_store.clone(),
         primary_store_1.certificate_store.clone(),
@@ -516,7 +517,7 @@ async fn test_read_causal_signed_certificates() {
     Primary::spawn(
         name_2.clone(),
         keypair_2,
-        committee.clone(),
+        Arc::new(ArcSwap::from_pointee(committee.clone())),
         primary_2_parameters.clone(),
         primary_store_2.header_store,
         primary_store_2.certificate_store,
@@ -635,7 +636,6 @@ async fn test_read_causal_unsigned_certificates() {
         &genesis,
         &committee
             .authorities
-            .load()
             .keys()
             .cloned()
             .collect::<Vec<Ed25519PublicKey>>(),
@@ -680,7 +680,7 @@ async fn test_read_causal_unsigned_certificates() {
     Primary::spawn(
         name_1.clone(),
         keypair_1,
-        committee.clone(),
+        Arc::new(ArcSwap::from_pointee(committee.clone())),
         primary_1_parameters.clone(),
         primary_store_1.header_store.clone(),
         primary_store_1.certificate_store.clone(),
@@ -701,7 +701,7 @@ async fn test_read_causal_unsigned_certificates() {
     Primary::spawn(
         name_2.clone(),
         keypair_2,
-        committee.clone(),
+        Arc::new(ArcSwap::from_pointee(committee.clone())),
         primary_2_parameters.clone(),
         primary_store_2.header_store,
         primary_store_2.certificate_store,
@@ -838,7 +838,7 @@ async fn test_get_collections_with_missing_certificates() {
     Primary::spawn(
         name_1.clone(),
         keypair_1,
-        committee.clone(),
+        Arc::new(ArcSwap::from_pointee(committee.clone())),
         parameters.clone(),
         store_primary_1.header_store,
         store_primary_1.certificate_store,
@@ -862,7 +862,7 @@ async fn test_get_collections_with_missing_certificates() {
     Worker::spawn(
         name_1,
         worker_id,
-        committee.clone(),
+        Arc::new(ArcSwap::from_pointee(committee.clone())),
         parameters.clone(),
         store_primary_1.batch_store,
         metrics_1,
@@ -875,7 +875,7 @@ async fn test_get_collections_with_missing_certificates() {
     Primary::spawn(
         name_2.clone(),
         keypair_2,
-        committee.clone(),
+        Arc::new(ArcSwap::from_pointee(committee.clone())),
         parameters.clone(),
         store_primary_2.header_store,
         store_primary_2.certificate_store,
@@ -897,7 +897,7 @@ async fn test_get_collections_with_missing_certificates() {
     Worker::spawn(
         name_2,
         worker_id,
-        committee.clone(),
+        Arc::new(ArcSwap::from_pointee(committee.clone())),
         parameters.clone(),
         store_primary_2.batch_store,
         metrics_2,

--- a/types/src/primary.rs
+++ b/types/src/primary.rs
@@ -375,7 +375,6 @@ impl<PublicKey: VerifyingKey> Certificate<PublicKey> {
     pub fn genesis(committee: &Committee<PublicKey>) -> Vec<Self> {
         committee
             .authorities
-            .load()
             .keys()
             .map(|name| Self {
                 header: Header {

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -34,6 +34,7 @@ prometheus = "0.13.1"
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 [dev-dependencies]
+arc-swap = { version = "1.5.0", features = ["serde"] }
 rand = "0.7.3"
 tempfile = "3.3.0"
 test_utils = { path = "../test_utils" }

--- a/worker/src/helper.rs
+++ b/worker/src/helper.rs
@@ -62,7 +62,7 @@ impl<PublicKey: VerifyingKey> Helper<PublicKey> {
                 // Handle requests from other workers.
                 Some((digests, origin)) = self.rx_worker_request.recv() => {
                     // get the requestors address.
-                    let address = match self.committee.worker(&origin, &self.id) {
+                    let address = match self.committee.load().worker(&origin, &self.id) {
                         Ok(x) => x.worker_to_worker,
                         Err(e) => {
                             warn!("Unexpected batch request: {e}");

--- a/worker/src/quorum_waiter.rs
+++ b/worker/src/quorum_waiter.rs
@@ -67,7 +67,7 @@ impl<PublicKey: VerifyingKey> QuorumWaiter<PublicKey> {
             let mut wait_for_quorum: FuturesUnordered<_> = handlers
                 .into_iter()
                 .map(|(name, handler)| {
-                    let stake = self.committee.stake(&name);
+                    let stake = self.committee.load().stake(&name);
                     Self::waiter(handler, stake)
                 })
                 .collect();
@@ -78,7 +78,7 @@ impl<PublicKey: VerifyingKey> QuorumWaiter<PublicKey> {
             let mut total_stake = self.stake;
             while let Some(stake) = wait_for_quorum.next().await {
                 total_stake += stake;
-                if total_stake >= self.committee.quorum_threshold() {
+                if total_stake >= self.committee.load().quorum_threshold() {
                     self.tx_batch
                         .send(batch)
                         .await

--- a/worker/src/synchronizer.rs
+++ b/worker/src/synchronizer.rs
@@ -160,7 +160,7 @@ impl<PublicKey: VerifyingKey> Synchronizer<PublicKey> {
 
                         // Send sync request to a single node. If this fails, we will send it
                         // to other nodes when a timer times out.
-                        let address = match self.committee.worker(&target, &self.id) {
+                        let address = match self.committee.load().worker(&target, &self.id) {
                             Ok(address) => address.worker_to_worker,
                             Err(e) => {
                                 error!("The primary asked us to sync with an unknown node: {e}");
@@ -228,7 +228,7 @@ impl<PublicKey: VerifyingKey> Synchronizer<PublicKey> {
                         }
                     }
                     if !retry.is_empty() {
-                        let addresses = self.committee
+                        let addresses = self.committee.load()
                             .others_workers(&self.name, &self.id)
                             .into_iter()
                             .map(|(_, address)| address.worker_to_worker)
@@ -244,7 +244,7 @@ impl<PublicKey: VerifyingKey> Synchronizer<PublicKey> {
 
                     // Report list of pending elements
                     self.metrics.pending_elements_worker_synchronizer
-                    .with_label_values(&[&self.committee.epoch.to_string()])
+                    .with_label_values(&[&self.committee.load().epoch.to_string()])
                     .set(self.pending.len() as i64);
                 },
             }

--- a/worker/src/tests/helper_tests.rs
+++ b/worker/src/tests/helper_tests.rs
@@ -2,7 +2,9 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use super::*;
+use arc_swap::ArcSwap;
 use crypto::traits::KeyPair;
+use std::sync::Arc;
 use store::rocks;
 use test_utils::{
     batch, committee, digest_batch, keys, serialize_batch_message, temp_dir,
@@ -37,7 +39,7 @@ async fn worker_batch_reply() {
     // Spawn an `Helper` instance.
     Helper::spawn(
         id,
-        committee.clone(),
+        Arc::new(ArcSwap::from_pointee(committee.clone())),
         store,
         rx_worker_request,
         rx_client_request,
@@ -81,7 +83,7 @@ async fn client_batch_reply() {
     // Spawn an `Helper` instance.
     Helper::spawn(
         id,
-        committee.clone(),
+        Arc::new(ArcSwap::from_pointee(committee.clone())),
         store,
         rx_worker_request,
         rx_client_request,

--- a/worker/src/tests/quorum_waiter_tests.rs
+++ b/worker/src/tests/quorum_waiter_tests.rs
@@ -3,9 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 use super::*;
 use crate::worker::WorkerMessage;
+use arc_swap::ArcSwap;
 use bytes::Bytes;
 use crypto::{ed25519::Ed25519PublicKey, traits::KeyPair};
 use network::WorkerNetwork;
+use std::sync::Arc;
 use test_utils::{batch, committee, keys, WorkerToWorkerMockServer};
 use tokio::sync::mpsc::channel;
 
@@ -17,7 +19,12 @@ async fn wait_for_quorum() {
     let committee = committee(None);
 
     // Spawn a `QuorumWaiter` instance.
-    QuorumWaiter::spawn(committee.clone(), /* stake */ 1, rx_message, tx_batch);
+    QuorumWaiter::spawn(
+        Arc::new(ArcSwap::from_pointee(committee.clone())),
+        /* stake */ 1,
+        rx_message,
+        tx_batch,
+    );
 
     // Make a batch.
     let message = WorkerMessage::<Ed25519PublicKey>::Batch(batch());

--- a/worker/src/tests/synchronizer_tests.rs
+++ b/worker/src/tests/synchronizer_tests.rs
@@ -2,6 +2,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use super::*;
+use arc_swap::ArcSwap;
 use crypto::{ed25519::Ed25519PublicKey, traits::KeyPair};
 use prometheus::Registry;
 use test_utils::{
@@ -30,7 +31,7 @@ async fn synchronize() {
     Synchronizer::spawn(
         name.clone(),
         id,
-        committee.clone(),
+        Arc::new(ArcSwap::from_pointee(committee.clone())),
         store.clone(),
         /* gc_depth */ 50, // Not used in this test.
         /* sync_retry_delay */
@@ -76,7 +77,7 @@ async fn test_successful_request_batch() {
     Synchronizer::spawn(
         name.clone(),
         id,
-        committee.clone(),
+        Arc::new(ArcSwap::from_pointee(committee.clone())),
         store.clone(),
         /* gc_depth */ 50, // Not used in this test.
         /* sync_retry_delay */
@@ -134,7 +135,7 @@ async fn test_request_batch_not_found() {
     Synchronizer::spawn(
         name.clone(),
         id,
-        committee.clone(),
+        Arc::new(ArcSwap::from_pointee(committee.clone())),
         store.clone(),
         /* gc_depth */ 50, // Not used in this test.
         /* sync_retry_delay */
@@ -191,7 +192,7 @@ async fn test_successful_batch_delete() {
     Synchronizer::spawn(
         name.clone(),
         id,
-        committee.clone(),
+        Arc::new(ArcSwap::from_pointee(committee.clone())),
         store.clone(),
         /* gc_depth */ 50, // Not used in this test.
         /* sync_retry_delay */

--- a/worker/src/tests/worker_tests.rs
+++ b/worker/src/tests/worker_tests.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use super::*;
 
+use arc_swap::ArcSwap;
 use crypto::traits::KeyPair;
 use futures::StreamExt;
 use primary::WorkerPrimaryMessage;
@@ -41,7 +42,7 @@ async fn handle_clients_transactions() {
     Worker::spawn(
         name.clone(),
         id,
-        committee.clone(),
+        Arc::new(ArcSwap::from_pointee(committee.clone())),
         parameters,
         store,
         metrics,
@@ -117,7 +118,7 @@ async fn handle_client_batch_request() {
     Worker::spawn(
         name.clone(),
         id,
-        committee.clone(),
+        Arc::new(ArcSwap::from_pointee(committee.clone())),
         parameters,
         store,
         metrics,

--- a/worker/src/worker.rs
+++ b/worker/src/worker.rs
@@ -82,6 +82,7 @@ impl<PublicKey: VerifyingKey> Worker<PublicKey> {
         let handle = PrimaryConnector::spawn(
             worker
                 .committee
+                .load()
                 .primary(&worker.name)
                 .expect("Our public key is not in the committee")
                 .worker_to_primary,
@@ -94,6 +95,7 @@ impl<PublicKey: VerifyingKey> Worker<PublicKey> {
             id,
             worker
                 .committee
+                .load()
                 .worker(&worker.name, &worker.id)
                 .expect("Our public key or worker id is not in the committee")
                 .transactions
@@ -117,6 +119,7 @@ impl<PublicKey: VerifyingKey> Worker<PublicKey> {
         // Receive incoming messages from our primary.
         let address = self
             .committee
+            .load()
             .worker(&self.name, &self.id)
             .expect("Our public key or worker id is not in the committee")
             .primary_to_worker;
@@ -160,6 +163,7 @@ impl<PublicKey: VerifyingKey> Worker<PublicKey> {
         // We first receive clients' transactions from the network.
         let address = self
             .committee
+            .load()
             .worker(&self.name, &self.id)
             .expect("Our public key or worker id is not in the committee")
             .transactions;
@@ -178,6 +182,7 @@ impl<PublicKey: VerifyingKey> Worker<PublicKey> {
             /* tx_message */ tx_quorum_waiter,
             /* workers_addresses */
             self.committee
+                .load()
                 .others_workers(&self.name, &self.id)
                 .into_iter()
                 .map(|(name, addresses)| (name, addresses.worker_to_worker))
@@ -188,7 +193,7 @@ impl<PublicKey: VerifyingKey> Worker<PublicKey> {
         // the batch to the `Processor`.
         let quorum_waiter_handle = QuorumWaiter::spawn(
             self.committee.clone(),
-            /* stake */ self.committee.stake(&self.name),
+            /* stake */ self.committee.load().stake(&self.name),
             /* rx_message */ rx_quorum_waiter,
             /* tx_batch */ tx_processor,
         );
@@ -223,6 +228,7 @@ impl<PublicKey: VerifyingKey> Worker<PublicKey> {
         // Receive incoming messages from other workers.
         let address = self
             .committee
+            .load()
             .worker(&self.name, &self.id)
             .expect("Our public key or worker id is not in the committee")
             .worker_to_worker;


### PR DESCRIPTION
## History
The intent of the `ArcSwap` instance included in #279 was actually to introduce the `SharedCommittee` type: all components that take a `SharedCommittee` actually share the same committee reference, which has interior mutability thanks to the `ArcSwap` (see [here](https://github.com/vorner/arc-swap/pull/33/files) for more on `ArcSwap`'s cloning behavior). The intended consequence is that one modification in one components changes the `SharedCommittee` reference for all components, hopefully maintaining the invariant that all components agree on the latest committee.

Then #382 came along, which implemented epochs by adding another `ArcSwap` for it, complicating the footprint of the concurrency containers in the `Commitee` data structures.

## This

Moves the concurrency data structures to the outer layer of `Committee` by defining :
```
type SharedCommittee<Publickey> = Arc<ArcSwap<Committee<PublicKey>>
```
This:
- resolves #421,
- allows us to work on `Committee` directly in single-committee contexts where we do not care about the existence of several committees (e.g. config module's tests),
- ports the helper functions to produce `Committee` rather than `SharedCommittee`, since they often themselves operate in this concurrency-free context (starting one component at a time): the concurrency is used in tests in an ad-hoc manner (mostly integration tests).

## Future work
Depending on whether we actually want to make use of the `ArcSwap` concurrent mutation affordances or rely on `watch` logic exclusively, we may simplify this in the direction of removing the `ArcSwap`, or simplifying the `watch` logic to use a lighter `changed` detection.