### PR TITLE
[metrics] adding more metrics for primary node

### DIFF
--- a/primary/src/core.rs
+++ b/primary/src/core.rs
@@ -180,11 +180,28 @@ impl<PublicKey: VerifyingKey> Core<PublicKey> {
     #[instrument(level = "debug", skip_all)]
     async fn process_header(&mut self, header: &Header<PublicKey>) -> DagResult<()> {
         debug!("Processing {:?}", header);
+        let header_source = if self.name.eq(&header.author) {
+            "own"
+        } else {
+            "other"
+        };
+
         // Indicate that we are processing this header.
-        self.processing
+        let inserted = self
+            .processing
             .entry(header.round)
             .or_insert_with(HashSet::new)
             .insert(header.id);
+
+        if inserted {
+            // Only increase the metric when the header has been seen for the first
+            // time. Edge case is headers received past gc_round so we might have already
+            // processed them, but not big issue for now.
+            self.metrics
+                .unique_headers_received
+                .with_label_values(&[&header.epoch.to_string(), header_source])
+                .inc();
+        }
 
         // If the following condition is valid, it means we already garbage collected the parents. There is thus
         // no points in trying to synchronize them or vote for the header. We just need to gather the payload.
@@ -240,11 +257,6 @@ impl<PublicKey: VerifyingKey> Core<PublicKey> {
         // Store the header.
         self.header_store.write(header.id, header.clone()).await;
 
-        let header_source = if self.name.eq(&header.author) {
-            "own"
-        } else {
-            "other"
-        };
         self.metrics
             .headers_processed
             .with_label_values(&[&header.epoch.to_string(), header_source])

--- a/primary/src/header_waiter.rs
+++ b/primary/src/header_waiter.rs
@@ -350,11 +350,16 @@ impl<PublicKey: VerifyingKey> HeaderWaiter<PublicKey> {
                     .observe(now.elapsed().as_secs_f64());
             }
 
-            // measure the pending elements
+            // measure the pending & parent elements
             self.metrics
                 .pending_elements_header_waiter
                 .with_label_values(&[&self.committee.epoch.to_string()])
                 .set(self.pending.len() as i64);
+
+            self.metrics
+                .parent_requests_header_waiter
+                .with_label_values(&[&self.committee.epoch.to_string()])
+                .set(self.parent_requests.len() as i64);
         }
     }
 }

--- a/primary/src/metrics.rs
+++ b/primary/src/metrics.rs
@@ -1,20 +1,24 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use crate::EndpointMetrics;
+use mysten_network::metrics::MetricsCallbackProvider;
 use prometheus::{
     default_registry, register_histogram_vec_with_registry, register_int_counter_vec_with_registry,
     register_int_gauge_vec_with_registry, HistogramVec, IntCounterVec, IntGaugeVec, Registry,
 };
-use std::sync::Once;
+use std::{sync::Once, time::Duration};
+use tonic::Code;
 
 #[derive(Clone)]
 pub(crate) struct Metrics {
     pub(crate) endpoint_metrics: Option<EndpointMetrics>,
+    pub(crate) primary_endpoint_metrics: Option<PrimaryEndpointMetrics>,
     pub(crate) node_metrics: Option<PrimaryMetrics>,
 }
 
 static mut METRICS: Metrics = Metrics {
     endpoint_metrics: None,
+    primary_endpoint_metrics: None,
     node_metrics: None,
 };
 static INIT: Once = Once::new();
