### PR TITLE
[testing] return joinhandles and add store preserve support in cluster

### DIFF
--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -199,9 +199,9 @@ where
         protocol: Protocol,
         metrics: Arc<ConsensusMetrics>,
         gc_depth: Round,
-    ) -> JoinHandle<StoreResult<()>> {
+    ) -> JoinHandle<()> {
         tokio::spawn(async move {
-            let consensus_index = store.read_last_consensus_index()?;
+            let consensus_index = store.read_last_consensus_index().expect("Store error");
             let recovered_last_committed = store.read_last_committed();
             let committee: &Committee<PublicKey> = &committee.load();
             let genesis = Certificate::genesis(committee);
@@ -216,6 +216,7 @@ where
             }
             .run(recovered_last_committed, cert_store, gc_depth)
             .await
+            .unwrap();
         })
     }
 
@@ -269,6 +270,7 @@ where
                 }
             }
         }
+
         Ok(())
     }
 }

--- a/consensus/src/subscriber.rs
+++ b/consensus/src/subscriber.rs
@@ -39,7 +39,7 @@ impl<PublicKey: VerifyingKey> SubscriberHandler<PublicKey> {
         rx_sequence: Receiver<ConsensusOutput<PublicKey>>,
         rx_client: Receiver<ConsensusSyncRequest>,
         tx_client: Sender<ConsensusOutput<PublicKey>>,
-    ) -> JoinHandle<StoreResult<()>> {
+    ) -> JoinHandle<()> {
         tokio::spawn(async move {
             Self {
                 consensus_store,
@@ -50,6 +50,7 @@ impl<PublicKey: VerifyingKey> SubscriberHandler<PublicKey> {
             }
             .run()
             .await
+            .unwrap();
         })
     }
 

--- a/executor/src/batch_loader.rs
+++ b/executor/src/batch_loader.rs
@@ -40,7 +40,7 @@ impl<PublicKey: VerifyingKey> BatchLoader<PublicKey> {
         store: Store<BatchDigest, SerializedBatchMessage>,
         rx_input: Receiver<ConsensusOutput<PublicKey>>,
         addresses: HashMap<WorkerId, Multiaddr>,
-    ) -> JoinHandle<SubscriberResult<()>> {
+    ) -> JoinHandle<()> {
         tokio::spawn(async move {
             Self {
                 store,
@@ -50,6 +50,7 @@ impl<PublicKey: VerifyingKey> BatchLoader<PublicKey> {
             }
             .run()
             .await
+            .unwrap();
         })
     }
 
@@ -86,6 +87,7 @@ impl<PublicKey: VerifyingKey> BatchLoader<PublicKey> {
                     .expect("Sync connections are kept alive and never die");
             }
         }
+
         Ok(())
     }
 }

--- a/executor/src/core.rs
+++ b/executor/src/core.rs
@@ -56,9 +56,12 @@ where
         execution_state: Arc<State>,
         rx_subscriber: Receiver<ConsensusOutput<PublicKey>>,
         tx_output: Sender<(SubscriberResult<Vec<u8>>, SerializedTransaction)>,
-    ) -> JoinHandle<SubscriberResult<()>> {
+    ) -> JoinHandle<()> {
         tokio::spawn(async move {
-            let execution_indices = execution_state.load_execution_indices().await?;
+            let execution_indices = execution_state
+                .load_execution_indices()
+                .await
+                .unwrap_or_default();
             Self {
                 store,
                 execution_state,
@@ -68,6 +71,7 @@ where
             }
             .run()
             .await
+            .unwrap();
         })
     }
 

--- a/executor/src/lib.rs
+++ b/executor/src/lib.rs
@@ -87,11 +87,7 @@ impl Executor {
         rx_consensus: Receiver<ConsensusOutput<PublicKey>>,
         tx_consensus: Sender<ConsensusSyncRequest>,
         tx_output: Sender<(SubscriberResult<Vec<u8>>, SerializedTransaction)>,
-    ) -> SubscriberResult<(
-        JoinHandle<SubscriberResult<()>>,
-        JoinHandle<SubscriberResult<()>>,
-        JoinHandle<SubscriberResult<()>>,
-    )>
+    ) -> SubscriberResult<Vec<JoinHandle<()>>>
     where
         State: ExecutionState + Send + Sync + 'static,
         PublicKey: VerifyingKey,
@@ -143,6 +139,10 @@ impl Executor {
 
         // Return the handle.
         info!("Consensus subscriber successfully started");
-        Ok((subscriber_handle, executor_handle, batch_loader_handle))
+        Ok(vec![
+            subscriber_handle,
+            executor_handle,
+            batch_loader_handle,
+        ])
     }
 }

