### PR TITLE
Fix breakage from #450

### DIFF
--- a/consensus/src/tests/bullshark_tests.rs
+++ b/consensus/src/tests/bullshark_tests.rs
@@ -4,6 +4,7 @@
 use super::*;
 
 use crate::{metrics::ConsensusMetrics, Consensus};
+use arc_swap::ArcSwap;
 use crypto::ed25519::Ed25519PublicKey;
 #[allow(unused_imports)]
 use crypto::traits::KeyPair;
@@ -55,7 +56,7 @@ async fn commit_one() {
         .into_iter()
         .map(|kp| kp.public().clone())
         .collect();
-    let genesis = Certificate::genesis(&mock_committee(&keys[..]).load())
+    let genesis = Certificate::genesis(&mock_committee(&keys[..]))
         .iter()
         .map(|x| x.digest())
         .collect::<BTreeSet<_>>();
@@ -75,13 +76,13 @@ async fn commit_one() {
     let store_path = test_utils::temp_dir();
     let store = make_consensus_store(&store_path);
     let bullshark = Bullshark {
-        committee: mock_committee(&keys[..]),
+        committee: Arc::new(ArcSwap::from_pointee(mock_committee(&keys[..]))),
         store: store.clone(),
         gc_depth: 50,
     };
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
     Consensus::spawn(
-        mock_committee(&keys[..]),
+        Arc::new(ArcSwap::from_pointee(mock_committee(&keys[..]))),
         store,
         rx_waiter,
         tx_primary,
@@ -119,7 +120,7 @@ async fn dead_node() {
     keys.sort(); // Ensure we don't remove one of the leaders.
     let _ = keys.pop().unwrap();
 
-    let genesis = Certificate::genesis(mock_committee(&keys[..]).load().deref())
+    let genesis = Certificate::genesis(&mock_committee(&keys[..]))
         .iter()
         .map(|x| x.digest())
         .collect::<BTreeSet<_>>();
@@ -133,14 +134,14 @@ async fn dead_node() {
     let store_path = test_utils::temp_dir();
     let store = make_consensus_store(&store_path);
     let bullshark = Bullshark {
-        committee: mock_committee(&keys[..]),
+        committee: Arc::new(ArcSwap::from_pointee(mock_committee(&keys[..]))),
         store: store.clone(),
         gc_depth: 50,
     };
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
 
     Consensus::spawn(
-        mock_committee(&keys[..]),
+        Arc::new(ArcSwap::from_pointee(mock_committee(&keys[..]))),
         store,
         rx_waiter,
         tx_primary,
@@ -177,7 +178,7 @@ async fn not_enough_support() {
         .collect();
     keys.sort();
 
-    let genesis = Certificate::genesis(mock_committee(&keys[..]).load().deref())
+    let genesis = Certificate::genesis(&mock_committee(&keys[..]))
         .iter()
         .map(|x| x.digest())
         .collect::<BTreeSet<_>>();
@@ -238,14 +239,14 @@ async fn not_enough_support() {
     let store_path = test_utils::temp_dir();
     let store = make_consensus_store(&store_path);
     let bullshark = Bullshark {
-        committee: mock_committee(&keys[..]),
+        committee: Arc::new(ArcSwap::from_pointee(mock_committee(&keys[..]))),
         store: store.clone(),
         gc_depth: 50,
     };
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
 
     Consensus::spawn(
-        mock_committee(&keys[..]),
+        Arc::new(ArcSwap::from_pointee(mock_committee(&keys[..]))),
         store,
         rx_waiter,
         tx_primary,
@@ -288,7 +289,7 @@ async fn missing_leader() {
         .collect();
     keys.sort();
 
-    let genesis = Certificate::genesis(mock_committee(&keys[..]).load().deref())
+    let genesis = Certificate::genesis(&mock_committee(&keys[..]))
         .iter()
         .map(|x| x.digest())
         .collect::<BTreeSet<_>>();
@@ -317,14 +318,14 @@ async fn missing_leader() {
     let store_path = test_utils::temp_dir();
     let store = make_consensus_store(&store_path);
     let bullshark = Bullshark {
-        committee: mock_committee(&keys[..]),
+        committee: Arc::new(ArcSwap::from_pointee(mock_committee(&keys[..]))),
         store: store.clone(),
         gc_depth: 50,
     };
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
 
     Consensus::spawn(
-        mock_committee(&keys[..]),
+        Arc::new(ArcSwap::from_pointee(mock_committee(&keys[..]))),
         store,
         rx_waiter,
         tx_primary,

--- a/consensus/src/tests/dag_tests.rs
+++ b/consensus/src/tests/dag_tests.rs
@@ -24,7 +24,7 @@ async fn inner_dag_insert_one() {
         .map(|kp| kp.public().clone())
         .collect();
     let committee = mock_committee(&keys.clone()[..]);
-    let genesis_certs = Certificate::genesis(&*committee.load());
+    let genesis_certs = Certificate::genesis(&committee);
     let genesis = genesis_certs
         .iter()
         .map(|x| x.digest())
@@ -34,7 +34,7 @@ async fn inner_dag_insert_one() {
     // set up a Dag
     let (tx_cert, rx_cert) = channel(1);
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
-    Dag::new(&*committee.load(), rx_cert, metrics);
+    Dag::new(&committee, rx_cert, metrics);
 
     // Feed the certificates to the Dag
     while let Some(certificate) = certificates.pop_front() {
@@ -85,7 +85,7 @@ async fn test_dag_new_has_genesis_and_its_not_live() {
         .map(|kp| kp.public().clone())
         .collect();
     let committee = mock_committee(&keys.clone()[..]);
-    let genesis_certs = Certificate::genesis(&*committee.load());
+    let genesis_certs = Certificate::genesis(&committee);
     let genesis = genesis_certs
         .iter()
         .map(|x| x.digest())
@@ -94,7 +94,7 @@ async fn test_dag_new_has_genesis_and_its_not_live() {
     // set up a Dag
     let (_tx_cert, rx_cert) = channel(1);
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
-    let (_, dag) = Dag::new(&*committee.load(), rx_cert, metrics);
+    let (_, dag) = Dag::new(&committee, rx_cert, metrics);
 
     for certificate in genesis.clone() {
         assert!(dag.contains(certificate).await);
@@ -136,7 +136,7 @@ async fn test_dag_compresses_empty_blocks() {
         .map(|kp| kp.public().clone())
         .collect();
     let committee = mock_committee(&keys.clone()[..]);
-    let genesis_certs = Certificate::genesis(&*committee.load());
+    let genesis_certs = Certificate::genesis(&committee);
     let genesis = genesis_certs
         .iter()
         .map(|x| x.digest())
@@ -145,7 +145,7 @@ async fn test_dag_compresses_empty_blocks() {
     // set up a Dag
     let (_tx_cert, rx_cert) = channel(1);
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
-    let (_, dag) = Dag::new(&*committee.load(), rx_cert, metrics);
+    let (_, dag) = Dag::new(&committee, rx_cert, metrics);
 
     // insert one round of empty certificates
     let (mut certificates, next_parents) =
@@ -204,7 +204,7 @@ async fn test_dag_rounds_after_compression() {
         .map(|kp| kp.public().clone())
         .collect();
     let committee = mock_committee(&keys.clone()[..]);
-    let genesis_certs = Certificate::genesis(&*committee.load());
+    let genesis_certs = Certificate::genesis(&committee);
     let genesis = genesis_certs
         .iter()
         .map(|x| x.digest())
@@ -213,7 +213,7 @@ async fn test_dag_rounds_after_compression() {
     // set up a Dag
     let (_tx_cert, rx_cert) = channel(1);
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
-    let (_, dag) = Dag::new(&*committee.load(), rx_cert, metrics);
+    let (_, dag) = Dag::new(&committee, rx_cert, metrics);
 
     // insert one round of empty certificates
     let (mut certificates, next_parents) =
@@ -253,7 +253,7 @@ async fn dag_mutation_failures() {
         .map(|kp| kp.public().clone())
         .collect();
     let committee = mock_committee(&keys.clone()[..]);
-    let genesis_certs = Certificate::genesis(&*committee.load());
+    let genesis_certs = Certificate::genesis(&committee);
     let genesis = genesis_certs
         .iter()
         .map(|x| x.digest())
@@ -263,7 +263,7 @@ async fn dag_mutation_failures() {
     // set up a Dag
     let (_tx_cert, rx_cert) = channel(1);
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
-    let (_handle, dag) = Dag::new(&*committee.load(), rx_cert, metrics);
+    let (_handle, dag) = Dag::new(&committee, rx_cert, metrics);
     let mut certs_to_insert = certificates.clone();
     let mut certs_to_insert_in_reverse = certs_to_insert.clone();
     let mut certs_to_remove_before_insert = certs_to_insert.clone();
@@ -322,7 +322,7 @@ async fn dag_insert_one_and_rounds_node_read() {
         .map(|kp| kp.public().clone())
         .collect();
     let committee = mock_committee(&keys.clone()[..]);
-    let genesis_certs = Certificate::genesis(&*committee.load());
+    let genesis_certs = Certificate::genesis(&committee);
     let genesis = genesis_certs
         .iter()
         .map(|x| x.digest())
@@ -332,7 +332,7 @@ async fn dag_insert_one_and_rounds_node_read() {
     // set up a Dag
     let (_tx_cert, rx_cert) = channel(1);
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
-    let (_handle, dag) = Dag::new(&*committee.load(), rx_cert, metrics);
+    let (_handle, dag) = Dag::new(&committee, rx_cert, metrics);
     let mut certs_to_insert = certificates.clone();
 
     // Feed the certificates to the Dag
@@ -370,7 +370,7 @@ async fn dag_insert_and_remove_reads() {
         .map(|kp| kp.public().clone())
         .collect();
     let committee = mock_committee(&keys.clone()[..]);
-    let mut genesis_certs = Certificate::genesis(&*committee.load());
+    let mut genesis_certs = Certificate::genesis(&committee);
     let genesis = genesis_certs
         .iter()
         .map(|x| x.digest())
@@ -380,7 +380,7 @@ async fn dag_insert_and_remove_reads() {
     // set up a Dag
     let (_tx_cert, rx_cert) = channel(1);
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
-    let (_handle, dag) = Dag::new(&*committee.load(), rx_cert, metrics);
+    let (_handle, dag) = Dag::new(&committee, rx_cert, metrics);
 
     // Feed the certificates to the Dag
     while let Some(certificate) = certificates.pop_front() {

--- a/consensus/src/tests/subscriber_tests.rs
+++ b/consensus/src/tests/subscriber_tests.rs
@@ -6,6 +6,7 @@ use crate::{
     tusk::{tusk_tests::*, Tusk},
     Consensus, ConsensusOutput, ConsensusSyncRequest, SubscriberHandler,
 };
+use arc_swap::ArcSwap;
 use crypto::{ed25519::Ed25519PublicKey, traits::KeyPair, Hash};
 use prometheus::Registry;
 use std::collections::{BTreeSet, VecDeque};
@@ -19,7 +20,7 @@ pub fn commit_certificates() -> VecDeque<Certificate<Ed25519PublicKey>> {
         .into_iter()
         .map(|kp| kp.public().clone())
         .collect();
-    let genesis = Certificate::genesis(&*mock_committee(&keys[..]).load())
+    let genesis = Certificate::genesis(&mock_committee(&keys[..]))
         .iter()
         .map(|x| x.digest())
         .collect::<BTreeSet<_>>();
@@ -47,7 +48,7 @@ pub async fn spawn_node(
         .into_iter()
         .map(|kp| kp.public().clone())
         .collect();
-    let committee = mock_committee(&keys[..]);
+    let committee = Arc::new(ArcSwap::from_pointee(mock_committee(&keys[..])));
 
     // Create the storages.
     let consensus_store_path = test_utils::temp_dir();

--- a/consensus/src/tests/tusk_tests.rs
+++ b/consensus/src/tests/tusk_tests.rs
@@ -4,6 +4,7 @@
 use super::*;
 
 use crate::{metrics::ConsensusMetrics, Consensus};
+use arc_swap::ArcSwap;
 use crypto::ed25519::Ed25519PublicKey;
 #[allow(unused_imports)]
 use crypto::traits::KeyPair;
@@ -55,7 +56,7 @@ async fn commit_one() {
         .into_iter()
         .map(|kp| kp.public().clone())
         .collect();
-    let genesis = Certificate::genesis(&*mock_committee(&keys[..]).load())
+    let genesis = Certificate::genesis(&mock_committee(&keys[..]))
         .iter()
         .map(|x| x.digest())
         .collect::<BTreeSet<_>>();
@@ -73,14 +74,14 @@ async fn commit_one() {
     let store_path = test_utils::temp_dir();
     let store = make_consensus_store(&store_path);
     let tusk = Tusk {
-        committee: mock_committee(&keys[..]),
+        committee: Arc::new(ArcSwap::from_pointee(mock_committee(&keys[..]))),
         store: store.clone(),
         gc_depth: 50,
     };
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
 
     Consensus::spawn(
-        mock_committee(&keys[..]),
+        Arc::new(ArcSwap::from_pointee(mock_committee(&keys[..]))),
         store,
         rx_waiter,
         tx_primary,
@@ -118,7 +119,7 @@ async fn dead_node() {
     keys.sort(); // Ensure we don't remove one of the leaders.
     let _ = keys.pop().unwrap();
 
-    let genesis = Certificate::genesis(&*mock_committee(&keys[..]).load())
+    let genesis = Certificate::genesis(&mock_committee(&keys[..]))
         .iter()
         .map(|x| x.digest())
         .collect::<BTreeSet<_>>();
@@ -132,14 +133,14 @@ async fn dead_node() {
     let store_path = test_utils::temp_dir();
     let store = make_consensus_store(&store_path);
     let tusk = Tusk {
-        committee: mock_committee(&keys[..]),
+        committee: Arc::new(ArcSwap::from_pointee(mock_committee(&keys[..]))),
         store: store.clone(),
         gc_depth: 50,
     };
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
 
     Consensus::spawn(
-        mock_committee(&keys[..]),
+        Arc::new(ArcSwap::from_pointee(mock_committee(&keys[..]))),
         store,
         rx_waiter,
         tx_primary,
@@ -176,7 +177,7 @@ async fn not_enough_support() {
         .collect();
     keys.sort();
 
-    let genesis = Certificate::genesis(&*mock_committee(&keys[..]).load())
+    let genesis = Certificate::genesis(&mock_committee(&keys[..]))
         .iter()
         .map(|x| x.digest())
         .collect::<BTreeSet<_>>();
@@ -235,14 +236,14 @@ async fn not_enough_support() {
     let store_path = test_utils::temp_dir();
     let store = make_consensus_store(&store_path);
     let tusk = Tusk {
-        committee: mock_committee(&keys[..]),
+        committee: Arc::new(ArcSwap::from_pointee(mock_committee(&keys[..]))),
         store: store.clone(),
         gc_depth: 50,
     };
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
 
     Consensus::spawn(
-        mock_committee(&keys[..]),
+        Arc::new(ArcSwap::from_pointee(mock_committee(&keys[..]))),
         store,
         rx_waiter,
         tx_primary,
@@ -285,7 +286,7 @@ async fn missing_leader() {
         .collect();
     keys.sort();
 
-    let genesis = Certificate::genesis(&*mock_committee(&keys[..]).load())
+    let genesis = Certificate::genesis(&mock_committee(&keys[..]))
         .iter()
         .map(|x| x.digest())
         .collect::<BTreeSet<_>>();
@@ -312,13 +313,13 @@ async fn missing_leader() {
     let store_path = test_utils::temp_dir();
     let store = make_consensus_store(&store_path);
     let tusk = Tusk {
-        committee: mock_committee(&keys[..]),
+        committee: Arc::new(ArcSwap::from_pointee(mock_committee(&keys[..]))),
         store: store.clone(),
         gc_depth: 50,
     };
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
     Consensus::spawn(
-        mock_committee(&keys[..]),
+        Arc::new(ArcSwap::from_pointee(mock_committee(&keys[..]))),
         store,
         rx_waiter,
         tx_primary,

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -1,10 +1,9 @@
 // Copyright (c) 2021, Facebook, Inc. and its affiliates
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use arc_swap::ArcSwap;
 use config::{
-    utils::get_available_port, Authority, Committee, Epoch, PrimaryAddresses, SharedCommittee,
-    WorkerAddresses, WorkerId,
+    utils::get_available_port, Authority, Committee, Epoch, PrimaryAddresses, WorkerAddresses,
+    WorkerId,
 };
 use crypto::{
     ed25519::{Ed25519KeyPair, Ed25519PublicKey, Ed25519Signature},
@@ -158,8 +157,8 @@ pub fn pure_committee_from_keys(keys: &[Ed25519KeyPair]) -> Committee<Ed25519Pub
 ////////////////////////////////////////////////////////////////
 
 // Fixture
-pub fn mock_committee(keys: &[Ed25519PublicKey]) -> SharedCommittee<Ed25519PublicKey> {
-    Arc::new(ArcSwap::from_pointee(Committee {
+pub fn mock_committee(keys: &[Ed25519PublicKey]) -> Committee<Ed25519PublicKey> {
+    Committee {
         epoch: Epoch::default(),
         authorities: keys
             .iter()
@@ -177,7 +176,7 @@ pub fn mock_committee(keys: &[Ed25519PublicKey]) -> SharedCommittee<Ed25519Publi
                 )
             })
             .collect(),
-    }))
+    }
 }
 
 pub fn make_consensus_store(store_path: &std::path::Path) -> Arc<ConsensusStore<Ed25519PublicKey>> {


### PR DESCRIPTION
At the same time, makes `mock_committee` output a `Committee` rather than a `SharedCommittee` and propagates simplification.