### PR TITLE
[Lint] Run clang-format for protobuf

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,4 +1,5 @@
 # For proto file format
 BasedOnStyle: Google
 IndentWidth: 4
+ColumnLimit: 100
 

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,4 @@
+# For proto file format
+BasedOnStyle: Google
+IndentWidth: 4
+

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@latest
+        uses: actions/checkout@v3
         with:
           # Full git history is needed to get a proper list of changed files within `super-linter`
           fetch-depth: 0
@@ -27,7 +27,7 @@ jobs:
           fallback-style: 'Google'
   
       - name: Lint shell, Docker and protobuf
-        uses: github/super-linter@slim-v4
+        uses: github/super-linter/slim@v4
         env:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: main

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -1,4 +1,4 @@
-name: Check scripts & Docker file
+name: Check scripts, Docker file and profobuf
 
 on:
   push:
@@ -9,32 +9,24 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
-  shellcheck:
-    name: Check shell scripts
-    runs-on: [ubuntu-latest]
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Run ShellCheck
-      uses: ludeeus/action-shellcheck@master
-      with:
-        severity: error
-
-  docker-lint:
-    name: Lint Docker file
+  lint:
+    name: Lint shell, docker and protobuf files
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: dorny/paths-filter@v2
-        id: filter
+      - name: Checkout Code
+        uses: actions/checkout@latest
         with:
-          filters: |
-            docker:
-              - 'Docker/**'
-      - name: Lint Docker file
-        if: steps.filter.outputs.docker == 'true'
-        uses: hadolint/hadolint-action@v2.1.0
-        with:
-          failure-threshold: error
-          dockerfile: Docker/Dockerfile
+          # Full git history is needed to get a proper list of changed files within `super-linter`
+          fetch-depth: 0
+
+      - name: Lint Code Base
+        uses: github/super-linter@slim-v4
+        env:
+          VALIDATE_ALL_CODEBASE: false
+          DEFAULT_BRANCH: main
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Select file types to lint. Python and Rust linters are configured separately.
+          VALIDATE_SHELL_SHFMT: true
+          VALIDATE_DOCKERFILE_HADOLINT: true
+          VALIDATE_PROTOBUF: true

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -20,6 +20,12 @@ jobs:
           # Full git history is needed to get a proper list of changed files within `super-linter`
           fetch-depth: 0
 
+      - name: Run clang-format for protobuf
+        uses: jidicula/clang-format-action@v4.6.2
+        with:
+          clang-format-version: '14'
+          fallback-style: 'Google'
+  
       - name: Lint Code Base
         uses: github/super-linter@slim-v4
         env:

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -10,7 +10,6 @@ on:
 
 jobs:
   lint:
-    name: Lint shell, docker and protobuf files
     runs-on: ubuntu-latest
 
     steps:
@@ -35,4 +34,5 @@ jobs:
           # Select file types to lint. Python and Rust linters are configured separately.
           VALIDATE_SHELL_SHFMT: true
           VALIDATE_DOCKERFILE_HADOLINT: true
-          VALIDATE_PROTOBUF: true
+          # Enable after fixing proto lint issues.
+          # VALIDATE_PROTOBUF: true

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -23,7 +23,6 @@ jobs:
         uses: jidicula/clang-format-action@v4.6.2
         with:
           clang-format-version: '14'
-          fallback-style: 'Google'
   
       - name: Lint shell, Docker and protobuf
         uses: github/super-linter/slim@v4

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -1,4 +1,4 @@
-name: Lint shell, Docker and protobuf files
+name: Miscellaneous Lint
 
 on:
   push:
@@ -20,13 +20,13 @@ jobs:
           # Full git history is needed to get a proper list of changed files within `super-linter`
           fetch-depth: 0
 
-      - name: Run clang-format for protobuf
+      - name: Protobuf format
         uses: jidicula/clang-format-action@v4.6.2
         with:
           clang-format-version: '14'
           fallback-style: 'Google'
   
-      - name: Lint Code Base
+      - name: Lint shell, Docker and protobuf
         uses: github/super-linter@slim-v4
         env:
           VALIDATE_ALL_CODEBASE: false

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -1,4 +1,4 @@
-name: Check scripts, Docker file and profobuf
+name: Lint shell, Docker and protobuf files
 
 on:
   push:

--- a/examples/protos/narwhal.proto
+++ b/examples/protos/narwhal.proto
@@ -6,191 +6,194 @@ syntax = "proto3";
 package narwhal;
 
 message CertificateDigest {
-    bytes digest = 1;
+  bytes digest = 1;
 }
 
 message BatchDigest {
-    bytes digest = 1;
+  bytes digest = 1;
 }
 
 message Batch {
-    repeated Transaction transaction = 1;
+  repeated Transaction transaction = 1;
 }
 
 message Transaction {
-    bytes transaction = 1;
+  bytes transaction = 1;
 }
 