--- a/executor/src/subscriber.rs
+++ b/executor/src/subscriber.rs
@@ -52,7 +52,7 @@ impl<PublicKey: VerifyingKey> Subscriber<PublicKey> {
         tx_batch_loader: Sender<ConsensusOutput<PublicKey>>,
         tx_executor: Sender<ConsensusOutput<PublicKey>>,
         next_consensus_index: SequenceNumber,
-    ) -> JoinHandle<SubscriberResult<()>> {
+    ) -> JoinHandle<()> {
         tokio::spawn(async move {
             Self {
                 store,
@@ -64,6 +64,7 @@ impl<PublicKey: VerifyingKey> Subscriber<PublicKey> {
             }
             .run()
             .await
+            .unwrap();
         })
     }
 

--- a/primary/tests/causal_completion_tests.rs
+++ b/primary/tests/causal_completion_tests.rs
@@ -46,7 +46,7 @@ async fn test_read_causal_signed_certificates() {
     tokio::time::sleep(Duration::from_secs(10)).await;
 
     // Now start the validator 0 again
-    let node = cluster.start_node(0).await.unwrap();
+    let node = cluster.start_node(0, true).await.unwrap();
 
     // Now check that the current round advances. Give the opportunity with a few
     // iterations. If metric hasn't picked up then we know that node can't make

--- a/test_utils/src/cluster.rs
+++ b/test_utils/src/cluster.rs
@@ -4,12 +4,11 @@ use crate::{committee, keys, temp_dir};
 use arc_swap::ArcSwap;
 use config::{Committee, Parameters};
 use crypto::{ed25519::Ed25519PublicKey, traits::KeyPair};
-use executor::SubscriberResult;
 use node::{
     execution_state::SimpleExecutionState, metrics::primary_metrics_registry, Node, NodeStorage,
 };
 use prometheus::Registry;
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{collections::HashMap, path::PathBuf, sync::Arc, time::Duration};
 use tokio::{sync::mpsc::channel, task::JoinHandle};
 use tracing::info;
 
@@ -18,7 +17,18 @@ pub struct NodeDetails {
     pub id: usize,
     pub name: Ed25519PublicKey,
     pub registry: Registry,
-    handlers: SubscriberResult<Vec<JoinHandle<()>>>,
+    pub store_path: PathBuf,
+    handlers: Vec<JoinHandle<()>>,
+}
+
+impl NodeDetails {
+    /// This method returns whether the node is still running or not. We
+    /// iterate over all the handlers and check whether there is still any
+    /// that is not finished. If we find at least one, then we report the
+    /// node as still running.
+    fn is_running(&self) -> bool {
+        self.handlers.iter().any(|h| !h.is_finished())
+    }
 }
 
 pub struct Cluster {
@@ -34,13 +44,25 @@ impl Cluster {
         info!("###### Creating new cluster ######");
         info!("Validator keys:");
         let k = keys(None);
+        let mut nodes = HashMap::new();
 
         for (index, key) in k.into_iter().enumerate() {
             info!("Key {index} -> {}", key.public().clone());
+
+            nodes.insert(
+                index,
+                Arc::new(NodeDetails {
+                    id: index,
+                    name: key.public().clone(),
+                    registry: Registry::new(),
+                    store_path: Default::default(),
+                    handlers: vec![],
+                }),
+            );
         }
 
         Self {
-            nodes: HashMap::new(),
+            nodes,
             committee_shared: Arc::new(ArcSwap::from_pointee(committee)),
             parameters: parameters.unwrap_or_else(Self::parameters),
         }
@@ -60,7 +82,7 @@ impl Cluster {
 
         for id in 0..nodes_number {
             info!("Spinning up node: {id}");
-            let node = self.start_node(id).await;
+            let node = self.start_node(id, false).await;
 
             regs.push(node.unwrap());
         }
@@ -71,8 +93,17 @@ impl Cluster {
     /// Starts a node by the defined id - if not already running - and
     /// the details are returned. If the node is already running then an
     /// error is returned instead.
-    pub async fn start_node(&mut self, id: usize) -> Result<Arc<NodeDetails>, ()> {
-        if self.nodes.contains_key(&id) {
+    /// When the preserve_store is true then the started node will use the
+    /// same path that has been used the last time when the node was started.
+    /// This is basically a way to use the same storage between node restarts.
+    pub async fn start_node(
+        &mut self,
+        id: usize,
+        preserve_store: bool,
+    ) -> Result<Arc<NodeDetails>, ()> {
+        let node = self.nodes.get(&id).unwrap();
+
+        if node.is_running() {
             return Err(());
         }
 
@@ -83,7 +114,15 @@ impl Cluster {
         let registry = primary_metrics_registry(name.clone());
 
         // Make the data store.
-        let store: NodeStorage<Ed25519PublicKey> = NodeStorage::reopen(temp_dir());
+        let store_path = if preserve_store {
+            node.store_path.clone()
+        } else {
+            temp_dir()
+        };
+
+        info!("Node {} will use path {:?}", id, store_path.clone());
+
+        let store: NodeStorage<Ed25519PublicKey> = NodeStorage::reopen(store_path.clone());
 
         // The channel returning the result for each transaction's execution.
         let (tx_transaction_confirmation, _) = channel(Node::CHANNEL_CAPACITY);
@@ -104,7 +143,8 @@ impl Cluster {
             id,
             name,
             registry,
-            handlers: h,
+            handlers: h.unwrap(),
+            store_path,
         });
 
         // Insert to the nodes map
@@ -117,10 +157,8 @@ impl Cluster {
     /// either when the node has been successfully stopped or even when
     /// the node doesn't exist.
     pub fn stop_node(&mut self, id: usize) {
-        if let Some(node) = self.nodes.remove(&id) {
-            if let Ok(handlers) = &node.handlers {
-                handlers.iter().for_each(|h| h.abort());
-            }
+        if let Some(node) = self.nodes.get_mut(&id) {
+            node.handlers.iter().for_each(|h| h.abort());
             info!("Aborted node for id {id}");
         } else {
             info!("Node with {id} not found - nothing to stop");


### PR DESCRIPTION
A follow up of https://github.com/MystenLabs/narwhal/pull/487 , is doing the following:

1) Making the code return JoinHandles from all the parts that we spawn new tasks
2) Because of the above we are now able to properly shutdown all the running parts of the primary when we stop a node and _properly close the database_ (automatically closed once all references are dropped)
3) Refactoring the `Cluster` struct to allow us preserve storage when node is restarted. That will allow us to test our network under different assumptions

**Note:** Interestingly enough the test now passes when we preserve the storage - the restarted node manages to perform the causal completion successfully, catch up the other nodes and make progress to the same commit round.