### PR TITLE
fix: fix entry.sh to derive validator/worker_id from hostname in k8s

### DIFF
--- a/Docker/entry.sh
+++ b/Docker/entry.sh
@@ -3,6 +3,14 @@
 # Capture stack trace
 export RUST_BACKTRACE=1
 
+if [ -z "$VALIDATOR_ID" -a "$KUBERNETES_PORT" ]; then
+    export VALIDATOR_ID=${HOSTNAME##*-}
+    # assuming that WORKER_ID isn't also set.
+    # currently they match the validator it is assigned to.
+    export WORKER_ID=${VALIDATOR_ID}
+fi
+
+
 # Environment variables to use on the script
 NODE_BIN="./bin/node"
 KEYS_PATH="/validators/validator-$VALIDATOR_ID/key.json"


### PR DESCRIPTION
Currently there is no way with k8s kustomize templates or manifests to know the member number of a stateful set.
However, the hostname does have a -# number appended that is sequential for the number of replicas.
