### PR TITLE
[proposer] Early-signal rounds from valid certificates to the proposer

### DIFF
--- a/primary/src/core.rs
+++ b/primary/src/core.rs
@@ -339,6 +339,19 @@ impl<PublicKey: VerifyingKey> Core<PublicKey> {
     async fn process_certificate(&mut self, certificate: Certificate<PublicKey>) -> DagResult<()> {
         debug!("Processing {:?}", certificate);
 
+        // Let the proposer draw early conclusions from a certificate at this round and epoch, without its
+        // parents or payload (which we may not have yet).
+        //
+        // Since our certificate is well-signed, it shows a majority of honest signers stand at round r,
+        // so to make a successful proposal, our proposer must use parents at least at round r-1.
+        //
+        // This allows the proposer not to fire proposals at rounds strictly below the certificate we witnessed.
+        let minimal_round_for_parents = certificate.round().saturating_sub(1);
+        self.tx_proposer
+            .send((vec![], minimal_round_for_parents, certificate.epoch()))
+            .await
+            .map_err(|_| DagError::ShuttingDown)?;
+
         // Process the header embedded in the certificate if we haven't already voted for it (if we already
         // voted, it means we already processed it). Since this header got certified, we are sure that all
         // the data it refers to (ie. its payload and its parents) are available. We can thus continue the

--- a/primary/src/proposer.rs
+++ b/primary/src/proposer.rs
@@ -258,7 +258,6 @@ impl<PublicKey: VerifyingKey> Proposer<PublicKey> {
                                 },
                                 Reconfigure::Shutdown(_token) => return,
                             }
-
                         }
                         Ordering::Less => {
                             // We already updated committee but the core is slow. Ignore the parents
@@ -277,6 +276,7 @@ impl<PublicKey: VerifyingKey> Proposer<PublicKey> {
                             // late (or just joined the network).
                             self.round = round;
                             self.last_parents = parents;
+
                         },
                         Ordering::Less => {
                             // Ignore parents from older rounds.

--- a/primary/src/tests/core_tests.rs
+++ b/primary/src/tests/core_tests.rs
@@ -416,6 +416,13 @@ async fn process_certificates() {
     }
 
     // Ensure the core sends the parents of the certificates to the proposer.
+    //
+    // The first messages are the core letting us know about the round of parent certificates
+    for _i in 0..3 {
+        let received = rx_parents.recv().await.unwrap();
+        assert_eq!(received, (vec![], 0, 0));
+    }
+    // the next message actually contains the parents
     let received = rx_parents.recv().await.unwrap();
     assert_eq!(received, (certificates.clone(), 1, 0));
 

--- a/primary/tests/epoch_change.rs
+++ b/primary/tests/epoch_change.rs
@@ -14,7 +14,7 @@ use types::ConsensusPrimaryMessage;
 
 /// The epoch changes but the stake distribution and network addresses stay the same.
 #[tokio::test]
-async fn simple_epoch_change() {
+async fn test_simple_epoch_change() {
     let parameters = Parameters {
         batch_size: 200, // Two transactions.
         ..Parameters::default()
@@ -93,7 +93,7 @@ async fn simple_epoch_change() {
 }
 
 #[tokio::test]
-async fn partial_committee_change() {
+async fn test_partial_committee_change() {
     let parameters = Parameters {
         batch_size: 200, // Two transactions.
         ..Parameters::default()
@@ -235,7 +235,7 @@ async fn partial_committee_change() {
 
 /// The epoch changes but the stake distribution and network addresses stay the same.
 #[tokio::test]
-async fn restart_with_new_committee() {
+async fn test_restart_with_new_committee_change() {
     let parameters = Parameters {
         batch_size: 200, // Two transactions.
         ..Parameters::default()


### PR DESCRIPTION
## Context

 The core's `process_certificates` lets the proposer know about full sets of parents certificates at a round r and at an epoch e. This set is full in the sense that it contains enough (2f+1) parents for the proposer to advance its round to r+1 and then propose (`make_header`) at that round r+1.

## Issues

- the proposer will propose at a round beyond that of any round for which it has a full set of parents, which is good,
- but it will also propose at that round even if it has evidence that such a proposal has zero chance of succeeding (to certification), which is bad.

Indeed, when a node receives a (well-signed) certificate C at round r, it knows that no proposal at a strictly lesser round can succeed, since a majority (>= f+1) of honest validators (of the 2f+1 signers of C) is committed to vote at least at this round. Note that we do not need to retrieve the payload or antecedents of the certificate C to assert this.

This leads our validator to make useless proposals when it is not fully caught up with the rest of the network (it reaches a proposal deadline without full sets of parents for every round).

## The Fix

When we learn of a (cryptographically valid) certificate bearing round r, without waiting, we let the proposer know of the smallest round at which we could ever provide a set of parents usable for a proposal: r-1.

This tells the validator to not bother proposing strictly below round r.