### PR TITLE
[synchronizer] make synchronizer use DAG for checking parent history

### DIFF
--- a/consensus/src/dag.rs
+++ b/consensus/src/dag.rs
@@ -75,6 +75,7 @@ enum DagCommand<PublicKey: VerifyingKey> {
         oneshot::Sender<Result<(), ValidatorDagError<PublicKey>>>,
     ),
     Contains(CertificateDigest, oneshot::Sender<bool>),
+    HasEverContained(CertificateDigest, oneshot::Sender<bool>),
     Rounds(
         PublicKey,
         oneshot::Sender<Result<std::ops::RangeInclusive<Round>, ValidatorDagError<PublicKey>>>,
@@ -131,6 +132,9 @@ impl<PublicKey: VerifyingKey> InnerDag<PublicKey> {
                         DagCommand::Contains(dig, sender)=> {
                             let _ = sender.send(self.contains(dig));
                         },
+                        DagCommand::HasEverContained(dig, sender) => {
+                            let _ = sender.send(self.has_ever_contained(dig));
+                        }
                         DagCommand::Rounds(pk, sender) => {
                             let _ = sender.send(self.rounds(pk));
                         },
@@ -177,6 +181,14 @@ impl<PublicKey: VerifyingKey> InnerDag<PublicKey> {
     /// For the purposes of this memory-conscious graph, this is just "contains" semantics.
     fn contains(&self, digest: CertificateDigest) -> bool {
         self.dag.contains_live(digest)
+    }
+
+    /// Returns whether the dag has ever contained a node with the provided digest. The method will return
+    /// true either when the node is live (uncompressed) or has been already compressed as still exists
+    /// as weak reference.
+    #[instrument(level = "debug", skip_all, fields(digest = ?digest))]
+    fn has_ever_contained(&self, digest: CertificateDigest) -> bool {
+        self.dag.contains(digest)
     }
 
     /// Returns the oldest and newest rounds for which a validator has (live) certificates in the DAG
@@ -366,6 +378,23 @@ impl<PublicKey: VerifyingKey> Dag<PublicKey> {
         receiver
             .await
             .expect("Failed to receive reply to Contains command from store")
+    }
+
+    /// Returns whether the dag has ever contained a node with the provided digest. The method will return
+    /// true either when the node is live (uncompressed) or has been already compressed as still exists
+    /// as weak reference.
+    pub async fn has_ever_contained(&self, digest: CertificateDigest) -> bool {
+        let (sender, receiver) = oneshot::channel();
+        if let Err(e) = self
+            .tx_commands
+            .send(DagCommand::HasEverContained(digest, sender))
+            .await
+        {
+            panic!("Failed to send HasEverContained command to store: {e}");
+        }
+        receiver
+            .await
+            .expect("Failed to receive reply to HasEverContained command from store")
     }
 
     /// Returns the oldest and newest rounds for which a validator has (live) certificates in the DAG

--- a/consensus/src/tests/dag_tests.rs
+++ b/consensus/src/tests/dag_tests.rs
@@ -361,4 +361,10 @@ async fn dag_insert_and_remove_reads() {
     for authority in keys {
         assert_eq!(13, dag.node_read_causal(authority, 4).await.unwrap().len());
     }
+
+    // Ensure that the dag will reply true when we check whether we have seen
+    // all the removed certificates.
+    for digest in genesis {
+        assert!(dag.has_ever_contained(digest).await);
+    }
 }

--- a/primary/src/primary.rs
+++ b/primary/src/primary.rs
@@ -202,6 +202,7 @@ impl Primary {
             payload_store.clone(),
             /* tx_header_waiter */ tx_sync_headers,
             /* tx_certificate_waiter */ tx_sync_certificates,
+            dag.clone(),
         );
 
         // The `SignatureService` is used to require signatures on specific digests.

--- a/primary/src/tests/core_tests.rs
+++ b/primary/src/tests/core_tests.rs
@@ -54,6 +54,7 @@ async fn process_header() {
         payload_store,
         /* tx_header_waiter */ tx_sync_headers,
         /* tx_certificate_waiter */ tx_sync_certificates,
+        None,
     );
 
     let metrics = Arc::new(PrimaryMetrics::new(&Registry::new()));
@@ -131,6 +132,7 @@ async fn process_header_missing_parent() {
         payload_store.clone(),
         /* tx_header_waiter */ tx_sync_headers,
         /* tx_certificate_waiter */ tx_sync_certificates,
+        None,
     );
 
     let metrics = Arc::new(PrimaryMetrics::new(&Registry::new()));
@@ -204,6 +206,7 @@ async fn process_header_missing_payload() {
         payload_store.clone(),
         /* tx_header_waiter */ tx_sync_headers,
         /* tx_certificate_waiter */ tx_sync_certificates,
+        None,
     );
 
     let metrics = Arc::new(PrimaryMetrics::new(&Registry::new()));
@@ -290,6 +293,7 @@ async fn process_votes() {
         payload_store.clone(),
         /* tx_header_waiter */ tx_sync_headers,
         /* tx_certificate_waiter */ tx_sync_certificates,
+        None,
     );
 
     let metrics = Arc::new(PrimaryMetrics::new(&Registry::new()));
@@ -381,6 +385,7 @@ async fn process_certificates() {
         payload_store.clone(),
         /* tx_header_waiter */ tx_sync_headers,
         /* tx_certificate_waiter */ tx_sync_certificates,
+        None,
     );
 
     let metrics = Arc::new(PrimaryMetrics::new(&Registry::new()));
@@ -476,6 +481,7 @@ async fn shutdown_core() {
         payload_store,
         /* tx_header_waiter */ tx_sync_headers,
         /* tx_certificate_waiter */ tx_sync_certificates,
+        None,
     );
 
     // Spawn the core.
@@ -552,6 +558,7 @@ async fn reconfigure_core() {
         payload_store,
         /* tx_header_waiter */ tx_sync_headers,
         /* tx_certificate_waiter */ tx_sync_certificates,
+        None,
     );
 
     // Spawn the core.

--- a/primary/src/tests/synchronizer_tests.rs
+++ b/primary/src/tests/synchronizer_tests.rs
@@ -1,0 +1,164 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use crate::{common::create_db_stores, synchronizer::Synchronizer};
+use consensus::{dag::Dag, metrics::ConsensusMetrics};
+use crypto::{traits::KeyPair, Hash};
+use prometheus::Registry;
+use std::{collections::BTreeSet, sync::Arc};
+use test_utils::{committee, keys, make_optimal_signed_certificates};
+use tokio::sync::mpsc::channel;
+use types::Certificate;
+
+#[tokio::test]
+async fn deliver_certificate_using_dag() {
+    let mut keys = keys(None);
+    let kp = keys.pop().unwrap();
+    let name = kp.public().clone();
+
+    // Make the current committee.
+    let committee = committee(None);
+
+    let (_, certificates_store, payload_store) = create_db_stores();
+    let (tx_header_waiter, _rx_header_waiter) = channel(1);
+    let (tx_certificate_waiter, _rx_certificate_waiter) = channel(1);
+    let (_tx_consensus, rx_consensus) = channel(1);
+
+    let consensus_metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
+    let dag = Arc::new(Dag::new(&committee, rx_consensus, consensus_metrics).1);
+
+    let mut synchronizer = Synchronizer::new(
+        name,
+        &committee,
+        certificates_store,
+        payload_store,
+        tx_header_waiter,
+        tx_certificate_waiter,
+        Some(dag.clone()),
+    );
+
+    // create some certificates in a complete DAG form
+    let genesis_certs = Certificate::genesis(&committee);
+    let genesis = genesis_certs
+        .iter()
+        .map(|x| x.digest())
+        .collect::<BTreeSet<_>>();
+
+    let (mut certificates, _next_parents) =
+        make_optimal_signed_certificates(1..=4, &genesis, &[kp]);
+
+    // insert the certificates in the DAG
+    for certificate in certificates.clone() {
+        dag.insert(certificate).await.unwrap();
+    }
+
+    // take the last one (top) and test for parents
+    let test_certificate = certificates.pop_back().unwrap();
+
+    // ensure that the certificate parents are found
+    let parents_available = synchronizer
+        .deliver_certificate(&test_certificate)
+        .await
+        .unwrap();
+    assert!(parents_available);
+}
+
+#[tokio::test]
+async fn deliver_certificate_using_store() {
+    let mut keys = keys(None);
+    let kp = keys.pop().unwrap();
+    let name = kp.public().clone();
+
+    // Make the current committee.
+    let committee = committee(None);
+
+    let (_, certificates_store, payload_store) = create_db_stores();
+    let (tx_header_waiter, _rx_header_waiter) = channel(1);
+    let (tx_certificate_waiter, _rx_certificate_waiter) = channel(1);
+
+    let mut synchronizer = Synchronizer::new(
+        name,
+        &committee,
+        certificates_store.clone(),
+        payload_store,
+        tx_header_waiter,
+        tx_certificate_waiter,
+        None,
+    );
+
+    // create some certificates in a complete DAG form
+    let genesis_certs = Certificate::genesis(&committee);
+    let genesis = genesis_certs
+        .iter()
+        .map(|x| x.digest())
+        .collect::<BTreeSet<_>>();
+
+    let (mut certificates, _next_parents) =
+        make_optimal_signed_certificates(1..=4, &genesis, &[kp]);
+
+    // insert the certificates in the DAG
+    for certificate in certificates.clone() {
+        certificates_store
+            .write(certificate.digest(), certificate)
+            .await;
+    }
+
+    // take the last one (top) and test for parents
+    let test_certificate = certificates.pop_back().unwrap();
+
+    // ensure that the certificate parents are found
+    let parents_available = synchronizer
+        .deliver_certificate(&test_certificate)
+        .await
+        .unwrap();
+    assert!(parents_available);
+}
+
+#[tokio::test]
+async fn deliver_certificate_not_found_parents() {
+    let mut keys = keys(None);
+    let kp = keys.pop().unwrap();
+    let name = kp.public().clone();
+
+    // Make the current committee.
+    let committee = committee(None);
+
+    let (_, certificates_store, payload_store) = create_db_stores();
+    let (tx_header_waiter, _rx_header_waiter) = channel(1);
+    let (tx_certificate_waiter, mut rx_certificate_waiter) = channel(1);
+
+    let mut synchronizer = Synchronizer::new(
+        name,
+        &committee,
+        certificates_store.clone(),
+        payload_store,
+        tx_header_waiter,
+        tx_certificate_waiter,
+        None,
+    );
+
+    // create some certificates in a complete DAG form
+    let genesis_certs = Certificate::genesis(&committee);
+    let genesis = genesis_certs
+        .iter()
+        .map(|x| x.digest())
+        .collect::<BTreeSet<_>>();
+
+    let (mut certificates, _next_parents) =
+        make_optimal_signed_certificates(1..=4, &genesis, &[kp]);
+
+    // take the last one (top) and test for parents
+    let test_certificate = certificates.pop_back().unwrap();
+
+    // we try to find the certificate's parents
+    let parents_available = synchronizer
+        .deliver_certificate(&test_certificate)
+        .await
+        .unwrap();
+
+    // and we should fail
+    assert!(!parents_available);
+
+    let certificate = rx_certificate_waiter.recv().await.unwrap();
+
+    assert_eq!(certificate, test_certificate);
+}


### PR DESCRIPTION
Resolves: https://github.com/MystenLabs/narwhal/issues/230

The PR is basically doing two things:
1. Adds on the `DAG` a new command to query for certificates that the dag "has seen"
2. Modifies the synchronizer to use the `DAG` instead of the `certificate_store` to check whether a certificate's parents have been already processed. Also introduced testing for the synchronizer.