### PR TITLE
[fix] possible round overflow in consensus

### DIFF
--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -91,7 +91,7 @@ impl<PublicKey: VerifyingKey> ConsensusState<PublicKey> {
         gc_depth: Round,
     ) -> Dag<PublicKey> {
         let mut dag: Dag<PublicKey> = HashMap::new();
-        let min_round = last_committed_round - gc_depth;
+        let min_round = last_committed_round.saturating_sub(gc_depth);
         let cert_map = cert_store
             .iter(Some(Box::new(move |(_dig, cert)| {
                 cert.header.round > min_round


### PR DESCRIPTION
If the node restarts before they manage to commit after the `gc_round`, consensus might panic as an `attempt to subtract with overflow` since we try to subtract `u64` numbers. This PR is fixing this by taking as lowest possible number the zero.