### PR TITLE
Fix panic in process_header, test CertificateWaiter

### DIFF
--- a/primary/src/certificate_waiter.rs
+++ b/primary/src/certificate_waiter.rs
@@ -29,6 +29,10 @@ use types::{
     Certificate, CertificateDigest, HeaderDigest, Reconfigure, Round,
 };
 
+#[cfg(test)]
+#[path = "tests/certificate_waiter_tests.rs"]
+pub mod certificate_waiter_tests;
+
 /// Waits to receive all the ancestors of a certificate before looping it back to the `Core`
 /// for further processing.
 pub struct CertificateWaiter<PublicKey: VerifyingKey> {

--- a/primary/src/tests/certificate_waiter_tests.rs
+++ b/primary/src/tests/certificate_waiter_tests.rs
@@ -1,0 +1,150 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use crate::{
+    certificate_waiter::CertificateWaiter, common::create_db_stores, core::Core,
+    header_waiter::HeaderWaiter, metrics::PrimaryMetrics, synchronizer::Synchronizer,
+};
+use core::sync::atomic::AtomicU64;
+use crypto::{traits::KeyPair, Hash, SignatureService};
+use prometheus::Registry;
+use std::{collections::BTreeSet, sync::Arc, time::Duration};
+use test_utils::{certificate, committee, fixture_headers_round, keys};
+use tokio::sync::{mpsc::channel, watch};
+use types::{Certificate, PrimaryMessage, Reconfigure, Round};
+
+#[tokio::test]
+async fn process_certificate_missing_parents_in_reverse() {
+    let kp = keys(None).pop().unwrap();
+    let name = kp.public().clone();
+    let signature_service = SignatureService::new(kp);
+
+    // kept empty
+    let (_tx_reconfigure, rx_reconfigure) =
+        watch::channel(Reconfigure::NewCommittee(committee(None)));
+    // synchronizer to header waiter
+    let (tx_sync_headers, rx_sync_headers) = channel(1);
+    // synchronizer to certificate waiter
+    let (tx_sync_certificates, rx_sync_certificates) = channel(1);
+    // primary messages
+    let (tx_primary_messages, rx_primary_messages) = channel(1);
+    // header waiter to primary
+    let (tx_headers_loopback, rx_headers_loopback) = channel(1);
+    // certificate waiter to primary
+    let (tx_certificates_loopback, rx_certificates_loopback) = channel(1);
+    // proposer back to the core
+    let (_tx_headers, rx_headers) = channel(1);
+    // core -> consensus, we store the output of process_certificate here, a small channel limit may backpressure the test into failure
+    let (tx_consensus, _rx_consensus) = channel(100);
+    // core -> proposers, byproduct of certificate processing, a small channel limit could backpressure the test into failure
+    let (tx_parents, _rx_parents) = channel(100);
+
+    // Create test stores.
+    let (header_store, certificates_store, payload_store) = create_db_stores();
+
+    // Make a synchronizer for the core.
+    let synchronizer = Synchronizer::new(
+        name.clone(),
+        &committee(None),
+        certificates_store.clone(),
+        payload_store.clone(),
+        /* tx_header_waiter */ tx_sync_headers,
+        /* tx_certificate_waiter */ tx_sync_certificates,
+        None,
+    );
+
+    let metrics = Arc::new(PrimaryMetrics::new(&Registry::new()));
+    let consensus_round = Arc::new(AtomicU64::new(0));
+    let gc_depth: Round = 50;
+
+    // Make a headerWaiter
+    HeaderWaiter::spawn(
+        name.clone(),
+        committee(None),
+        certificates_store.clone(),
+        payload_store.clone(),
+        consensus_round.clone(),
+        gc_depth,
+        /* sync_retry_delay */ Duration::from_secs(5),
+        /* sync_retry_nodes */ 3,
+        rx_reconfigure.clone(),
+        rx_sync_headers,
+        tx_headers_loopback,
+        metrics.clone(),
+    );
+
+    // Make a certificate waiter
+    CertificateWaiter::spawn(
+        committee(None),
+        certificates_store.clone(),
+        consensus_round.clone(),
+        gc_depth,
+        rx_reconfigure.clone(),
+        rx_sync_certificates,
+        tx_certificates_loopback,
+        metrics.clone(),
+    );
+
+    // Spawn the core.
+    Core::spawn(
+        name.clone(),
+        committee(None),
+        header_store.clone(),
+        certificates_store.clone(),
+        synchronizer,
+        signature_service,
+        /* consensus_round */ consensus_round,
+        /* gc_depth */ gc_depth,
+        rx_reconfigure,
+        /* rx_primaries */ rx_primary_messages,
+        /* rx_header_waiter */ rx_headers_loopback,
+        /* rx_certificate_waiter */ rx_certificates_loopback,
+        /* rx_proposer */ rx_headers,
+        tx_consensus,
+        /* tx_proposer */ tx_parents,
+        metrics.clone(),
+    );
+
+    // Generate headers in successive rounds
+    let mut current_round: Vec<_> = Certificate::genesis(&committee(None))
+        .into_iter()
+        .map(|cert| cert.header)
+        .collect();
+    let mut headers = vec![];
+    let rounds = 5;
+    for i in 0..rounds {
+        let parents: BTreeSet<_> = current_round
+            .into_iter()
+            .map(|header| certificate(&header).digest())
+            .collect();
+        (_, current_round) = fixture_headers_round(i, &parents);
+        headers.extend(current_round.clone());
+    }
+
+    // Avoid any sort of missing payload by pre-populating the batch
+    for (digest, worker_id) in headers.iter().flat_map(|h| h.payload.iter()) {
+        payload_store.write((*digest, *worker_id), 0u8).await;
+    }
+
+    // sanity-check
+    assert!(headers.len() == keys(None).len() * rounds as usize); // note we don't include genesis
+
+    // the `rev()` below is important, as we want to test anti-topological arrival
+    #[allow(clippy::needless_collect)]
+    let ids: Vec<_> = headers
+        .iter()
+        .map(|header| certificate(header).digest())
+        .collect();
+    for header in headers.into_iter().rev() {
+        tx_primary_messages
+            .send(PrimaryMessage::Certificate(certificate(&header)))
+            .await
+            .unwrap();
+    }
+
+    // we re-evaluate certificates pending after a little while
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    // Ensure all certificates are now stored
+    for id in ids.into_iter().rev() {
+        assert!(certificates_store.read(id).await.unwrap().is_some());
+    }
+}


### PR DESCRIPTION
The first commit is purely technical: replaces an `mpsc::channel` by a lighter `oneshot::channel` for waiter cancellations.

The second (see message) introduces a long test firing up the `CertificateWaiter` and all dependent components,
and feeding it valid certificates in inverse (decreasing) round order, simulating catching up as a late node.

Along the way, this *discovers a panic in this catch-up path*:
- `process_certificate` calls process_header,
- `process_header` can return with `Ok(())` in case the node has missing parents / payload,
- but in the case it doesn't, we will try to vote for the header if not in a `last_voted` table,
- that vote may be a panic-inducing duplicate vote if
    + the node was already among the voters for this certificate,
    + a restart has blown the node's in-memory `last_voted` table,
 - this panic blows up all the way to the process,
- we change this panic to instead generate the following message at the error level:
```
2022-07-13T12:36:25.607333Z ERROR process_header: primary::core: Failed to process our own vote: Authority vq2gYSbHjZi0oaafbuYYlpTw9HUVONqCTxrcixShtWI= appears in quorum more than once
```

The behavior-changing fix is ca. lines 275 of `primary/src/core.rs`

This also tweaks a few mock functions to generate those valid certificates and headers in the first place.