- enum CollectionErrorType {
-    COLLECTION_NOT_FOUND = 0;
-    COLLECTION_TIMEOUT = 1;
-    COLLECTION_ERROR = 2;
+enum CollectionErrorType {
+  COLLECTION_NOT_FOUND = 0;
+  COLLECTION_TIMEOUT = 1;
+  COLLECTION_ERROR = 2;
 }
 
 message CollectionError {
-    CertificateDigest id = 1;
-    CollectionErrorType error = 2;
+  CertificateDigest id = 1;
+  CollectionErrorType error = 2;
 }
 
 message BatchMessage {
-    BatchDigest id = 1;
-    Batch transactions = 2;
+  BatchDigest id = 1;
+  Batch transactions = 2;
 }
 
 message PrimaryAddresses {
-    MultiAddr primary_to_primary = 1;
-    MultiAddr worker_to_primary = 2;
+  MultiAddr primary_to_primary = 1;
+  MultiAddr worker_to_primary = 2;
 }
 
 message MultiAddr {
-    string address = 1;
+  string address = 1;
 }
 
 message PublicKey {
-    bytes bytes = 1;
+  bytes bytes = 1;
 }
 
 message ValidatorData {
-    PublicKey public_key = 1;
-    int64 stake_weight = 2;
-    PrimaryAddresses primary_addresses = 3;
+  PublicKey public_key = 1;
+  int64 stake_weight = 2;
+  PrimaryAddresses primary_addresses = 3;
 }
 
 message CollectionRetrievalResult {
-    oneof retrieval_result {
-        BatchMessage batch = 1;
-        CollectionError error = 2;
-    }
+  oneof retrieval_result {
+    BatchMessage batch = 1;
+    CollectionError error = 2;
+  }
 }
 
 message GetCollectionsRequest {
-    // List of collections to be retreived.
-    repeated CertificateDigest collection_ids = 1;
+  // List of collections to be retreived.
+  repeated CertificateDigest collection_ids = 1;
 }
 
 message GetCollectionsResponse {
-    // TODO: Revisit this for spec compliance.  
-    // List of retrieval results of collections.
-    repeated CollectionRetrievalResult result = 1;
+  // TODO: Revisit this for spec compliance.
+  // List of retrieval results of collections.
+  repeated CollectionRetrievalResult result = 1;
 }
 
 message RemoveCollectionsRequest {
-    // List of collections to be removed.
-    repeated CertificateDigest collection_ids = 1;
+  // List of collections to be removed.
+  repeated CertificateDigest collection_ids = 1;
 }
 
 message ReadCausalRequest {
-    // A collection for which a sequence of related collections are to be retrieved.
-    CertificateDigest collection_id = 1;
+  // A collection for which a sequence of related collections are to be
+  // retrieved.
+  CertificateDigest collection_id = 1;
 }
 
 message ReadCausalResponse {
-    // Resulting sequence of collections from DAG walk.
-    repeated CertificateDigest collection_ids = 1;
+  // Resulting sequence of collections from DAG walk.
+  repeated CertificateDigest collection_ids = 1;
 }
 
 message RoundsRequest {
-    /// The validator's key for which we want to retrieve
-    /// the available rounds.
-    PublicKey public_key = 1;
+  /// The validator's key for which we want to retrieve
+  /// the available rounds.
+  PublicKey public_key = 1;
 }
 
 message RoundsResponse {
-    /// The oldest round for which the node has available
-    /// blocks to propose for the defined validator.
-    uint64 oldest_round = 1;
+  /// The oldest round for which the node has available
+  /// blocks to propose for the defined validator.
+  uint64 oldest_round = 1;
 
-    /// The newest (latest) round for which the node has available
-    /// blocks to propose for the defined validator.
-    uint64 newest_round = 2;
+  /// The newest (latest) round for which the node has available
+  /// blocks to propose for the defined validator.
+  uint64 newest_round = 2;
 }
 
 message NodeReadCausalRequest {
-    PublicKey public_key = 1;
-    uint64 round = 2;
+  PublicKey public_key = 1;
+  uint64 round = 2;
 }
 
 message NodeReadCausalResponse {
-    // Resulting sequence of collections from DAG walk.
-    repeated CertificateDigest collection_ids = 1;
+  // Resulting sequence of collections from DAG walk.
+  repeated CertificateDigest collection_ids = 1;
 }
 
 message NewNetworkInfoRequest {
-    uint32 epoch_number = 1;
-    repeated ValidatorData validators = 2;
+  uint32 epoch_number = 1;
+  repeated ValidatorData validators = 2;
 }
 
 message NewEpochRequest {
-    uint32 epoch_number = 1;
-    repeated ValidatorData validators = 2;
+  uint32 epoch_number = 1;
+  repeated ValidatorData validators = 2;
 }
 
 // A bincode encoded payload. This is intended to be used in the short-term
 // while we don't have good protobuf definitions for Narwhal types
 message BincodeEncodedPayload {
-    bytes payload = 1;
-  }
-  
-// Empty message for when we don't have anything to return
-message Empty {
+  bytes payload = 1;
 }
+
+// Empty message for when we don't have anything to return
+message Empty {}
 
 // The consensus to mempool interface for validator actions.
 service Validator {
-    // Returns collection contents for each requested collection.
-    rpc GetCollections (GetCollectionsRequest) returns (GetCollectionsResponse);
-    // Expunges collections from the mempool.
-    rpc RemoveCollections (RemoveCollectionsRequest) returns (Empty);
-    // Returns collections along a DAG walk with a well-defined starting point.
-    rpc ReadCausal (ReadCausalRequest) returns (ReadCausalResponse);
+  // Returns collection contents for each requested collection.
+  rpc GetCollections(GetCollectionsRequest) returns (GetCollectionsResponse);
+  // Expunges collections from the mempool.
+  rpc RemoveCollections(RemoveCollectionsRequest) returns (Empty);
+  // Returns collections along a DAG walk with a well-defined starting point.
+  rpc ReadCausal(ReadCausalRequest) returns (ReadCausalResponse);
 }
 
 /// The API that hosts the endpoints that should be used to help
 /// proposing a block.
 service Proposer {
-  rpc Rounds (RoundsRequest) returns (RoundsResponse);
-  // Returns the read_causal obtained by starting the DAG walk at the collection 
-  // proposed by the input authority (as indicated by their public key) at the input round
-  rpc NodeReadCausal (NodeReadCausalRequest) returns (NodeReadCausalResponse);
+  rpc Rounds(RoundsRequest) returns (RoundsResponse);
+  // Returns the read_causal obtained by starting the DAG walk at the collection
+  // proposed by the input authority (as indicated by their public key) at the
+  // input round
+  rpc NodeReadCausal(NodeReadCausalRequest) returns (NodeReadCausalResponse);
 }
 
 service Configuration {
-    // Signals a new epoch
-    rpc NewEpoch (NewEpochRequest) returns (Empty);
-    // Signals a change in networking info
-    rpc NewNetworkInfo (NewNetworkInfoRequest) returns (Empty);
+  // Signals a new epoch
+  rpc NewEpoch(NewEpochRequest) returns (Empty);
+  // Signals a change in networking info
+  rpc NewNetworkInfo(NewNetworkInfoRequest) returns (Empty);
 }
 
 // The primary-to-primary interface
 service PrimaryToPrimary {
   // Sends a message
-  rpc SendMessage (BincodeEncodedPayload) returns (Empty) {}
+  rpc SendMessage(BincodeEncodedPayload) returns (Empty) {}
 }
 
 // The worker-to-worker interface
 service WorkerToWorker {
   // Sends a worker message
-  rpc SendMessage (BincodeEncodedPayload) returns (Empty) {}
-  // requests a number of batches that the service then streams back to the client
-  rpc ClientBatchRequest (BincodeEncodedPayload) returns (stream BincodeEncodedPayload) {}
+  rpc SendMessage(BincodeEncodedPayload) returns (Empty) {}
+  // requests a number of batches that the service then streams back to the
+  // client
+  rpc ClientBatchRequest(BincodeEncodedPayload)
+      returns (stream BincodeEncodedPayload) {}
 }
 
 // The worker-to-primary interface
 service WorkerToPrimary {
   // Sends a message
-  rpc SendMessage (BincodeEncodedPayload) returns (Empty) {}
+  rpc SendMessage(BincodeEncodedPayload) returns (Empty) {}
 }
 
 // The primary-to-worker interface
 service PrimaryToWorker {
   // Sends a message
-  rpc SendMessage (BincodeEncodedPayload) returns (Empty) {}
+  rpc SendMessage(BincodeEncodedPayload) returns (Empty) {}
 }
 
 service Transactions {
-    // Submit a Transactions
-    rpc SubmitTransaction (Transaction) returns (Empty) {}
+  // Submit a Transactions
+  rpc SubmitTransaction(Transaction) returns (Empty) {}
 
-    // Submit a Transactions
-    rpc SubmitTransactionStream (stream Transaction) returns (Empty) {}
+  // Submit a Transactions
+  rpc SubmitTransactionStream(stream Transaction) returns (Empty) {}
 }

--- a/examples/protos/narwhal.proto
+++ b/examples/protos/narwhal.proto
@@ -80,8 +80,7 @@ message RemoveCollectionsRequest {
 }
 
 message ReadCausalRequest {
-    // A collection for which a sequence of related collections are to be
-    // retrieved.
+    // A collection for which a sequence of related collections are to be retrieved.
     CertificateDigest collection_id = 1;
 }
 
@@ -149,9 +148,8 @@ service Validator {
 /// proposing a block.
 service Proposer {
     rpc Rounds(RoundsRequest) returns (RoundsResponse);
-    // Returns the read_causal obtained by starting the DAG walk at the
-    // collection proposed by the input authority (as indicated by their public
-    // key) at the input round
+    // Returns the read_causal obtained by starting the DAG walk at the collection
+    // proposed by the input authority (as indicated by their public key) at the input round
     rpc NodeReadCausal(NodeReadCausalRequest) returns (NodeReadCausalResponse);
 }
 
@@ -172,10 +170,8 @@ service PrimaryToPrimary {
 service WorkerToWorker {
     // Sends a worker message
     rpc SendMessage(BincodeEncodedPayload) returns (Empty) {}
-    // requests a number of batches that the service then streams back to the
-    // client
-    rpc ClientBatchRequest(BincodeEncodedPayload)
-        returns (stream BincodeEncodedPayload) {}
+    // requests a number of batches that the service then streams back to the client
+    rpc ClientBatchRequest(BincodeEncodedPayload) returns (stream BincodeEncodedPayload) {}
 }
 
 // The worker-to-primary interface

--- a/examples/protos/narwhal.proto
+++ b/examples/protos/narwhal.proto
@@ -6,130 +6,130 @@ syntax = "proto3";
 package narwhal;
 
 message CertificateDigest {
-  bytes digest = 1;
+    bytes digest = 1;
 }
 
 message BatchDigest {
-  bytes digest = 1;
+    bytes digest = 1;
 }
 
 message Batch {
-  repeated Transaction transaction = 1;
+    repeated Transaction transaction = 1;
 }
 
 message Transaction {
-  bytes transaction = 1;
+    bytes transaction = 1;
 }
 
 enum CollectionErrorType {
-  COLLECTION_NOT_FOUND = 0;
-  COLLECTION_TIMEOUT = 1;
-  COLLECTION_ERROR = 2;
+    COLLECTION_NOT_FOUND = 0;
+    COLLECTION_TIMEOUT = 1;
+    COLLECTION_ERROR = 2;
 }
 
 message CollectionError {
-  CertificateDigest id = 1;
-  CollectionErrorType error = 2;
+    CertificateDigest id = 1;
+    CollectionErrorType error = 2;
 }
 
 message BatchMessage {
-  BatchDigest id = 1;
-  Batch transactions = 2;
+    BatchDigest id = 1;
+    Batch transactions = 2;
 }
 
 message PrimaryAddresses {
-  MultiAddr primary_to_primary = 1;
-  MultiAddr worker_to_primary = 2;
+    MultiAddr primary_to_primary = 1;
+    MultiAddr worker_to_primary = 2;
 }
 
 message MultiAddr {
-  string address = 1;
+    string address = 1;
 }
 
 message PublicKey {
-  bytes bytes = 1;
+    bytes bytes = 1;
 }
 
 message ValidatorData {
-  PublicKey public_key = 1;
-  int64 stake_weight = 2;
-  PrimaryAddresses primary_addresses = 3;
+    PublicKey public_key = 1;
+    int64 stake_weight = 2;
+    PrimaryAddresses primary_addresses = 3;
 }
 
 message CollectionRetrievalResult {
-  oneof retrieval_result {
-    BatchMessage batch = 1;
-    CollectionError error = 2;
-  }
+    oneof retrieval_result {
+        BatchMessage batch = 1;
+        CollectionError error = 2;
+    }
 }
 
 message GetCollectionsRequest {
-  // List of collections to be retreived.
-  repeated CertificateDigest collection_ids = 1;
+    // List of collections to be retreived.
+    repeated CertificateDigest collection_ids = 1;
 }
 
 message GetCollectionsResponse {
-  // TODO: Revisit this for spec compliance.
-  // List of retrieval results of collections.
-  repeated CollectionRetrievalResult result = 1;
+    // TODO: Revisit this for spec compliance.
+    // List of retrieval results of collections.
+    repeated CollectionRetrievalResult result = 1;
 }
 
 message RemoveCollectionsRequest {
-  // List of collections to be removed.
-  repeated CertificateDigest collection_ids = 1;
+    // List of collections to be removed.
+    repeated CertificateDigest collection_ids = 1;
 }
 
 message ReadCausalRequest {
-  // A collection for which a sequence of related collections are to be
-  // retrieved.
-  CertificateDigest collection_id = 1;
+    // A collection for which a sequence of related collections are to be
+    // retrieved.
+    CertificateDigest collection_id = 1;
 }
 
 message ReadCausalResponse {
-  // Resulting sequence of collections from DAG walk.
-  repeated CertificateDigest collection_ids = 1;
+    // Resulting sequence of collections from DAG walk.
+    repeated CertificateDigest collection_ids = 1;
 }
 
 message RoundsRequest {
-  /// The validator's key for which we want to retrieve
-  /// the available rounds.
-  PublicKey public_key = 1;
+    /// The validator's key for which we want to retrieve
+    /// the available rounds.
+    PublicKey public_key = 1;
 }
 
 message RoundsResponse {
-  /// The oldest round for which the node has available
-  /// blocks to propose for the defined validator.
-  uint64 oldest_round = 1;
+    /// The oldest round for which the node has available
+    /// blocks to propose for the defined validator.
+    uint64 oldest_round = 1;
 
-  /// The newest (latest) round for which the node has available
-  /// blocks to propose for the defined validator.
-  uint64 newest_round = 2;
+    /// The newest (latest) round for which the node has available
+    /// blocks to propose for the defined validator.
+    uint64 newest_round = 2;
 }
 
 message NodeReadCausalRequest {
-  PublicKey public_key = 1;
-  uint64 round = 2;
+    PublicKey public_key = 1;
+    uint64 round = 2;
 }
 
 message NodeReadCausalResponse {
-  // Resulting sequence of collections from DAG walk.
-  repeated CertificateDigest collection_ids = 1;
+    // Resulting sequence of collections from DAG walk.
+    repeated CertificateDigest collection_ids = 1;
 }
 
 message NewNetworkInfoRequest {
-  uint32 epoch_number = 1;
-  repeated ValidatorData validators = 2;
+    uint32 epoch_number = 1;
+    repeated ValidatorData validators = 2;
 }
 
 message NewEpochRequest {
-  uint32 epoch_number = 1;
-  repeated ValidatorData validators = 2;
+    uint32 epoch_number = 1;
+    repeated ValidatorData validators = 2;
 }
 
 // A bincode encoded payload. This is intended to be used in the short-term
 // while we don't have good protobuf definitions for Narwhal types
 message BincodeEncodedPayload {
-  bytes payload = 1;
+    bytes payload = 1;
 }
 
 // Empty message for when we don't have anything to return
@@ -137,63 +137,63 @@ message Empty {}
 
 // The consensus to mempool interface for validator actions.
 service Validator {
-  // Returns collection contents for each requested collection.
-  rpc GetCollections(GetCollectionsRequest) returns (GetCollectionsResponse);
-  // Expunges collections from the mempool.
-  rpc RemoveCollections(RemoveCollectionsRequest) returns (Empty);
-  // Returns collections along a DAG walk with a well-defined starting point.
-  rpc ReadCausal(ReadCausalRequest) returns (ReadCausalResponse);
+    // Returns collection contents for each requested collection.
+    rpc GetCollections(GetCollectionsRequest) returns (GetCollectionsResponse);
+    // Expunges collections from the mempool.
+    rpc RemoveCollections(RemoveCollectionsRequest) returns (Empty);
+    // Returns collections along a DAG walk with a well-defined starting point.
+    rpc ReadCausal(ReadCausalRequest) returns (ReadCausalResponse);
 }
 
 /// The API that hosts the endpoints that should be used to help
 /// proposing a block.
 service Proposer {
-  rpc Rounds(RoundsRequest) returns (RoundsResponse);
-  // Returns the read_causal obtained by starting the DAG walk at the collection
-  // proposed by the input authority (as indicated by their public key) at the
-  // input round
-  rpc NodeReadCausal(NodeReadCausalRequest) returns (NodeReadCausalResponse);
+    rpc Rounds(RoundsRequest) returns (RoundsResponse);
+    // Returns the read_causal obtained by starting the DAG walk at the
+    // collection proposed by the input authority (as indicated by their public
+    // key) at the input round
+    rpc NodeReadCausal(NodeReadCausalRequest) returns (NodeReadCausalResponse);
 }
 
 service Configuration {
-  // Signals a new epoch
-  rpc NewEpoch(NewEpochRequest) returns (Empty);
-  // Signals a change in networking info
-  rpc NewNetworkInfo(NewNetworkInfoRequest) returns (Empty);
+    // Signals a new epoch
+    rpc NewEpoch(NewEpochRequest) returns (Empty);
+    // Signals a change in networking info
+    rpc NewNetworkInfo(NewNetworkInfoRequest) returns (Empty);
 }
 
 // The primary-to-primary interface
 service PrimaryToPrimary {
-  // Sends a message
-  rpc SendMessage(BincodeEncodedPayload) returns (Empty) {}
+    // Sends a message
+    rpc SendMessage(BincodeEncodedPayload) returns (Empty) {}
 }
 
 // The worker-to-worker interface
 service WorkerToWorker {
-  // Sends a worker message
-  rpc SendMessage(BincodeEncodedPayload) returns (Empty) {}
-  // requests a number of batches that the service then streams back to the
-  // client
-  rpc ClientBatchRequest(BincodeEncodedPayload)
-      returns (stream BincodeEncodedPayload) {}
+    // Sends a worker message
+    rpc SendMessage(BincodeEncodedPayload) returns (Empty) {}
+    // requests a number of batches that the service then streams back to the
+    // client
+    rpc ClientBatchRequest(BincodeEncodedPayload)
+        returns (stream BincodeEncodedPayload) {}
 }
 
 // The worker-to-primary interface
 service WorkerToPrimary {
-  // Sends a message
-  rpc SendMessage(BincodeEncodedPayload) returns (Empty) {}
+    // Sends a message
+    rpc SendMessage(BincodeEncodedPayload) returns (Empty) {}
 }
 
 // The primary-to-worker interface
 service PrimaryToWorker {
-  // Sends a message
-  rpc SendMessage(BincodeEncodedPayload) returns (Empty) {}
+    // Sends a message
+    rpc SendMessage(BincodeEncodedPayload) returns (Empty) {}
 }
 
 service Transactions {
-  // Submit a Transactions
-  rpc SubmitTransaction(Transaction) returns (Empty) {}
+    // Submit a Transactions
+    rpc SubmitTransaction(Transaction) returns (Empty) {}
 
-  // Submit a Transactions
-  rpc SubmitTransactionStream(stream Transaction) returns (Empty) {}
+    // Submit a Transactions
+    rpc SubmitTransactionStream(stream Transaction) returns (Empty) {}
 }

--- a/types/proto/narwhal.proto
+++ b/types/proto/narwhal.proto
@@ -6,191 +6,194 @@ syntax = "proto3";
 package narwhal;
 
 message CertificateDigest {
-    bytes digest = 1;
+  bytes digest = 1;
 }
 
 message BatchDigest {
-    bytes digest = 1;
+  bytes digest = 1;
 }
 
 message Batch {
-    repeated Transaction transaction = 1;
+  repeated Transaction transaction = 1;
 }
 
 message Transaction {
-    bytes transaction = 1;
+  bytes transaction = 1;
 }
 
- enum CollectionErrorType {
-    COLLECTION_NOT_FOUND = 0;
-    COLLECTION_TIMEOUT = 1;
-    COLLECTION_ERROR = 2;
+enum CollectionErrorType {
+  COLLECTION_NOT_FOUND = 0;
+  COLLECTION_TIMEOUT = 1;
+  COLLECTION_ERROR = 2;
 }
 
 message CollectionError {
-    CertificateDigest id = 1;
-    CollectionErrorType error = 2;
+  CertificateDigest id = 1;
+  CollectionErrorType error = 2;
 }
 
 message BatchMessage {
-    BatchDigest id = 1;
-    Batch transactions = 2;
+  BatchDigest id = 1;
+  Batch transactions = 2;
 }
 
 message PrimaryAddresses {
-    MultiAddr primary_to_primary = 1;
-    MultiAddr worker_to_primary = 2;
+  MultiAddr primary_to_primary = 1;
+  MultiAddr worker_to_primary = 2;
 }
 
 message MultiAddr {
-    string address = 1;
+  string address = 1;
 }
 
 message PublicKey {
-    bytes bytes = 1;
+  bytes bytes = 1;
 }
 
 message ValidatorData {
-    PublicKey public_key = 1;
-    int64 stake_weight = 2;
-    PrimaryAddresses primary_addresses = 3;
+  PublicKey public_key = 1;
+  int64 stake_weight = 2;
+  PrimaryAddresses primary_addresses = 3;
 }
 
 message CollectionRetrievalResult {
-    oneof retrieval_result {
-        BatchMessage batch = 1;
-        CollectionError error = 2;
-    }
+  oneof retrieval_result {
+    BatchMessage batch = 1;
+    CollectionError error = 2;
+  }
 }
 
 message GetCollectionsRequest {
-    // List of collections to be retreived.
-    repeated CertificateDigest collection_ids = 1;
+  // List of collections to be retreived.
+  repeated CertificateDigest collection_ids = 1;
 }
 
 message GetCollectionsResponse {
-    // TODO: Revisit this for spec compliance.  
-    // List of retrieval results of collections.
-    repeated CollectionRetrievalResult result = 1;
+  // TODO: Revisit this for spec compliance.
+  // List of retrieval results of collections.
+  repeated CollectionRetrievalResult result = 1;
 }
 
 message RemoveCollectionsRequest {
-    // List of collections to be removed.
-    repeated CertificateDigest collection_ids = 1;
+  // List of collections to be removed.
+  repeated CertificateDigest collection_ids = 1;
 }
 
 message ReadCausalRequest {
-    // A collection for which a sequence of related collections are to be retrieved.
-    CertificateDigest collection_id = 1;
+  // A collection for which a sequence of related collections are to be
+  // retrieved.
+  CertificateDigest collection_id = 1;
 }
 
 message ReadCausalResponse {
-    // Resulting sequence of collections from DAG walk.
-    repeated CertificateDigest collection_ids = 1;
+  // Resulting sequence of collections from DAG walk.
+  repeated CertificateDigest collection_ids = 1;
 }
 
 message RoundsRequest {
-    /// The validator's key for which we want to retrieve
-    /// the available rounds.
-    PublicKey public_key = 1;
+  /// The validator's key for which we want to retrieve
+  /// the available rounds.
+  PublicKey public_key = 1;
 }
 
 message RoundsResponse {
-    /// The oldest round for which the node has available
-    /// blocks to propose for the defined validator.
-    uint64 oldest_round = 1;
+  /// The oldest round for which the node has available
+  /// blocks to propose for the defined validator.
+  uint64 oldest_round = 1;
 
-    /// The newest (latest) round for which the node has available
-    /// blocks to propose for the defined validator.
-    uint64 newest_round = 2;
+  /// The newest (latest) round for which the node has available
+  /// blocks to propose for the defined validator.
+  uint64 newest_round = 2;
 }
 
 message NodeReadCausalRequest {
-    PublicKey public_key = 1;
-    uint64 round = 2;
+  PublicKey public_key = 1;
+  uint64 round = 2;
 }
 
 message NodeReadCausalResponse {
-    // Resulting sequence of collections from DAG walk.
-    repeated CertificateDigest collection_ids = 1;
+  // Resulting sequence of collections from DAG walk.
+  repeated CertificateDigest collection_ids = 1;
 }
 
 message NewNetworkInfoRequest {
-    uint32 epoch_number = 1;
-    repeated ValidatorData validators = 2;
+  uint32 epoch_number = 1;
+  repeated ValidatorData validators = 2;
 }
 
 message NewEpochRequest {
-    uint32 epoch_number = 1;
-    repeated ValidatorData validators = 2;
+  uint32 epoch_number = 1;
+  repeated ValidatorData validators = 2;
 }
 
 // A bincode encoded payload. This is intended to be used in the short-term
 // while we don't have good protobuf definitions for Narwhal types
 message BincodeEncodedPayload {
-    bytes payload = 1;
-  }
-  
-// Empty message for when we don't have anything to return
-message Empty {
+  bytes payload = 1;
 }
+
+// Empty message for when we don't have anything to return
+message Empty {}
 
 // The consensus to mempool interface for validator actions.
 service Validator {
-    // Returns collection contents for each requested collection.
-    rpc GetCollections (GetCollectionsRequest) returns (GetCollectionsResponse);
-    // Expunges collections from the mempool.
-    rpc RemoveCollections (RemoveCollectionsRequest) returns (Empty);
-    // Returns collections along a DAG walk with a well-defined starting point.
-    rpc ReadCausal (ReadCausalRequest) returns (ReadCausalResponse);
+  // Returns collection contents for each requested collection.
+  rpc GetCollections(GetCollectionsRequest) returns (GetCollectionsResponse);
+  // Expunges collections from the mempool.
+  rpc RemoveCollections(RemoveCollectionsRequest) returns (Empty);
+  // Returns collections along a DAG walk with a well-defined starting point.
+  rpc ReadCausal(ReadCausalRequest) returns (ReadCausalResponse);
 }
 
 /// The API that hosts the endpoints that should be used to help
 /// proposing a block.
 service Proposer {
-  rpc Rounds (RoundsRequest) returns (RoundsResponse);
-  // Returns the read_causal obtained by starting the DAG walk at the collection 
-  // proposed by the input authority (as indicated by their public key) at the input round
-  rpc NodeReadCausal (NodeReadCausalRequest) returns (NodeReadCausalResponse);
+  rpc Rounds(RoundsRequest) returns (RoundsResponse);
+  // Returns the read_causal obtained by starting the DAG walk at the collection
+  // proposed by the input authority (as indicated by their public key) at the
+  // input round
+  rpc NodeReadCausal(NodeReadCausalRequest) returns (NodeReadCausalResponse);
 }
 
 service Configuration {
-    // Signals a new epoch
-    rpc NewEpoch (NewEpochRequest) returns (Empty);
-    // Signals a change in networking info
-    rpc NewNetworkInfo (NewNetworkInfoRequest) returns (Empty);
+  // Signals a new epoch
+  rpc NewEpoch(NewEpochRequest) returns (Empty);
+  // Signals a change in networking info
+  rpc NewNetworkInfo(NewNetworkInfoRequest) returns (Empty);
 }
 
 // The primary-to-primary interface
 service PrimaryToPrimary {
   // Sends a message
-  rpc SendMessage (BincodeEncodedPayload) returns (Empty) {}
+  rpc SendMessage(BincodeEncodedPayload) returns (Empty) {}
 }
 
 // The worker-to-worker interface
 service WorkerToWorker {
   // Sends a worker message
-  rpc SendMessage (BincodeEncodedPayload) returns (Empty) {}
-  // requests a number of batches that the service then streams back to the client
-  rpc ClientBatchRequest (BincodeEncodedPayload) returns (stream BincodeEncodedPayload) {}
+  rpc SendMessage(BincodeEncodedPayload) returns (Empty) {}
+  // requests a number of batches that the service then streams back to the
+  // client
+  rpc ClientBatchRequest(BincodeEncodedPayload)
+      returns (stream BincodeEncodedPayload) {}
 }
 
 // The worker-to-primary interface
 service WorkerToPrimary {
   // Sends a message
-  rpc SendMessage (BincodeEncodedPayload) returns (Empty) {}
+  rpc SendMessage(BincodeEncodedPayload) returns (Empty) {}
 }
 
 // The primary-to-worker interface
 service PrimaryToWorker {
   // Sends a message
-  rpc SendMessage (BincodeEncodedPayload) returns (Empty) {}
+  rpc SendMessage(BincodeEncodedPayload) returns (Empty) {}
 }
 
 service Transactions {
-    // Submit a Transactions
-    rpc SubmitTransaction (Transaction) returns (Empty) {}
+  // Submit a Transactions
+  rpc SubmitTransaction(Transaction) returns (Empty) {}
 
-    // Submit a Transactions
-    rpc SubmitTransactionStream (stream Transaction) returns (Empty) {}
+  // Submit a Transactions
+  rpc SubmitTransactionStream(stream Transaction) returns (Empty) {}
 }

--- a/types/proto/narwhal.proto
+++ b/types/proto/narwhal.proto
@@ -80,8 +80,7 @@ message RemoveCollectionsRequest {
 }
 
 message ReadCausalRequest {
-    // A collection for which a sequence of related collections are to be
-    // retrieved.
+    // A collection for which a sequence of related collections are to be retrieved.
     CertificateDigest collection_id = 1;
 }
 
@@ -149,9 +148,8 @@ service Validator {
 /// proposing a block.
 service Proposer {
     rpc Rounds(RoundsRequest) returns (RoundsResponse);
-    // Returns the read_causal obtained by starting the DAG walk at the
-    // collection proposed by the input authority (as indicated by their public
-    // key) at the input round
+    // Returns the read_causal obtained by starting the DAG walk at the collection
+    // proposed by the input authority (as indicated by their public key) at the input round
     rpc NodeReadCausal(NodeReadCausalRequest) returns (NodeReadCausalResponse);
 }
 
@@ -172,10 +170,8 @@ service PrimaryToPrimary {
 service WorkerToWorker {
     // Sends a worker message
     rpc SendMessage(BincodeEncodedPayload) returns (Empty) {}
-    // requests a number of batches that the service then streams back to the
-    // client
-    rpc ClientBatchRequest(BincodeEncodedPayload)
-        returns (stream BincodeEncodedPayload) {}
+    // requests a number of batches that the service then streams back to the client
+    rpc ClientBatchRequest(BincodeEncodedPayload) returns (stream BincodeEncodedPayload) {}
 }
 
 // The worker-to-primary interface

--- a/types/proto/narwhal.proto
+++ b/types/proto/narwhal.proto
@@ -6,130 +6,130 @@ syntax = "proto3";
 package narwhal;
 
 message CertificateDigest {
-  bytes digest = 1;
+    bytes digest = 1;
 }
 
 message BatchDigest {
-  bytes digest = 1;
+    bytes digest = 1;
 }
 
 message Batch {
-  repeated Transaction transaction = 1;
+    repeated Transaction transaction = 1;
 }
 
 message Transaction {
-  bytes transaction = 1;
+    bytes transaction = 1;
 }
 
 enum CollectionErrorType {
-  COLLECTION_NOT_FOUND = 0;
-  COLLECTION_TIMEOUT = 1;
-  COLLECTION_ERROR = 2;
+    COLLECTION_NOT_FOUND = 0;
+    COLLECTION_TIMEOUT = 1;
+    COLLECTION_ERROR = 2;
 }
 
 message CollectionError {
-  CertificateDigest id = 1;
-  CollectionErrorType error = 2;
+    CertificateDigest id = 1;
+    CollectionErrorType error = 2;
 }
 
 message BatchMessage {
-  BatchDigest id = 1;
-  Batch transactions = 2;
+    BatchDigest id = 1;
+    Batch transactions = 2;
 }
 
 message PrimaryAddresses {
-  MultiAddr primary_to_primary = 1;
-  MultiAddr worker_to_primary = 2;
+    MultiAddr primary_to_primary = 1;
+    MultiAddr worker_to_primary = 2;
 }
 
 message MultiAddr {
-  string address = 1;
+    string address = 1;
 }
 
 message PublicKey {
-  bytes bytes = 1;
+    bytes bytes = 1;
 }
 
 message ValidatorData {
-  PublicKey public_key = 1;
-  int64 stake_weight = 2;
-  PrimaryAddresses primary_addresses = 3;
+    PublicKey public_key = 1;
+    int64 stake_weight = 2;
+    PrimaryAddresses primary_addresses = 3;
 }
 
 message CollectionRetrievalResult {
-  oneof retrieval_result {
-    BatchMessage batch = 1;
-    CollectionError error = 2;
-  }
+    oneof retrieval_result {
+        BatchMessage batch = 1;
+        CollectionError error = 2;
+    }
 }
 
 message GetCollectionsRequest {
-  // List of collections to be retreived.
-  repeated CertificateDigest collection_ids = 1;
+    // List of collections to be retreived.
+    repeated CertificateDigest collection_ids = 1;
 }
 
 message GetCollectionsResponse {
-  // TODO: Revisit this for spec compliance.
-  // List of retrieval results of collections.
-  repeated CollectionRetrievalResult result = 1;
+    // TODO: Revisit this for spec compliance.
+    // List of retrieval results of collections.
+    repeated CollectionRetrievalResult result = 1;
 }
 
 message RemoveCollectionsRequest {
-  // List of collections to be removed.
-  repeated CertificateDigest collection_ids = 1;
+    // List of collections to be removed.
+    repeated CertificateDigest collection_ids = 1;
 }
 
 message ReadCausalRequest {
-  // A collection for which a sequence of related collections are to be
-  // retrieved.
-  CertificateDigest collection_id = 1;
+    // A collection for which a sequence of related collections are to be
+    // retrieved.
+    CertificateDigest collection_id = 1;
 }
 
 message ReadCausalResponse {
-  // Resulting sequence of collections from DAG walk.
-  repeated CertificateDigest collection_ids = 1;
+    // Resulting sequence of collections from DAG walk.
+    repeated CertificateDigest collection_ids = 1;
 }
 
 message RoundsRequest {
-  /// The validator's key for which we want to retrieve
-  /// the available rounds.
-  PublicKey public_key = 1;
+    /// The validator's key for which we want to retrieve
+    /// the available rounds.
+    PublicKey public_key = 1;
 }
 
 message RoundsResponse {
-  /// The oldest round for which the node has available
-  /// blocks to propose for the defined validator.
-  uint64 oldest_round = 1;
+    /// The oldest round for which the node has available
+    /// blocks to propose for the defined validator.
+    uint64 oldest_round = 1;
 
-  /// The newest (latest) round for which the node has available
-  /// blocks to propose for the defined validator.
-  uint64 newest_round = 2;
+    /// The newest (latest) round for which the node has available
+    /// blocks to propose for the defined validator.
+    uint64 newest_round = 2;
 }
 
 message NodeReadCausalRequest {
-  PublicKey public_key = 1;
-  uint64 round = 2;
+    PublicKey public_key = 1;
+    uint64 round = 2;
 }
 
 message NodeReadCausalResponse {
-  // Resulting sequence of collections from DAG walk.
-  repeated CertificateDigest collection_ids = 1;
+    // Resulting sequence of collections from DAG walk.
+    repeated CertificateDigest collection_ids = 1;
 }
 
 message NewNetworkInfoRequest {
-  uint32 epoch_number = 1;
-  repeated ValidatorData validators = 2;
+    uint32 epoch_number = 1;
+    repeated ValidatorData validators = 2;
 }
 
 message NewEpochRequest {
-  uint32 epoch_number = 1;
-  repeated ValidatorData validators = 2;
+    uint32 epoch_number = 1;
+    repeated ValidatorData validators = 2;
 }
 
 // A bincode encoded payload. This is intended to be used in the short-term
 // while we don't have good protobuf definitions for Narwhal types
 message BincodeEncodedPayload {
-  bytes payload = 1;
+    bytes payload = 1;
 }
 
 // Empty message for when we don't have anything to return
@@ -137,63 +137,63 @@ message Empty {}
 
 // The consensus to mempool interface for validator actions.
 service Validator {
-  // Returns collection contents for each requested collection.
-  rpc GetCollections(GetCollectionsRequest) returns (GetCollectionsResponse);
-  // Expunges collections from the mempool.
-  rpc RemoveCollections(RemoveCollectionsRequest) returns (Empty);
-  // Returns collections along a DAG walk with a well-defined starting point.
-  rpc ReadCausal(ReadCausalRequest) returns (ReadCausalResponse);
+    // Returns collection contents for each requested collection.
+    rpc GetCollections(GetCollectionsRequest) returns (GetCollectionsResponse);
+    // Expunges collections from the mempool.
+    rpc RemoveCollections(RemoveCollectionsRequest) returns (Empty);
+    // Returns collections along a DAG walk with a well-defined starting point.
+    rpc ReadCausal(ReadCausalRequest) returns (ReadCausalResponse);
 }
 
 /// The API that hosts the endpoints that should be used to help
 /// proposing a block.
 service Proposer {
-  rpc Rounds(RoundsRequest) returns (RoundsResponse);
-  // Returns the read_causal obtained by starting the DAG walk at the collection
-  // proposed by the input authority (as indicated by their public key) at the
-  // input round
-  rpc NodeReadCausal(NodeReadCausalRequest) returns (NodeReadCausalResponse);
+    rpc Rounds(RoundsRequest) returns (RoundsResponse);
+    // Returns the read_causal obtained by starting the DAG walk at the
+    // collection proposed by the input authority (as indicated by their public
+    // key) at the input round
+    rpc NodeReadCausal(NodeReadCausalRequest) returns (NodeReadCausalResponse);
 }
 
 service Configuration {
-  // Signals a new epoch
-  rpc NewEpoch(NewEpochRequest) returns (Empty);
-  // Signals a change in networking info
-  rpc NewNetworkInfo(NewNetworkInfoRequest) returns (Empty);
+    // Signals a new epoch
+    rpc NewEpoch(NewEpochRequest) returns (Empty);
+    // Signals a change in networking info
+    rpc NewNetworkInfo(NewNetworkInfoRequest) returns (Empty);
 }
 
 // The primary-to-primary interface
 service PrimaryToPrimary {
-  // Sends a message
-  rpc SendMessage(BincodeEncodedPayload) returns (Empty) {}
+    // Sends a message
+    rpc SendMessage(BincodeEncodedPayload) returns (Empty) {}
 }
 
 // The worker-to-worker interface
 service WorkerToWorker {
-  // Sends a worker message
-  rpc SendMessage(BincodeEncodedPayload) returns (Empty) {}
-  // requests a number of batches that the service then streams back to the
-  // client
-  rpc ClientBatchRequest(BincodeEncodedPayload)
-      returns (stream BincodeEncodedPayload) {}
+    // Sends a worker message
+    rpc SendMessage(BincodeEncodedPayload) returns (Empty) {}
+    // requests a number of batches that the service then streams back to the
+    // client
+    rpc ClientBatchRequest(BincodeEncodedPayload)
+        returns (stream BincodeEncodedPayload) {}
 }
 
 // The worker-to-primary interface
 service WorkerToPrimary {
-  // Sends a message
-  rpc SendMessage(BincodeEncodedPayload) returns (Empty) {}
+    // Sends a message
+    rpc SendMessage(BincodeEncodedPayload) returns (Empty) {}
 }
 
 // The primary-to-worker interface
 service PrimaryToWorker {
-  // Sends a message
-  rpc SendMessage(BincodeEncodedPayload) returns (Empty) {}
+    // Sends a message
+    rpc SendMessage(BincodeEncodedPayload) returns (Empty) {}
 }
 
 service Transactions {
-  // Submit a Transactions
-  rpc SubmitTransaction(Transaction) returns (Empty) {}
+    // Submit a Transactions
+    rpc SubmitTransaction(Transaction) returns (Empty) {}
 
-  // Submit a Transactions
-  rpc SubmitTransactionStream(stream Transaction) returns (Empty) {}
+    // Submit a Transactions
+    rpc SubmitTransactionStream(stream Transaction) returns (Empty) {}
 }

--- a/types/src/generated/narwhal.rs
+++ b/types/src/generated/narwhal.rs
@@ -83,7 +83,7 @@ pub struct GetCollectionsRequest {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetCollectionsResponse {
-    /// TODO: Revisit this for spec compliance.  
+    /// TODO: Revisit this for spec compliance.
     /// List of retrieval results of collections.
     #[prost(message, repeated, tag="1")]
     pub result: ::prost::alloc::vec::Vec<CollectionRetrievalResult>,


### PR DESCRIPTION
There seems to be no formatting for protobuf right now, so add them to the CI workflow.

There are some existing lint issues, e.g. proto enums should start with a `UNSPECIFIED` / `NOT_SET` tag at 0. This can be fixed in a subsequent PR if people agree with them. Then proto linting can be enabled.

Also, switch to [`super-linter`](https://github.com/github/super-linter) which has support for all existing linters, and can hopefully reduce effort for adding linters in future.