### PR TITLE
[metrics] add metrics to monitor concurrent tasks in network

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2236,6 +2236,7 @@ dependencies = [
  "futures",
  "multiaddr",
  "mysten-network 0.1.0 (git+https://github.com/mystenlabs/mysten-infra.git?rev=123c9e40b529315e1c1d91a54fb717111c3e349c)",
+ "prometheus",
  "rand 0.7.3",
  "serde",
  "test_utils",

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -21,6 +21,7 @@ tonic = { version = "0.7.2", features = ["tls"] }
 backoff = { version = "0.4.0", features = ["tokio"] }
 multiaddr = "0.14.0"
 anyhow = "1.0.58"
+prometheus = "0.13.1"
 
 mysten-network = { git = "https://github.com/mystenlabs/mysten-infra.git", rev = "123c9e40b529315e1c1d91a54fb717111c3e349c" }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -10,6 +10,7 @@
 #![allow(clippy::async_yields_async)]
 
 mod bounded_executor;
+pub mod metrics;
 mod primary;
 mod retry;
 mod traits;

--- a/network/src/metrics.rs
+++ b/network/src/metrics.rs
@@ -1,0 +1,155 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use prometheus::{default_registry, register_int_gauge_vec_with_registry, IntGaugeVec, Registry};
+use std::sync::Arc;
+
+pub trait NetworkMetrics {
+    fn network_available_tasks(&self) -> &IntGaugeVec;
+}
+
+#[derive(Clone, Debug)]
+pub struct PrimaryNetworkMetrics {
+    /// The number of executor available tasks
+    pub network_available_tasks: IntGaugeVec,
+}
+
+impl PrimaryNetworkMetrics {
+    pub fn new(registry: &Registry) -> Self {
+        Self {
+            network_available_tasks: register_int_gauge_vec_with_registry!(
+                "primary_network_available_tasks",
+                "The number of available tasks to run in the network connector",
+                &["module", "network", "address"],
+                registry
+            )
+            .unwrap(),
+        }
+    }
+}
+
+impl NetworkMetrics for PrimaryNetworkMetrics {
+    fn network_available_tasks(&self) -> &IntGaugeVec {
+        &self.network_available_tasks
+    }
+}
+
+impl Default for PrimaryNetworkMetrics {
+    fn default() -> Self {
+        Self::new(default_registry())
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct WorkerNetworkMetrics {
+    /// The number of executor available tasks
+    pub network_available_tasks: IntGaugeVec,
+}
+
+impl WorkerNetworkMetrics {
+    pub fn new(registry: &Registry) -> Self {
+        Self {
+            network_available_tasks: register_int_gauge_vec_with_registry!(
+                "worker_network_concurrent_tasks",
+                "The number of available tasks to run in the network connector",
+                &["module", "network", "address"],
+                registry
+            )
+            .unwrap(),
+        }
+    }
+}
+
+impl NetworkMetrics for WorkerNetworkMetrics {
+    fn network_available_tasks(&self) -> &IntGaugeVec {
+        &self.network_available_tasks
+    }
+}
+
+impl Default for WorkerNetworkMetrics {
+    fn default() -> Self {
+        Self::new(default_registry())
+    }
+}
+
+pub struct Metrics<N: NetworkMetrics> {
+    /// The handler to report the metrics.
+    metrics_handler: Arc<N>,
+    /// A tag used for every reported metric to trace the module where this has been used from
+    module_tag: String,
+    /// The network type - this shouldn't be set outside of this crate but is meant to
+    /// be initialised from the network modules.
+    network_type: String,
+}
+
+impl<N: NetworkMetrics> Metrics<N> {
+    pub fn new(metrics_handler: Arc<N>, module_tag: String) -> Self {
+        Self {
+            metrics_handler,
+            module_tag,
+            network_type: "".to_string(),
+        }
+    }
+
+    pub fn from(metrics: Metrics<N>, network_type: String) -> Metrics<N> {
+        Metrics {
+            metrics_handler: metrics.metrics_handler,
+            module_tag: metrics.module_tag,
+            network_type,
+        }
+    }
+
+    pub fn module_tag(&self) -> String {
+        self.module_tag.clone()
+    }
+
+    pub fn network_type(&self) -> String {
+        self.network_type.clone()
+    }
+
+    pub fn set_network_available_tasks(&self, value: i64, addr: Option<String>) {
+        self.metrics_handler
+            .network_available_tasks()
+            .with_label_values(&[
+                self.module_tag.as_str(),
+                self.network_type.as_str(),
+                addr.map_or("".to_string(), |a| a).as_str(),
+            ])
+            .set(value);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::metrics::{Metrics, NetworkMetrics, PrimaryNetworkMetrics};
+    use prometheus::Registry;
+    use std::{collections::HashMap, sync::Arc};
+
+    #[test]
+    fn test_called_metrics() {
+        // GIVEN
+        let registry = Registry::new();
+        let metrics = Metrics {
+            metrics_handler: Arc::new(PrimaryNetworkMetrics::new(&registry)),
+            module_tag: "demo_handler".to_string(),
+            network_type: "primary".to_string(),
+        };
+
+        // WHEN update metrics
+        metrics.set_network_available_tasks(14, Some("127.0.0.1".to_string()));
+
+        // THEN registry should be updated with expected tag
+        let mut m = HashMap::new();
+        m.insert("module", "demo_handler");
+        m.insert("network", "primary");
+        m.insert("address", "127.0.0.1");
+        assert_eq!(
+            metrics
+                .metrics_handler
+                .network_available_tasks()
+                .get_metric_with(&m)
+                .unwrap()
+                .get(),
+            14
+        );
+    }
+}

--- a/primary/src/block_waiter.rs
+++ b/primary/src/block_waiter.rs
@@ -128,6 +128,7 @@ type RequestKey = Vec<u8>;
 /// # use crypto::traits::VerifyingKey;
 /// # use async_trait::async_trait;
 /// # use std::sync::Arc;
+/// # use network::PrimaryToWorkerNetwork;
 ///
 /// # // A mock implementation of the BlockSynchronizerHandler
 /// struct BlockSynchronizerHandler;
@@ -171,6 +172,7 @@ type RequestKey = Vec<u8>;
 ///         rx_commands,
 ///         rx_batches,
 ///         Arc::new(BlockSynchronizerHandler{}),
+///         PrimaryToWorkerNetwork::default()
 ///     );
 ///
 ///     // Send a command to receive a block
@@ -254,6 +256,7 @@ impl<SynchronizerHandler: Handler + Send + Sync + 'static> BlockWaiter<Synchroni
         rx_commands: Receiver<BlockCommand>,
         batch_receiver: Receiver<BatchResult>,
         block_synchronizer_handler: Arc<SynchronizerHandler>,
+        worker_network: PrimaryToWorkerNetwork,
     ) -> JoinHandle<()> {
         tokio::spawn(async move {
             Self {
@@ -261,7 +264,7 @@ impl<SynchronizerHandler: Handler + Send + Sync + 'static> BlockWaiter<Synchroni
                 committee,
                 rx_commands,
                 pending_get_block: HashMap::new(),
-                worker_network: PrimaryToWorkerNetwork::default(),
+                worker_network,
                 rx_reconfigure,
                 rx_batch_receiver: batch_receiver,
                 tx_pending_batch: HashMap::new(),

--- a/primary/src/core.rs
+++ b/primary/src/core.rs
@@ -110,6 +110,7 @@ impl Core {
         tx_consensus: Sender<Certificate>,
         tx_proposer: Sender<(Vec<Certificate>, Round, Epoch)>,
         metrics: Arc<PrimaryMetrics>,
+        primary_network: PrimaryNetwork,
     ) -> JoinHandle<()> {
         tokio::spawn(async move {
             Self {
@@ -134,7 +135,7 @@ impl Core {
                 current_header: Header::default(),
                 votes_aggregator: VotesAggregator::new(),
                 certificates_aggregators: HashMap::with_capacity(2 * gc_depth as usize),
-                network: Default::default(),
+                network: primary_network,
                 cancel_handlers: HashMap::with_capacity(2 * gc_depth as usize),
                 metrics,
             }

--- a/primary/src/header_waiter.rs
+++ b/primary/src/header_waiter.rs
@@ -108,6 +108,8 @@ impl HeaderWaiter {
         rx_synchronizer: Receiver<WaiterMessage>,
         tx_core: Sender<Header>,
         metrics: Arc<PrimaryMetrics>,
+        primary_network: PrimaryNetwork,
+        worker_network: PrimaryToWorkerNetwork,
     ) -> JoinHandle<()> {
         tokio::spawn(async move {
             Self {
@@ -122,8 +124,8 @@ impl HeaderWaiter {
                 rx_reconfigure,
                 rx_synchronizer,
                 tx_core,
-                primary_network: Default::default(),
-                worker_network: Default::default(),
+                primary_network,
+                worker_network,
                 parent_requests: HashMap::new(),
                 batch_requests: HashMap::new(),
                 pending: HashMap::new(),

--- a/primary/src/helper.rs
+++ b/primary/src/helper.rs
@@ -57,6 +57,7 @@ impl Helper {
         payload_store: Store<(BatchDigest, WorkerId), PayloadToken>,
         rx_committee: watch::Receiver<ReconfigureNotification>,
         rx_primaries: Receiver<PrimaryMessage>,
+        primary_network: PrimaryNetwork,
     ) -> JoinHandle<()> {
         tokio::spawn(async move {
             Self {
@@ -66,7 +67,7 @@ impl Helper {
                 payload_store,
                 rx_committee,
                 rx_primaries,
-                primary_network: PrimaryNetwork::default(),
+                primary_network,
             }
             .run()
             .await;

--- a/primary/src/metrics.rs
+++ b/primary/src/metrics.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use crate::EndpointMetrics;
 use mysten_network::metrics::MetricsCallbackProvider;
+use network::{metrics, metrics::PrimaryNetworkMetrics};
 use prometheus::{
     default_registry, register_histogram_vec_with_registry, register_int_counter_vec_with_registry,
     register_int_gauge_vec_with_registry, HistogramVec, IntCounterVec, IntGaugeVec, Registry,
@@ -14,11 +15,10 @@ pub(crate) struct Metrics {
     pub(crate) endpoint_metrics: Option<EndpointMetrics>,
     pub(crate) primary_endpoint_metrics: Option<PrimaryEndpointMetrics>,
     pub(crate) node_metrics: Option<PrimaryMetrics>,
+    pub(crate) network_metrics: Option<PrimaryNetworkMetrics>,
 }
 
-/// Initialises the metrics. Should be called only once when the primary
-/// node is initialised, otherwise it will lead to erroneously creating
-/// multiple registries.
+/// Initialises the metrics
 pub(crate) fn initialise_metrics(metrics_registry: &Registry) -> Metrics {
     // The metrics used for the gRPC primary node endpoints we expose to the external consensus
     let endpoint_metrics = EndpointMetrics::new(metrics_registry);
@@ -29,10 +29,14 @@ pub(crate) fn initialise_metrics(metrics_registry: &Registry) -> Metrics {
     // Essential/core metrics across the primary node
     let node_metrics = PrimaryMetrics::new(metrics_registry);
 
+    // Network metrics for the primary to primary comms
+    let network_metrics = metrics::PrimaryNetworkMetrics::new(metrics_registry);
+
     Metrics {
         node_metrics: Some(node_metrics),
         endpoint_metrics: Some(endpoint_metrics),
         primary_endpoint_metrics: Some(primary_endpoint_metrics),
+        network_metrics: Some(network_metrics),
     }
 }
 

--- a/primary/src/tests/block_waiter_tests.rs
+++ b/primary/src/tests/block_waiter_tests.rs
@@ -91,6 +91,7 @@ async fn test_successfully_retrieve_block() {
         rx_commands,
         rx_batch_messages,
         Arc::new(mock_handler),
+        PrimaryToWorkerNetwork::default(),
     );
 
     // WHEN we send a request to get a block
@@ -256,6 +257,7 @@ async fn test_successfully_retrieve_multiple_blocks() {
         rx_commands,
         rx_batch_messages,
         Arc::new(mock_handler),
+        PrimaryToWorkerNetwork::default(),
     );
 
     // WHEN we send a request to get a block
@@ -474,6 +476,7 @@ async fn test_batch_timeout() {
         rx_commands,
         rx_batch_messages,
         Arc::new(mock_handler),
+        PrimaryToWorkerNetwork::default(),
     );
 
     // WHEN we send a request to get a block
@@ -535,6 +538,7 @@ async fn test_return_error_when_certificate_is_missing() {
         rx_commands,
         rx_batch_messages,
         Arc::new(mock_handler),
+        PrimaryToWorkerNetwork::default(),
     );
 
     // WHEN we send a request to get a block
@@ -604,6 +608,7 @@ async fn test_return_error_when_certificate_is_missing_when_get_blocks() {
         rx_commands,
         rx_batch_messages,
         Arc::new(mock_handler),
+        PrimaryToWorkerNetwork::default(),
     );
 
     // WHEN we send a request to get a block

--- a/primary/src/tests/certificate_waiter_tests.rs
+++ b/primary/src/tests/certificate_waiter_tests.rs
@@ -10,6 +10,7 @@ use crate::{
 };
 use core::sync::atomic::AtomicU64;
 use crypto::{traits::KeyPair, Hash, SignatureService};
+use network::{PrimaryNetwork, PrimaryToWorkerNetwork};
 use prometheus::Registry;
 use std::{
     collections::BTreeSet,
@@ -78,6 +79,8 @@ async fn process_certificate_missing_parents_in_reverse() {
         rx_sync_headers,
         tx_headers_loopback,
         metrics.clone(),
+        PrimaryNetwork::default(),
+        PrimaryToWorkerNetwork::default(),
     );
 
     // Make a certificate waiter
@@ -110,6 +113,7 @@ async fn process_certificate_missing_parents_in_reverse() {
         tx_consensus,
         /* tx_proposer */ tx_parents,
         metrics.clone(),
+        PrimaryNetwork::default(),
     );
 
     // Generate headers in successive rounds
@@ -216,6 +220,8 @@ async fn process_certificate_check_gc_fires() {
         rx_sync_headers,
         tx_headers_loopback,
         metrics.clone(),
+        PrimaryNetwork::default(),
+        PrimaryToWorkerNetwork::default(),
     );
 
     // Make a certificate waiter
@@ -248,6 +254,7 @@ async fn process_certificate_check_gc_fires() {
         tx_consensus,
         /* tx_proposer */ tx_parents,
         metrics.clone(),
+        PrimaryNetwork::default(),
     );
 
     // Generate headers in successive rounds

--- a/primary/src/tests/core_tests.rs
+++ b/primary/src/tests/core_tests.rs
@@ -77,6 +77,7 @@ async fn process_header() {
         tx_consensus,
         /* tx_proposer */ tx_parents,
         metrics.clone(),
+        PrimaryNetwork::default(),
     );
 
     // Send a header to the core.
@@ -156,6 +157,7 @@ async fn process_header_missing_parent() {
         tx_consensus,
         /* tx_proposer */ tx_parents,
         metrics.clone(),
+        PrimaryNetwork::default(),
     );
 
     // Send a header to the core.
@@ -231,6 +233,7 @@ async fn process_header_missing_payload() {
         tx_consensus,
         /* tx_proposer */ tx_parents,
         metrics.clone(),
+        PrimaryNetwork::default(),
     );
 
     // Send a header that another node has created to the core.
@@ -318,6 +321,7 @@ async fn process_votes() {
         tx_consensus,
         /* tx_proposer */ tx_parents,
         metrics.clone(),
+        PrimaryNetwork::default(),
     );
 
     // Make the certificate we expect to receive.
@@ -410,6 +414,7 @@ async fn process_certificates() {
         tx_consensus,
         /* tx_proposer */ tx_parents,
         metrics.clone(),
+        PrimaryNetwork::default(),
     );
 
     // Send enough certificates to the core.
@@ -511,6 +516,7 @@ async fn shutdown_core() {
         tx_consensus,
         /* tx_proposer */ tx_parents,
         Arc::new(PrimaryMetrics::new(&Registry::new())),
+        PrimaryNetwork::default(),
     );
 
     // Shutdown the core.
@@ -587,6 +593,7 @@ async fn reconfigure_core() {
         tx_consensus,
         /* tx_proposer */ tx_parents,
         Arc::new(PrimaryMetrics::new(&Registry::new())),
+        PrimaryNetwork::default(),
     );
 
     // Change committee

--- a/primary/src/tests/header_waiter_tests.rs
+++ b/primary/src/tests/header_waiter_tests.rs
@@ -8,6 +8,7 @@ use crate::{
 };
 use core::sync::atomic::AtomicU64;
 use crypto::Hash;
+use network::{PrimaryNetwork, PrimaryToWorkerNetwork};
 use prometheus::Registry;
 use std::{sync::Arc, time::Duration};
 use test_utils::{fixture_header_with_payload, resolve_name_and_committee};
@@ -43,6 +44,8 @@ async fn successfully_synchronize_batches() {
         rx_synchronizer,
         tx_core,
         metrics,
+        PrimaryNetwork::default(),
+        PrimaryToWorkerNetwork::default(),
     );
 
     // AND a header

--- a/primary/src/tests/helper_tests.rs
+++ b/primary/src/tests/helper_tests.rs
@@ -5,6 +5,7 @@ use bincode::Options;
 use config::WorkerId;
 use crypto::Hash;
 use itertools::Itertools;
+use network::PrimaryNetwork;
 use std::{
     borrow::Borrow,
     collections::{HashMap, HashSet},
@@ -41,6 +42,7 @@ async fn test_process_certificates_stream_mode() {
         payload_store.clone(),
         rx_reconfigure,
         rx_primaries,
+        PrimaryNetwork::default(),
     );
 
     // AND some mock certificates
@@ -116,6 +118,7 @@ async fn test_process_certificates_batch_mode() {
         payload_store.clone(),
         rx_reconfigure,
         rx_primaries,
+        PrimaryNetwork::default(),
     );
 
     // AND some mock certificates
@@ -212,6 +215,7 @@ async fn test_process_payload_availability_success() {
         payload_store.clone(),
         rx_reconfigure,
         rx_primaries,
+        PrimaryNetwork::default(),
     );
 
     // AND some mock certificates
@@ -327,6 +331,7 @@ async fn test_process_payload_availability_when_failures() {
         payload_store.clone(),
         rx_reconfigure,
         rx_primaries,
+        PrimaryNetwork::default(),
     );
 
     // AND some mock certificates

--- a/primary/tests/integration_tests_validator_api.rs
+++ b/primary/tests/integration_tests_validator_api.rs
@@ -4,6 +4,7 @@ use arc_swap::ArcSwap;
 use config::{Parameters, WorkerId};
 use consensus::{dag::Dag, metrics::ConsensusMetrics};
 use crypto::{traits::KeyPair as _, Hash, KeyPair, PublicKey};
+use network::metrics::WorkerNetworkMetrics;
 use node::NodeStorage;
 use primary::{NetworkModel, PayloadToken, Primary, CHANNEL_CAPACITY};
 use prometheus::Registry;
@@ -128,6 +129,7 @@ async fn test_get_collections() {
     let metrics = Metrics {
         worker_metrics: Some(WorkerMetrics::new(&registry)),
         endpoint_metrics: Some(WorkerEndpointMetrics::new(&registry)),
+        network_metrics: Some(WorkerNetworkMetrics::new(&registry)),
     };
 
     // Spawn a `Worker` instance.
@@ -334,6 +336,7 @@ async fn test_remove_collections() {
     let metrics = Metrics {
         worker_metrics: Some(WorkerMetrics::new(&registry)),
         endpoint_metrics: Some(WorkerEndpointMetrics::new(&registry)),
+        network_metrics: Some(WorkerNetworkMetrics::new(&registry)),
     };
 
     // Spawn a `Worker` instance.
@@ -878,10 +881,11 @@ async fn test_get_collections_with_missing_certificates() {
         &Registry::new(),
     );
 
-    let registry = Registry::new();
+    let registry_1 = Registry::new();
     let metrics_1 = Metrics {
-        worker_metrics: Some(WorkerMetrics::new(&registry)),
-        endpoint_metrics: Some(WorkerEndpointMetrics::new(&registry)),
+        worker_metrics: Some(WorkerMetrics::new(&registry_1)),
+        endpoint_metrics: Some(WorkerEndpointMetrics::new(&registry_1)),
+        network_metrics: Some(WorkerNetworkMetrics::new(&registry_1)),
     };
 
     // Spawn a `Worker` instance for primary 1.
@@ -918,10 +922,11 @@ async fn test_get_collections_with_missing_certificates() {
         &Registry::new(),
     );
 
-    let registry = Registry::new();
+    let registry_2 = Registry::new();
     let metrics_2 = Metrics {
-        worker_metrics: Some(WorkerMetrics::new(&registry)),
-        endpoint_metrics: Some(WorkerEndpointMetrics::new(&registry)),
+        worker_metrics: Some(WorkerMetrics::new(&registry_2)),
+        endpoint_metrics: Some(WorkerEndpointMetrics::new(&registry_2)),
+        network_metrics: Some(WorkerNetworkMetrics::new(&registry_2)),
     };
 
     // Spawn a `Worker` instance for primary 2.

--- a/worker/src/helper.rs
+++ b/worker/src/helper.rs
@@ -46,6 +46,7 @@ impl Helper {
         rx_reconfigure: watch::Receiver<ReconfigureNotification>,
         rx_worker_request: Receiver<(Vec<BatchDigest>, PublicKey)>,
         rx_client_request: Receiver<(Vec<BatchDigest>, Sender<SerializedBatchMessage>)>,
+        network: WorkerNetwork,
     ) -> JoinHandle<()> {
         tokio::spawn(async move {
             Self {
@@ -55,7 +56,7 @@ impl Helper {
                 rx_reconfigure,
                 rx_worker_request,
                 rx_client_request,
-                network: WorkerNetwork::default(),
+                network,
             }
             .run()
             .await;

--- a/worker/src/metrics.rs
+++ b/worker/src/metrics.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use mysten_network::metrics::MetricsCallbackProvider;
+use network::metrics::WorkerNetworkMetrics;
 use prometheus::{
     default_registry, register_histogram_vec_with_registry, register_int_counter_vec_with_registry,
     register_int_gauge_vec_with_registry, HistogramVec, IntCounterVec, IntGaugeVec, Registry,
@@ -12,11 +13,10 @@ use tonic::Code;
 pub struct Metrics {
     pub worker_metrics: Option<WorkerMetrics>,
     pub endpoint_metrics: Option<WorkerEndpointMetrics>,
+    pub network_metrics: Option<WorkerNetworkMetrics>,
 }
 
-/// Initialises the metrics. Should be called only once when the worker
-/// node is initialised, otherwise it will lead to erroneously creating
-/// multiple registries.
+/// Initialises the metrics
 pub fn initialise_metrics(metrics_registry: &Registry) -> Metrics {
     // Essential/core metrics across the worker node
     let node_metrics = WorkerMetrics::new(metrics_registry);
@@ -24,9 +24,13 @@ pub fn initialise_metrics(metrics_registry: &Registry) -> Metrics {
     // Endpoint metrics
     let endpoint_metrics = WorkerEndpointMetrics::new(metrics_registry);
 
+    // The network metrics
+    let network_metrics = WorkerNetworkMetrics::new(metrics_registry);
+
     Metrics {
         worker_metrics: Some(node_metrics),
         endpoint_metrics: Some(endpoint_metrics),
+        network_metrics: Some(network_metrics),
     }
 }
 

--- a/worker/src/quorum_waiter.rs
+++ b/worker/src/quorum_waiter.rs
@@ -47,6 +47,7 @@ impl QuorumWaiter {
         rx_reconfigure: watch::Receiver<ReconfigureNotification>,
         rx_message: Receiver<Batch>,
         tx_batch: Sender<Vec<u8>>,
+        network: WorkerNetwork,
     ) -> JoinHandle<()> {
         tokio::spawn(async move {
             Self {
@@ -56,7 +57,7 @@ impl QuorumWaiter {
                 rx_reconfigure,
                 rx_message,
                 tx_batch,
-                network: WorkerNetwork::default(),
+                network,
             }
             .run()
             .await;

--- a/worker/src/synchronizer.rs
+++ b/worker/src/synchronizer.rs
@@ -82,6 +82,7 @@ impl Synchronizer {
         tx_reconfigure: watch::Sender<ReconfigureNotification>,
         tx_primary: Sender<WorkerPrimaryMessage>,
         metrics: Arc<WorkerMetrics>,
+        network: WorkerNetwork,
     ) -> JoinHandle<()> {
         tokio::spawn(async move {
             Self {
@@ -93,7 +94,7 @@ impl Synchronizer {
                 sync_retry_delay,
                 sync_retry_nodes,
                 rx_message,
-                network: WorkerNetwork::default(),
+                network,
                 round: Round::default(),
                 pending: HashMap::new(),
                 tx_reconfigure,

--- a/worker/src/tests/helper_tests.rs
+++ b/worker/src/tests/helper_tests.rs
@@ -44,6 +44,7 @@ async fn worker_batch_reply() {
         rx_reconfiguration,
         rx_worker_request,
         rx_client_request,
+        WorkerNetwork::default(),
     );
 
     // Spawn a listener to receive the batch reply.
@@ -91,6 +92,7 @@ async fn client_batch_reply() {
         rx_reconfiguration,
         rx_worker_request,
         rx_client_request,
+        WorkerNetwork::default(),
     );
 
     // Send batch request.

--- a/worker/src/tests/quorum_waiter_tests.rs
+++ b/worker/src/tests/quorum_waiter_tests.rs
@@ -25,6 +25,7 @@ async fn wait_for_quorum() {
         rx_reconfiguration,
         rx_message,
         tx_batch,
+        WorkerNetwork::default(),
     );
 
     // Make a batch.

--- a/worker/src/tests/synchronizer_tests.rs
+++ b/worker/src/tests/synchronizer_tests.rs
@@ -44,6 +44,7 @@ async fn synchronize() {
         tx_reconfiguration,
         tx_primary,
         metrics,
+        WorkerNetwork::default(),
     );
 
     // Spawn a listener to receive our batch requests.
@@ -94,6 +95,7 @@ async fn test_successful_request_batch() {
         tx_reconfiguration,
         tx_primary,
         metrics,
+        WorkerNetwork::default(),
     );
 
     // Create a dummy batch and store
@@ -156,6 +158,7 @@ async fn test_request_batch_not_found() {
         tx_reconfiguration,
         tx_primary,
         metrics,
+        WorkerNetwork::default(),
     );
 
     // The non existing batch id
@@ -217,6 +220,7 @@ async fn test_successful_batch_delete() {
         tx_reconfiguration,
         tx_primary,
         metrics,
+        WorkerNetwork::default(),
     );
 
     // Create dummy batches and store them

--- a/worker/src/tests/worker_tests.rs
+++ b/worker/src/tests/worker_tests.rs
@@ -35,10 +35,12 @@ async fn handle_clients_transactions() {
     )
     .unwrap();
     let store = Store::new(db);
+
     let registry = Registry::new();
     let metrics = Metrics {
         worker_metrics: Some(WorkerMetrics::new(&registry)),
         endpoint_metrics: Some(WorkerEndpointMetrics::new(&registry)),
+        network_metrics: Some(WorkerNetworkMetrics::new(&registry)),
     };
 
     // Spawn a `Worker` instance.
@@ -117,6 +119,7 @@ async fn handle_client_batch_request() {
     let metrics = Metrics {
         worker_metrics: Some(WorkerMetrics::new(&registry)),
         endpoint_metrics: Some(WorkerEndpointMetrics::new(&registry)),
+        network_metrics: Some(WorkerNetworkMetrics::new(&registry)),
     };
 
     // Spawn a `Worker` instance.

--- a/worker/src/worker.rs
+++ b/worker/src/worker.rs
@@ -11,6 +11,7 @@ use config::{Parameters, SharedCommittee, WorkerId};
 use crypto::PublicKey;
 use futures::{Stream, StreamExt};
 use multiaddr::{Multiaddr, Protocol};
+use network::{metrics::WorkerNetworkMetrics, WorkerNetwork};
 use primary::PrimaryWorkerMessage;
 use std::{net::Ipv4Addr, pin::Pin, sync::Arc};
 use store::Store;
@@ -75,6 +76,7 @@ impl Worker {
 
         let node_metrics = Arc::new(metrics.worker_metrics.unwrap());
         let endpoint_metrics = metrics.endpoint_metrics.unwrap();
+        let network_metrics = Arc::new(metrics.network_metrics.unwrap());
 
         // Spawn all worker tasks.
         let (tx_primary, rx_primary) = channel(CHANNEL_CAPACITY);
@@ -88,11 +90,19 @@ impl Worker {
             &tx_reconfigure,
             tx_primary.clone(),
             endpoint_metrics,
+            network_metrics.clone(),
         );
-        let worker_flow_handles =
-            worker.handle_workers_messages(&tx_reconfigure, tx_primary.clone());
-        let primary_flow_handles =
-            worker.handle_primary_messages(tx_reconfigure, tx_primary, node_metrics);
+        let worker_flow_handles = worker.handle_workers_messages(
+            &tx_reconfigure,
+            tx_primary.clone(),
+            network_metrics.clone(),
+        );
+        let primary_flow_handles = worker.handle_primary_messages(
+            tx_reconfigure,
+            tx_primary,
+            node_metrics,
+            network_metrics,
+        );
 
         // The `PrimaryConnector` allows the worker to send messages to its primary.
         let handle = PrimaryConnector::spawn(name, initial_committee, rx_reconfigure, rx_primary);
@@ -122,6 +132,7 @@ impl Worker {
         tx_reconfigure: watch::Sender<ReconfigureNotification>,
         tx_primary: Sender<WorkerPrimaryMessage>,
         node_metrics: Arc<WorkerMetrics>,
+        network_metrics: Arc<WorkerNetworkMetrics>,
     ) -> Vec<JoinHandle<()>> {
         let (tx_synchronizer, rx_synchronizer) = channel(CHANNEL_CAPACITY);
 
@@ -140,6 +151,10 @@ impl Worker {
 
         // The `Synchronizer` is responsible to keep the worker in sync with the others. It handles the commands
         // it receives from the primary (which are mainly notifications that we are out of sync).
+        let worker_network = WorkerNetwork::new(network::metrics::Metrics::new(
+            network_metrics,
+            "synchronizer".to_string(),
+        ));
         let handle = Synchronizer::spawn(
             self.name.clone(),
             self.id,
@@ -152,6 +167,7 @@ impl Worker {
             tx_reconfigure,
             tx_primary,
             node_metrics,
+            worker_network,
         );
 
         info!(
@@ -168,6 +184,7 @@ impl Worker {
         tx_reconfigure: &watch::Sender<ReconfigureNotification>,
         tx_primary: Sender<WorkerPrimaryMessage>,
         endpoint_metrics: WorkerEndpointMetrics,
+        network_metrics: Arc<WorkerNetworkMetrics>,
     ) -> Vec<JoinHandle<()>> {
         let (tx_batch_maker, rx_batch_maker) = channel(CHANNEL_CAPACITY);
         let (tx_quorum_waiter, rx_quorum_waiter) = channel(CHANNEL_CAPACITY);
@@ -203,6 +220,10 @@ impl Worker {
 
         // The `QuorumWaiter` waits for 2f authorities to acknowledge reception of the batch. It then forwards
         // the batch to the `Processor`.
+        let worker_network = WorkerNetwork::new(network::metrics::Metrics::new(
+            network_metrics,
+            "quorum_waiter".to_string(),
+        ));
         let quorum_waiter_handle = QuorumWaiter::spawn(
             self.name.clone(),
             self.id,
@@ -210,6 +231,7 @@ impl Worker {
             tx_reconfigure.subscribe(),
             /* rx_message */ rx_quorum_waiter,
             /* tx_batch */ tx_processor,
+            worker_network,
         );
 
         // The `Processor` hashes and stores the batch. It then forwards the batch's digest to the `PrimaryConnector`
@@ -241,6 +263,7 @@ impl Worker {
         &self,
         tx_reconfigure: &watch::Sender<ReconfigureNotification>,
         tx_primary: Sender<WorkerPrimaryMessage>,
+        network_metrics: Arc<WorkerNetworkMetrics>,
     ) -> Vec<JoinHandle<()>> {
         let (tx_worker_helper, rx_worker_helper) = channel(CHANNEL_CAPACITY);
         let (tx_client_helper, rx_client_helper) = channel(CHANNEL_CAPACITY);
@@ -268,6 +291,10 @@ impl Worker {
         );
 
         // The `Helper` is dedicated to reply to batch requests from other workers.
+        let worker_network = WorkerNetwork::new(network::metrics::Metrics::new(
+            network_metrics,
+            "worker_helper".to_string(),
+        ));
         let helper_handle = Helper::spawn(
             self.id,
             (*(*(*self.committee).load()).clone()).clone(),
@@ -275,6 +302,7 @@ impl Worker {
             tx_reconfigure.subscribe(),
             /* rx_worker_request */ rx_worker_helper,
             /* rx_client_request */ rx_client_helper,
+            worker_network,
         );
 
         // This `Processor` hashes and stores the batches we receive from the other workers. It then forwards the


### PR DESCRIPTION
Following the work on https://github.com/MystenLabs/narwhal/pull/463 I believe that @velvia made a good point on adding metrics to monitor when we reach the maximum of capacity on concurrent tasks. Took the opportunity to add those since we are still hot on adding metrics and keep them until we stabilise things. Once we gain strong confidence on our nodes and we consider this an implementation detail we can probably remove.