@@ -25,8 +29,11 @@ static INIT: Once = Once::new();
 pub(crate) fn initialise_metrics(metrics_registry: &Registry) -> Metrics {
     unsafe {
         INIT.call_once(|| {
-            // The metrics used for the primary node endpoints
+            // The metrics used for the gRPC primary node endpoints we expose to the external consensus
             let endpoint_metrics = EndpointMetrics::new(metrics_registry);
+
+            // The metrics used for the primary-to-primary communication node endpoints
+            let primary_endpoint_metrics = PrimaryEndpointMetrics::new(metrics_registry);
 
             // Essential/core metrics across the primary node
             let node_metrics = PrimaryMetrics::new(metrics_registry);
@@ -34,6 +41,7 @@ pub(crate) fn initialise_metrics(metrics_registry: &Registry) -> Metrics {
             METRICS = Metrics {
                 node_metrics: Some(node_metrics),
                 endpoint_metrics: Some(endpoint_metrics),
+                primary_endpoint_metrics: Some(primary_endpoint_metrics),
             }
         });
         METRICS.clone()
@@ -44,6 +52,8 @@ pub(crate) fn initialise_metrics(metrics_registry: &Registry) -> Metrics {
 pub struct PrimaryMetrics {
     /// count number of headers that the node processed (others + own)
     pub headers_processed: IntCounterVec,
+    /// count unique number of headers that we have received for processing (others + own)
+    pub unique_headers_received: IntCounterVec,
     /// count number of headers that we suspended their processing
     pub headers_suspended: IntCounterVec,
     /// count number of certificates that the node created
@@ -62,6 +72,10 @@ pub struct PrimaryMetrics {
     pub gc_header_waiter_latency: HistogramVec,
     /// Number of elements in pending list of header_waiter
     pub pending_elements_header_waiter: IntGaugeVec,
+    /// Number of parent requests list of header_waiter
+    pub parent_requests_header_waiter: IntGaugeVec,
+    /// Number of elements in pending list of certificate_waiter
+    pub pending_elements_certificate_waiter: IntGaugeVec,
 }
 
 impl PrimaryMetrics {
@@ -70,6 +84,13 @@ impl PrimaryMetrics {
             headers_processed: register_int_counter_vec_with_registry!(
                 "headers_processed",
                 "Number of headers that node processed (others + own)",
+                &["epoch", "source"],
+                registry
+            )
+            .unwrap(),
+            unique_headers_received: register_int_counter_vec_with_registry!(
+                "unique_headers_received",
+                "Number of unique headers that received for processing (others + own)",
                 &["epoch", "source"],
                 registry
             )
@@ -137,11 +158,78 @@ impl PrimaryMetrics {
                 registry
             )
             .unwrap(),
+            parent_requests_header_waiter: register_int_gauge_vec_with_registry!(
+                "parent_requests_header_waiter",
+                "Number of parent requests in header waiter",
+                &["epoch"],
+                registry
+            )
+            .unwrap(),
+            pending_elements_certificate_waiter: register_int_gauge_vec_with_registry!(
+                "pending_elements_certificate_waiter",
+                "Number of pending elements in certificate waiter",
+                &["epoch"],
+                registry
+            )
+            .unwrap(),
         }
     }
 }
 
 impl Default for PrimaryMetrics {
+    fn default() -> Self {
+        Self::new(default_registry())
+    }
+}
+
+#[derive(Clone)]
+pub struct PrimaryEndpointMetrics {
+    /// Counter of requests, route is a label (ie separate timeseries per route)
+    requests_by_route: IntCounterVec,
+    /// Request latency, route is a label
+    req_latency_by_route: HistogramVec,
+}
+
+impl PrimaryEndpointMetrics {
+    pub fn new(registry: &Registry) -> Self {
+        Self {
+            requests_by_route: register_int_counter_vec_with_registry!(
+                "primary_requests_by_route",
+                "Number of requests by route",
+                &["route", "status", "grpc_status_code"],
+                registry
+            )
+            .unwrap(),
+            req_latency_by_route: register_histogram_vec_with_registry!(
+                "primary_req_latency_by_route",
+                "Latency of a request by route",
+                &["route", "status", "grpc_status_code"],
+                registry
+            )
+            .unwrap(),
+        }
+    }
+}
+
+impl MetricsCallbackProvider for PrimaryEndpointMetrics {
+    fn on_request(&self, _path: String) {
+        // For now we just do nothing
+    }
+
+    fn on_response(&self, path: String, latency: Duration, status: u16, grpc_status_code: Code) {
+        let code: i32 = grpc_status_code.into();
+        let labels = [path.as_str(), &status.to_string(), &code.to_string()];
+
+        self.requests_by_route.with_label_values(&labels).inc();
+
+        let req_latency_secs = latency.as_secs_f64();
+        self.req_latency_by_route
+            .with_label_values(&labels)
+            .observe(req_latency_secs);
+    }
+}
+
+impl Default for PrimaryEndpointMetrics {
     fn default() -> Self {
         Self::new(default_registry())
     }


### PR DESCRIPTION
Enhancing observability with adding more metrics across `core`, `certificate_waiter` , `header_waiter`. Also adding metrics for the endpoint requests for the primary to primary communication