### PR TITLE
fix: update timestamp of requests when we re-issue them

### DIFF
--- a/primary/src/header_waiter.rs
+++ b/primary/src/header_waiter.rs
@@ -295,10 +295,12 @@ impl<PublicKey: VerifyingKey> HeaderWaiter<PublicKey> {
                         .as_millis();
 
                     let mut retry = Vec::new();
-                    for (digest, (_, timestamp)) in &self.parent_requests {
-                        if timestamp + self.sync_retry_delay.as_millis() < now {
+                    for (digest, (_, timestamp)) in self.parent_requests.iter_mut() {
+                        if *timestamp + self.sync_retry_delay.as_millis() < now {
                             debug!("Requesting sync for certificate {digest} (retry)");
                             retry.push(*digest);
+                            // reset the time at which this request was last issued
+                            *timestamp = now;
                         }
                     }
 

--- a/worker/src/synchronizer.rs
+++ b/worker/src/synchronizer.rs
@@ -253,10 +253,12 @@ impl<PublicKey: VerifyingKey> Synchronizer<PublicKey> {
                         .as_millis();
 
                     let mut retry = Vec::new();
-                    for (digest, (_, _, timestamp)) in &self.pending {
-                        if timestamp + self.sync_retry_delay.as_millis() < now {
+                    for (digest, (_, _, timestamp)) in self.pending.iter_mut() {
+                        if *timestamp + self.sync_retry_delay.as_millis() < now {
                             debug!("Requesting sync for batch {digest} (retry)");
                             retry.push(*digest);
+                            // reset the time at which this request was last issued
+                            *timestamp = now;
                         }
                     }
                     if !retry.is_empty() {


### PR DESCRIPTION
This addresses a too-frequent-retry behavior, whereby:
- we set a time of request when queuing one,
- in a loop, reexamine the requests with a high examination frequency,
- reissue the requests older than a retry delay,
- and don't modify the queued request in any way.

The intent of this code was to reissue the requests at the retry frequency, but since we never update the request's issuance time, it ends up reissuing all requests on every iteration, at the (much higher) examination frequency.