### PR TITLE
[testing] add cluster workers support

### DIFF
--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -10,6 +10,7 @@ use tokio::{
     sync::mpsc::{Receiver, Sender},
     task::JoinHandle,
 };
+use tracing::info;
 use types::{
     Certificate, CertificateDigest, ConsensusPrimaryMessage, ConsensusStore, Round, StoreResult,
 };
@@ -91,6 +92,9 @@ impl<PublicKey: VerifyingKey> ConsensusState<PublicKey> {
         gc_depth: Round,
     ) -> Dag<PublicKey> {
         let mut dag: Dag<PublicKey> = HashMap::new();
+
+        info!("Last committed round: {}", last_committed_round);
+
         let min_round = last_committed_round.saturating_sub(gc_depth);
         let cert_map = cert_store
             .iter(Some(Box::new(move |(_dig, cert)| {

--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -199,9 +199,9 @@ where
         protocol: Protocol,
         metrics: Arc<ConsensusMetrics>,
         gc_depth: Round,
-    ) -> JoinHandle<StoreResult<()>> {
+    ) -> JoinHandle<()> {
         tokio::spawn(async move {
-            let consensus_index = store.read_last_consensus_index()?;
+            let consensus_index = store.read_last_consensus_index().expect("Store error");
             let recovered_last_committed = store.read_last_committed();
             let committee: &Committee<PublicKey> = &committee.load();
             let genesis = Certificate::genesis(committee);
@@ -216,6 +216,7 @@ where
             }
             .run(recovered_last_committed, cert_store, gc_depth)
             .await
+            .unwrap();
         })
     }
 
@@ -269,6 +270,7 @@ where
                 }
             }
         }
+
         Ok(())
     }
 }

--- a/consensus/src/subscriber.rs
+++ b/consensus/src/subscriber.rs
@@ -39,7 +39,7 @@ impl<PublicKey: VerifyingKey> SubscriberHandler<PublicKey> {
         rx_sequence: Receiver<ConsensusOutput<PublicKey>>,
         rx_client: Receiver<ConsensusSyncRequest>,
         tx_client: Sender<ConsensusOutput<PublicKey>>,
-    ) -> JoinHandle<StoreResult<()>> {
+    ) -> JoinHandle<()> {
         tokio::spawn(async move {
             Self {
                 consensus_store,
@@ -50,6 +50,7 @@ impl<PublicKey: VerifyingKey> SubscriberHandler<PublicKey> {
             }
             .run()
             .await
+            .unwrap();
         })
     }
 

--- a/crypto/src/ed25519.rs
+++ b/crypto/src/ed25519.rs
@@ -339,7 +339,7 @@ impl KeyPair for Ed25519KeyPair {
     fn copy(&self) -> Self {
         Self {
             name: Ed25519PublicKey::from_bytes(self.name.as_ref()).unwrap(),
-            secret: Ed25519PrivateKey::from_bytes(self.name.as_ref()).unwrap(),
+            secret: Ed25519PrivateKey::from_bytes(self.secret.as_ref()).unwrap(),
         }
     }
 

--- a/crypto/src/tests/ed25519_tests.rs
+++ b/crypto/src/tests/ed25519_tests.rs
@@ -418,6 +418,15 @@ fn test_public_key_bytes_conversion() {
     assert_eq!(kp.public().as_bytes(), rebuilded_pk.as_bytes());
 }
 
+#[test]
+fn test_copy_key_pair() {
+    let kp = keys().pop().unwrap();
+    let kp_copied = kp.copy();
+
+    assert_eq!(kp.public().0.as_bytes(), kp_copied.public().0.as_bytes());
+    assert_eq!(kp.private().0.as_bytes(), kp_copied.private().0.as_bytes());
+}
+
 #[tokio::test]
 async fn signature_service() {
     // Get a keypair.

--- a/executor/src/batch_loader.rs
+++ b/executor/src/batch_loader.rs
@@ -40,7 +40,7 @@ impl<PublicKey: VerifyingKey> BatchLoader<PublicKey> {
         store: Store<BatchDigest, SerializedBatchMessage>,
         rx_input: Receiver<ConsensusOutput<PublicKey>>,
         addresses: HashMap<WorkerId, Multiaddr>,
-    ) -> JoinHandle<SubscriberResult<()>> {
+    ) -> JoinHandle<()> {
         tokio::spawn(async move {
             Self {
                 store,
@@ -50,6 +50,7 @@ impl<PublicKey: VerifyingKey> BatchLoader<PublicKey> {
             }
             .run()
             .await
+            .unwrap();
         })
     }
 
@@ -86,6 +87,7 @@ impl<PublicKey: VerifyingKey> BatchLoader<PublicKey> {
                     .expect("Sync connections are kept alive and never die");
             }
         }
+
         Ok(())
     }
 }

--- a/executor/src/core.rs
+++ b/executor/src/core.rs
@@ -61,7 +61,7 @@ where
             let execution_indices = execution_state
                 .load_execution_indices()
                 .await
-                .unwrap_or_default();
+                .expect("Couldn't load execution indices");
             Self {
                 store,
                 execution_state,

--- a/executor/src/core.rs
+++ b/executor/src/core.rs
@@ -56,9 +56,12 @@ where
         execution_state: Arc<State>,
         rx_subscriber: Receiver<ConsensusOutput<PublicKey>>,
         tx_output: Sender<(SubscriberResult<Vec<u8>>, SerializedTransaction)>,
-    ) -> JoinHandle<SubscriberResult<()>> {
+    ) -> JoinHandle<()> {
         tokio::spawn(async move {
-            let execution_indices = execution_state.load_execution_indices().await?;
+            let execution_indices = execution_state
+                .load_execution_indices()
+                .await
+                .unwrap_or_default();
             Self {
                 store,
                 execution_state,
@@ -68,6 +71,7 @@ where
             }
             .run()
             .await
+            .unwrap();
         })
     }
 

--- a/executor/src/errors.rs
+++ b/executor/src/errors.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use config::WorkerId;
+use std::fmt::Debug;
 use store::StoreError;
 use thiserror::Error;
 use types::SequenceNumber;
@@ -64,7 +65,7 @@ impl From<Box<bincode::ErrorKind>> for SubscriberError {
 
 /// Trait do separate execution errors in two categories: (i) errors caused by a bad client, (ii)
 /// errors caused by a fault in the authority.
-pub trait ExecutionStateError {
+pub trait ExecutionStateError: Debug {
     /// Whether the error is due to a fault in the authority (eg. internal storage error).
     fn node_error(&self) -> bool;
 

--- a/executor/src/lib.rs
+++ b/executor/src/lib.rs
@@ -87,11 +87,7 @@ impl Executor {
         rx_consensus: Receiver<ConsensusOutput<PublicKey>>,
         tx_consensus: Sender<ConsensusSyncRequest>,
         tx_output: Sender<(SubscriberResult<Vec<u8>>, SerializedTransaction)>,
-    ) -> SubscriberResult<(
-        JoinHandle<SubscriberResult<()>>,
-        JoinHandle<SubscriberResult<()>>,
-        JoinHandle<SubscriberResult<()>>,
-    )>
+    ) -> SubscriberResult<Vec<JoinHandle<()>>>
     where
         State: ExecutionState + Send + Sync + 'static,
         PublicKey: VerifyingKey,
@@ -143,6 +139,10 @@ impl Executor {
 
         // Return the handle.
         info!("Consensus subscriber successfully started");
-        Ok((subscriber_handle, executor_handle, batch_loader_handle))
+        Ok(vec![
+            subscriber_handle,
+            executor_handle,
+            batch_loader_handle,
+        ])
     }
 }

--- a/executor/src/subscriber.rs
+++ b/executor/src/subscriber.rs
@@ -52,7 +52,7 @@ impl<PublicKey: VerifyingKey> Subscriber<PublicKey> {
         tx_batch_loader: Sender<ConsensusOutput<PublicKey>>,
         tx_executor: Sender<ConsensusOutput<PublicKey>>,
         next_consensus_index: SequenceNumber,
-    ) -> JoinHandle<SubscriberResult<()>> {
+    ) -> JoinHandle<()> {
         tokio::spawn(async move {
             Self {
                 store,
@@ -64,6 +64,7 @@ impl<PublicKey: VerifyingKey> Subscriber<PublicKey> {
             }
             .run()
             .await
+            .unwrap();
         })
     }
 

--- a/primary/tests/causal_completion_tests.rs
+++ b/primary/tests/causal_completion_tests.rs
@@ -54,20 +54,10 @@ async fn test_read_causal_signed_certificates() {
     let mut node_made_progress = false;
     let node = cluster.authority(0);
 
-    // show case the transactions channel
-    /*
-    let mut receiver = node.primary.tx_transaction_confirmation.subscribe();
-    loop {
-        if let Ok(result) = receiver.recv().await {
-            // do something here
-        }
-    }
-     */
-
     for _ in 0..10 {
         tokio::time::sleep(Duration::from_secs(1)).await;
 
-        let metric_family = node.registry.gather();
+        let metric_family = node.primary.registry.gather();
 
         for metric in metric_family {
             if metric.get_name() == CURRENT_ROUND_METRIC {

--- a/primary/tests/causal_completion_tests.rs
+++ b/primary/tests/causal_completion_tests.rs
@@ -14,10 +14,10 @@ async fn test_read_causal_signed_certificates() {
     // nodes logs.
     setup_tracing();
 
-    let mut cluster = Cluster::new(None);
+    let mut cluster = Cluster::new(None, None);
 
     // start the cluster
-    cluster.start(4).await;
+    cluster.start(Some(4), Some(1)).await;
 
     // Let primaries advance little bit
     tokio::time::sleep(Duration::from_secs(10)).await;
@@ -46,13 +46,14 @@ async fn test_read_causal_signed_certificates() {
     tokio::time::sleep(Duration::from_secs(10)).await;
 
     // Now start the validator 0 again
-    cluster.start_node(0, true).await;
+    cluster.start_node(0, true, Some(1)).await;
 
     // Now check that the current round advances. Give the opportunity with a few
     // iterations. If metric hasn't picked up then we know that node can't make
     // progress.
     let mut node_made_progress = false;
     let node = cluster.authority(0);
+
     for _ in 0..10 {
         tokio::time::sleep(Duration::from_secs(1)).await;
 

--- a/primary/tests/causal_completion_tests.rs
+++ b/primary/tests/causal_completion_tests.rs
@@ -46,7 +46,7 @@ async fn test_read_causal_signed_certificates() {
     tokio::time::sleep(Duration::from_secs(10)).await;
 
     // Now start the validator 0 again
-    let node = cluster.start_node(0).await.unwrap();
+    let node = cluster.start_node(0, true).await.unwrap();
 
     // Now check that the current round advances. Give the opportunity with a few
     // iterations. If metric hasn't picked up then we know that node can't make

--- a/primary/tests/causal_completion_tests.rs
+++ b/primary/tests/causal_completion_tests.rs
@@ -54,6 +54,16 @@ async fn test_read_causal_signed_certificates() {
     let mut node_made_progress = false;
     let node = cluster.authority(0);
 
+    // show case the transactions channel
+    /*
+    let mut receiver = node.primary.tx_transaction_confirmation.subscribe();
+    loop {
+        if let Ok(result) = receiver.recv().await {
+            // do something here
+        }
+    }
+     */
+
     for _ in 0..10 {
         tokio::time::sleep(Duration::from_secs(1)).await;
 

--- a/test_utils/Cargo.toml
+++ b/test_utils/Cargo.toml
@@ -27,7 +27,7 @@ tracing = "0.1.35"
 prometheus = "0.13.1"
 
 config = { path = "../config" }
-crypto = { path = "../crypto" }
+crypto = { path = "../crypto", features = ["copy_key"] }
 types = { path = "../types" }
 worker = { path = "../worker"}
 node = { path = "../node"}

--- a/test_utils/src/cluster.rs
+++ b/test_utils/src/cluster.rs
@@ -4,12 +4,11 @@ use crate::{committee, keys, temp_dir};
 use arc_swap::ArcSwap;
 use config::{Committee, Parameters};
 use crypto::{ed25519::Ed25519PublicKey, traits::KeyPair};
-use executor::SubscriberResult;
 use node::{
     execution_state::SimpleExecutionState, metrics::primary_metrics_registry, Node, NodeStorage,
 };
 use prometheus::Registry;
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{collections::HashMap, path::PathBuf, sync::Arc, time::Duration};
 use tokio::{sync::mpsc::channel, task::JoinHandle};
 use tracing::info;
 
@@ -18,7 +17,18 @@ pub struct NodeDetails {
     pub id: usize,
     pub name: Ed25519PublicKey,
     pub registry: Registry,
-    handlers: SubscriberResult<Vec<JoinHandle<()>>>,
+    pub store_path: PathBuf,
+    handlers: Vec<JoinHandle<()>>,
+}
+
+impl NodeDetails {
+    /// This method returns whether the node is still running or not. We
+    /// iterate over all the handlers and check whether there is still any
+    /// that is not finished. If we find at least one, then we report the
+    /// node as still running.
+    fn is_running(&self) -> bool {
+        self.handlers.iter().any(|h| !h.is_finished())
+    }
 }
 
 pub struct Cluster {
@@ -34,13 +44,25 @@ impl Cluster {
         info!("###### Creating new cluster ######");
         info!("Validator keys:");
         let k = keys(None);
+        let mut nodes = HashMap::new();
 
         for (index, key) in k.into_iter().enumerate() {
             info!("Key {index} -> {}", key.public().clone());
+
+            nodes.insert(
+                index,
+                Arc::new(NodeDetails {
+                    id: index,
+                    name: key.public().clone(),
+                    registry: Registry::new(),
+                    store_path: Default::default(),
+                    handlers: vec![],
+                }),
+            );
         }
 
         Self {
-            nodes: HashMap::new(),
+            nodes,
             committee_shared: Arc::new(ArcSwap::from_pointee(committee)),
             parameters: parameters.unwrap_or_else(Self::parameters),
         }
@@ -60,7 +82,7 @@ impl Cluster {
 
         for id in 0..nodes_number {
             info!("Spinning up node: {id}");
-            let node = self.start_node(id).await;
+            let node = self.start_node(id, false).await;
 
             regs.push(node.unwrap());
         }
@@ -71,8 +93,17 @@ impl Cluster {
     /// Starts a node by the defined id - if not already running - and
     /// the details are returned. If the node is already running then an
     /// error is returned instead.
-    pub async fn start_node(&mut self, id: usize) -> Result<Arc<NodeDetails>, ()> {
-        if self.nodes.contains_key(&id) {
+    /// When the preserve_store is true then the started node will use the
+    /// same path that has been used the last time when the node was started.
+    /// This is basically a way to use the same storage between node restarts.
+    pub async fn start_node(
+        &mut self,
+        id: usize,
+        preserve_store: bool,
+    ) -> Result<Arc<NodeDetails>, ()> {
+        let node = self.nodes.get(&id).unwrap();
+
+        if node.is_running() {
             return Err(());
         }
 
@@ -83,7 +114,15 @@ impl Cluster {
         let registry = primary_metrics_registry(name.clone());
 
         // Make the data store.
-        let store: NodeStorage<Ed25519PublicKey> = NodeStorage::reopen(temp_dir());
+        let store_path = if preserve_store {
+            node.store_path.clone()
+        } else {
+            temp_dir()
+        };
+
+        info!("Node {} will use path {:?}", id, store_path.clone());
+
+        let store: NodeStorage<Ed25519PublicKey> = NodeStorage::reopen(store_path.clone());
 
         // The channel returning the result for each transaction's execution.
         let (tx_transaction_confirmation, _) = channel(Node::CHANNEL_CAPACITY);
@@ -104,7 +143,8 @@ impl Cluster {
             id,
             name,
             registry,
-            handlers: h,
+            handlers: h.unwrap(),
+            store_path,
         });
 
         // Insert to the nodes map
@@ -117,10 +157,8 @@ impl Cluster {
     /// either when the node has been successfully stopped or even when
     /// the node doesn't exist.
     pub fn stop_node(&mut self, id: usize) {
-        if let Some(node) = self.nodes.remove(&id) {
-            if let Ok(handlers) = &node.handlers {
-                handlers.iter().for_each(|h| h.abort());
-            }
+        if let Some(node) = self.nodes.get_mut(&id) {
+            node.handlers.iter().for_each(|h| h.abort());
             info!("Aborted node for id {id}");
         } else {
             info!("Node with {id} not found - nothing to stop");

--- a/test_utils/src/cluster.rs
+++ b/test_utils/src/cluster.rs
@@ -2,70 +2,340 @@
 // SPDX-License-Identifier: Apache-2.0
 use crate::{committee, keys, temp_dir};
 use arc_swap::ArcSwap;
-use config::{Committee, Parameters};
-use crypto::{ed25519::Ed25519PublicKey, traits::KeyPair};
+use config::{Committee, Parameters, SharedCommittee, WorkerId};
+use crypto::{
+    ed25519::{Ed25519KeyPair, Ed25519PrivateKey, Ed25519PublicKey},
+    traits::{KeyPair, ToFromBytes},
+};
+use multiaddr::Multiaddr;
 use node::{
-    execution_state::SimpleExecutionState, metrics::primary_metrics_registry, Node, NodeStorage,
+    execution_state::SimpleExecutionState,
+    metrics::{primary_metrics_registry, worker_metrics_registry},
+    Node, NodeStorage,
 };
 use prometheus::Registry;
 use std::{collections::HashMap, path::PathBuf, sync::Arc, time::Duration};
 use tokio::{sync::mpsc::channel, task::JoinHandle};
 use tracing::info;
 
-#[allow(dead_code)]
-pub struct NodeDetails {
+#[derive(Clone)]
+pub struct PrimaryNodeDetails {
     pub id: usize,
-    pub name: Ed25519PublicKey,
-    pub registry: Registry,
+    pub key_pair: Arc<Ed25519KeyPair>,
     pub store_path: PathBuf,
-    handlers: Vec<JoinHandle<()>>,
+    pub registry: Registry,
+    committee: SharedCommittee<Ed25519PublicKey>,
+    parameters: Parameters,
+    handlers: Arc<ArcSwap<Vec<JoinHandle<()>>>>,
 }
 
-impl NodeDetails {
+impl PrimaryNodeDetails {
+    fn new(
+        id: usize,
+        key_pair: Ed25519KeyPair,
+        parameters: Parameters,
+        committee: SharedCommittee<Ed25519PublicKey>,
+    ) -> Self {
+        Self {
+            id,
+            key_pair: Arc::new(key_pair),
+            registry: Registry::new(),
+            store_path: temp_dir(),
+            committee,
+            parameters,
+            handlers: Arc::new(ArcSwap::from_pointee(Vec::new())),
+        }
+    }
+
+    pub async fn start(&mut self, preserve_store: bool) {
+        if self.is_running() {
+            panic!("Tried to start a node that is already running");
+        }
+
+        let registry = primary_metrics_registry(self.key_pair.public().clone());
+
+        // Make the data store.
+        let store_path = if preserve_store {
+            self.store_path.clone()
+        } else {
+            temp_dir()
+        };
+
+        info!(
+            "Primary Node {} will use path {:?}",
+            self.id,
+            store_path.clone()
+        );
+
+        // The channel returning the result for each transaction's execution.
+        let (tx_transaction_confirmation, _) = channel(Node::CHANNEL_CAPACITY);
+
+        let pub_key = Ed25519PublicKey::from_bytes(self.key_pair.name.0.as_bytes()).unwrap();
+        let private_key = Ed25519PrivateKey::from_bytes(self.key_pair.secret.0.as_bytes()).unwrap();
+
+        let key_pair = Ed25519KeyPair {
+            name: pub_key,
+            secret: private_key,
+        };
+
+        // Primary node
+        let primary_store: NodeStorage<Ed25519PublicKey> = NodeStorage::reopen(store_path.clone());
+        let primary_handlers = Node::spawn_primary(
+            key_pair,
+            self.committee.clone(),
+            &primary_store,
+            self.parameters.clone(),
+            /* consensus */ true,
+            /* execution_state */ Arc::new(SimpleExecutionState),
+            tx_transaction_confirmation,
+            &registry,
+        )
+        .await
+        .unwrap();
+
+        self.handlers.swap(Arc::new(primary_handlers));
+        self.store_path = store_path;
+        self.registry = registry;
+    }
+
+    pub fn stop(&self) {
+        self.handlers.load().iter().for_each(|h| h.abort());
+        info!("Aborted primary node for id {}", self.id);
+    }
+
     /// This method returns whether the node is still running or not. We
     /// iterate over all the handlers and check whether there is still any
     /// that is not finished. If we find at least one, then we report the
     /// node as still running.
     fn is_running(&self) -> bool {
-        self.handlers.iter().any(|h| !h.is_finished())
+        if self.handlers.load().is_empty() {
+            return false;
+        }
+
+        self.handlers.load().iter().any(|h| !h.is_finished())
+    }
+}
+
+#[derive(Clone)]
+pub struct WorkerNodeDetails {
+    pub id: WorkerId,
+    pub transactions_address: Multiaddr,
+    pub registry: Registry,
+    name: Ed25519PublicKey,
+    committee: SharedCommittee<Ed25519PublicKey>,
+    parameters: Parameters,
+    store_path: PathBuf,
+    handlers: Arc<ArcSwap<Vec<JoinHandle<()>>>>,
+}
+
+impl WorkerNodeDetails {
+    fn new(
+        id: WorkerId,
+        name: Ed25519PublicKey,
+        parameters: Parameters,
+        transactions_address: Multiaddr,
+        committee: SharedCommittee<Ed25519PublicKey>,
+    ) -> Self {
+        Self {
+            id,
+            name,
+            registry: Registry::new(),
+            store_path: temp_dir(),
+            transactions_address,
+            committee,
+            parameters,
+            handlers: Arc::new(ArcSwap::from_pointee(Vec::new())),
+        }
+    }
+
+    pub async fn start(&mut self, preserve_store: bool) {
+        if self.is_running() {
+            panic!(
+                "Worker with id {} is already running, can't start again",
+                self.id
+            );
+        }
+
+        let registry = worker_metrics_registry(self.id, self.name.clone());
+
+        // Make the data store.
+        let store_path = if preserve_store {
+            self.store_path.clone()
+        } else {
+            temp_dir()
+        };
+
+        let worker_store = NodeStorage::reopen(store_path.clone());
+        let worker_handlers = Node::spawn_workers(
+            self.name.clone(),
+            vec![self.id],
+            self.committee.clone(),
+            &worker_store,
+            self.parameters.clone(),
+            &registry,
+        );
+
+        self.handlers.swap(Arc::new(worker_handlers));
+        self.store_path = store_path;
+        self.registry = registry;
+    }
+
+    pub fn stop(&self) {
+        self.handlers.load().iter().for_each(|h| h.abort());
+        info!("Aborted worker node for id {}", self.id);
+    }
+
+    /// This method returns whether the node is still running or not. We
+    /// iterate over all the handlers and check whether there is still any
+    /// that is not finished. If we find at least one, then we report the
+    /// node as still running.
+    fn is_running(&self) -> bool {
+        self.handlers.load().iter().any(|h| !h.is_finished())
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Clone)]
+pub struct AuthorityDetails {
+    pub id: usize,
+    pub name: Ed25519PublicKey,
+    pub registry: Registry,
+    pub primary: PrimaryNodeDetails,
+    pub workers: HashMap<WorkerId, WorkerNodeDetails>,
+}
+
+impl AuthorityDetails {
+    pub fn new(
+        id: usize,
+        key_pair: Ed25519KeyPair,
+        parameters: Parameters,
+        committee: SharedCommittee<Ed25519PublicKey>,
+    ) -> Self {
+        // Create all the nodes we have in the committee
+        let name = key_pair.public().clone();
+        let primary = PrimaryNodeDetails::new(id, key_pair, parameters.clone(), committee.clone());
+
+        // Create all the workers - even if we don't intend to start them all
+        let mut workers = HashMap::new();
+        for (worker_id, addresses) in committee
+            .load()
+            .authorities
+            .get(&name)
+            .unwrap()
+            .workers
+            .clone()
+        {
+            let worker = WorkerNodeDetails::new(
+                worker_id,
+                name.clone(),
+                parameters.clone(),
+                addresses.transactions.clone(),
+                committee.clone(),
+            );
+            workers.insert(worker_id, worker);
+        }
+
+        Self {
+            id,
+            name,
+            registry: Registry::new(),
+            primary,
+            workers,
+        }
+    }
+
+    fn is_running(&self) -> bool {
+        if self.primary.is_running() {
+            return true;
+        }
+
+        for (_, worker) in self.workers.iter() {
+            if worker.is_running() {
+                return true;
+            }
+        }
+        false
+    }
+
+    pub async fn start_primary(&mut self, preserve_store: bool) {
+        self.primary.start(preserve_store).await;
+    }
+
+    pub fn stop_primary(&self) {
+        self.primary.stop();
+    }
+
+    pub async fn start_worker(&mut self, id: WorkerId, preserve_store: bool) {
+        self.workers
+            .get_mut(&id)
+            .unwrap_or_else(|| panic!("Worker with id {} not found ", id))
+            .start(preserve_store)
+            .await;
+    }
+
+    pub fn stop_worker(&self, id: WorkerId) {
+        self.workers
+            .get(&id)
+            .unwrap_or_else(|| panic!("Worker with id {} not found ", id))
+            .stop();
+    }
+
+    pub fn stop_all(&self) {
+        self.primary.stop();
+
+        for (_, worker) in self.workers.iter() {
+            worker.stop();
+        }
     }
 }
 
 pub struct Cluster {
-    nodes: HashMap<usize, Arc<NodeDetails>>,
+    authorities: HashMap<usize, AuthorityDetails>,
     committee_shared: Arc<ArcSwap<Committee<Ed25519PublicKey>>>,
+    #[allow(dead_code)]
     parameters: Parameters,
 }
 
 impl Cluster {
     pub fn new(parameters: Option<Parameters>) -> Self {
         let committee = committee(None);
+        let shared_committee = Arc::new(ArcSwap::from_pointee(committee));
+        let params = parameters.unwrap_or_else(Self::parameters);
 
         info!("###### Creating new cluster ######");
         info!("Validator keys:");
         let k = keys(None);
         let mut nodes = HashMap::new();
 
-        for (index, key) in k.into_iter().enumerate() {
-            info!("Key {index} -> {}", key.public().clone());
+        for (id, key_pair) in k.into_iter().enumerate() {
+            info!("Key {id} -> {}", key_pair.public().clone());
 
-            nodes.insert(
-                index,
-                Arc::new(NodeDetails {
-                    id: index,
-                    name: key.public().clone(),
-                    registry: Registry::new(),
-                    store_path: Default::default(),
-                    handlers: vec![],
-                }),
-            );
+            let authority =
+                AuthorityDetails::new(id, key_pair, params.clone(), shared_committee.clone());
+            nodes.insert(id, authority);
         }
 
         Self {
-            nodes,
-            committee_shared: Arc::new(ArcSwap::from_pointee(committee)),
-            parameters: parameters.unwrap_or_else(Self::parameters),
+            authorities: nodes,
+            committee_shared: shared_committee,
+            parameters: params,
         }
+    }
+
+    /// Returns the running authorities
+    pub fn authorities(&mut self) -> Vec<AuthorityDetails> {
+        self.authorities
+            .iter()
+            .filter(|(_, authority)| authority.is_running())
+            .map(|(_, authority)| authority.clone())
+            .collect()
+    }
+
+    pub fn authority(&mut self, id: usize) -> AuthorityDetails {
+        self.authorities
+            .get(&id)
+            .unwrap_or_else(|| panic!("Authority with id {} not found", id))
+            .clone()
     }
 
     /// Starts a cluster by the defined number of validators.
@@ -73,92 +343,44 @@ impl Cluster {
     /// started.
     /// Returns a tuple for each spin up node with their id and
     /// the corresponding Registry
-    pub async fn start(&mut self, nodes_number: usize) -> Vec<Arc<NodeDetails>> {
-        let mut regs = Vec::new();
-
+    pub async fn start(&mut self, nodes_number: usize) {
         if nodes_number > self.committee_shared.load().authorities.len() {
             panic!("Provided nodes number is greater than the maximum allowed");
         }
 
         for id in 0..nodes_number {
             info!("Spinning up node: {id}");
-            let node = self.start_node(id, false).await;
-
-            regs.push(node.unwrap());
+            self.start_node(id, false).await;
         }
-
-        regs
     }
 
     /// Starts a node by the defined id - if not already running - and
     /// the details are returned. If the node is already running then an
     /// error is returned instead.
-    /// When the preserve_store is true then the started node will use the
+    /// When the preserve_store is true, then the started node will use the
     /// same path that has been used the last time when the node was started.
     /// This is basically a way to use the same storage between node restarts.
-    pub async fn start_node(
-        &mut self,
-        id: usize,
-        preserve_store: bool,
-    ) -> Result<Arc<NodeDetails>, ()> {
-        let node = self.nodes.get(&id).unwrap();
+    /// When the preserve_store is false, then node will start with an empty
+    /// storage.
+    pub async fn start_node(&mut self, id: usize, preserve_store: bool) {
+        let authority = self
+            .authorities
+            .get_mut(&id)
+            .unwrap_or_else(|| panic!("Authority with id {} not found", id));
 
-        if node.is_running() {
-            return Err(());
-        }
+        // start the primary
+        authority.start_primary(preserve_store).await;
 
-        let mut k = keys(None);
-        let keypair = k.remove(id);
-        let name = keypair.public().clone();
-
-        let registry = primary_metrics_registry(name.clone());
-
-        // Make the data store.
-        let store_path = if preserve_store {
-            node.store_path.clone()
-        } else {
-            temp_dir()
-        };
-
-        info!("Node {} will use path {:?}", id, store_path.clone());
-
-        let store: NodeStorage<Ed25519PublicKey> = NodeStorage::reopen(store_path.clone());
-
-        // The channel returning the result for each transaction's execution.
-        let (tx_transaction_confirmation, _) = channel(Node::CHANNEL_CAPACITY);
-
-        let h = Node::spawn_primary(
-            keypair,
-            self.committee_shared.clone(),
-            &store,
-            self.parameters.clone(),
-            /* consensus */ true,
-            /* execution_state */ Arc::new(SimpleExecutionState),
-            tx_transaction_confirmation,
-            &registry,
-        )
-        .await;
-
-        let node = Arc::new(NodeDetails {
-            id,
-            name,
-            registry,
-            handlers: h.unwrap(),
-            store_path,
-        });
-
-        // Insert to the nodes map
-        self.nodes.insert(id, node.clone());
-
-        Ok(node)
+        // start only the worker with id 0
+        authority.start_worker(0, preserve_store).await;
     }
 
     /// This method stops a node by the provided id. The method will return
     /// either when the node has been successfully stopped or even when
     /// the node doesn't exist.
     pub fn stop_node(&mut self, id: usize) {
-        if let Some(node) = self.nodes.get_mut(&id) {
-            node.handlers.iter().for_each(|h| h.abort());
+        if let Some(node) = self.authorities.get_mut(&id) {
+            node.stop_all();
             info!("Aborted node for id {id}");
         } else {
             info!("Node with {id} not found - nothing to stop");

--- a/test_utils/src/tests/cluster_tests.rs
+++ b/test_utils/src/tests/cluster_tests.rs
@@ -1,3 +1,5 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
 use crate::cluster::Cluster;
 use std::time::Duration;
 

--- a/test_utils/src/tests/cluster_tests.rs
+++ b/test_utils/src/tests/cluster_tests.rs
@@ -1,0 +1,33 @@
+use crate::cluster::Cluster;
+use std::time::Duration;
+
+#[tokio::test]
+async fn basic_cluster_setup() {
+    let mut cluster = Cluster::new(None, None);
+
+    // start the cluster will all the possible nodes
+    cluster.start(None, None).await;
+
+    // give some time for nodes to boostrap
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // fetch all the running authorities
+    let authorities = cluster.authorities();
+
+    assert_eq!(authorities.len(), 4);
+
+    // fetch their workers transactions address
+    for authority in cluster.authorities() {
+        assert_eq!(authority.worker_transaction_addresses().len(), 4);
+    }
+
+    // now stop all authorities
+    for id in 0..4 {
+        cluster.stop_node(id);
+    }
+
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // No authority should still run
+    assert!(cluster.authorities().is_empty());
+}

--- a/worker/src/metrics.rs
+++ b/worker/src/metrics.rs
@@ -1,32 +1,21 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use prometheus::{default_registry, register_int_gauge_vec_with_registry, IntGaugeVec, Registry};
-use std::sync::Once;
 
 #[derive(Clone)]
 pub struct Metrics {
     pub worker_metrics: Option<WorkerMetrics>,
 }
 
-static mut METRICS: Metrics = Metrics {
-    worker_metrics: None,
-};
-static INIT: Once = Once::new();
-
 /// Initialises the metrics. Should be called only once when the worker
 /// node is initialised, otherwise it will lead to erroneously creating
 /// multiple registries.
 pub fn initialise_metrics(metrics_registry: &Registry) -> Metrics {
-    unsafe {
-        INIT.call_once(|| {
-            // Essential/core metrics across the worker node
-            let node_metrics = WorkerMetrics::new(metrics_registry);
+    // Essential/core metrics across the worker node
+    let node_metrics = WorkerMetrics::new(metrics_registry);
 
-            METRICS = Metrics {
-                worker_metrics: Some(node_metrics),
-            }
-        });
-        METRICS.clone()
+    Metrics {
+        worker_metrics: Some(node_metrics),
     }
 }
 

--- a/worker/src/worker.rs
+++ b/worker/src/worker.rs
@@ -216,7 +216,12 @@ impl<PublicKey: VerifyingKey> Worker<PublicKey> {
             self.id, address
         );
 
-        vec![batch_maker_handle, quorum_waiter_handle, processor_handle, tx_receiver_handle]
+        vec![
+            batch_maker_handle,
+            quorum_waiter_handle,
+            processor_handle,
+            tx_receiver_handle,
+        ]
     }
 
     /// Spawn all tasks responsible to handle messages from other workers.
@@ -438,7 +443,8 @@ impl<PublicKey: VerifyingKey> PrimaryReceiverHandler<PublicKey> {
                 .await
                 .unwrap()
                 .serve()
-                .await.unwrap()
+                .await
+                .unwrap()
         })
     }
 }

--- a/worker/src/worker.rs
+++ b/worker/src/worker.rs
@@ -129,7 +129,7 @@ impl<PublicKey: VerifyingKey> Worker<PublicKey> {
         let address = address
             .replace(0, |_protocol| Some(Protocol::Ip4(INADDR_ANY)))
             .unwrap();
-        PrimaryReceiverHandler { tx_synchronizer }.spawn(address.clone());
+        let primary_handle = PrimaryReceiverHandler { tx_synchronizer }.spawn(address.clone());
 
         // The `Synchronizer` is responsible to keep the worker in sync with the others. It handles the commands
         // it receives from the primary (which are mainly notifications that we are out of sync).
@@ -152,7 +152,7 @@ impl<PublicKey: VerifyingKey> Worker<PublicKey> {
             self.id, address
         );
 
-        vec![handle]
+        vec![handle, primary_handle]
     }
 
     /// Spawn all tasks responsible to handle clients transactions.
@@ -175,7 +175,7 @@ impl<PublicKey: VerifyingKey> Worker<PublicKey> {
         let address = address
             .replace(0, |_protocol| Some(Protocol::Ip4(INADDR_ANY)))
             .unwrap();
-        TxReceiverHandler { tx_batch_maker }.spawn(address.clone());
+        let tx_receiver_handle = TxReceiverHandler { tx_batch_maker }.spawn(address.clone());
 
         // The transactions are sent to the `BatchMaker` that assembles them into batches. It then broadcasts
         // (in a reliable manner) the batches to all other workers that share the same `id` as us. Finally, it
@@ -216,7 +216,7 @@ impl<PublicKey: VerifyingKey> Worker<PublicKey> {
             self.id, address
         );
 
-        vec![batch_maker_handle, quorum_waiter_handle, processor_handle]
+        vec![batch_maker_handle, quorum_waiter_handle, processor_handle, tx_receiver_handle]
     }
 
     /// Spawn all tasks responsible to handle messages from other workers.
@@ -239,7 +239,7 @@ impl<PublicKey: VerifyingKey> Worker<PublicKey> {
         let address = address
             .replace(0, |_protocol| Some(Protocol::Ip4(INADDR_ANY)))
             .unwrap();
-        WorkerReceiverHandler {
+        let worker_handle = WorkerReceiverHandler {
             tx_worker_helper,
             tx_client_helper,
             tx_processor,
@@ -272,7 +272,7 @@ impl<PublicKey: VerifyingKey> Worker<PublicKey> {
             self.id, address
         );
 
-        vec![helper_handle, processor_handle]
+        vec![helper_handle, processor_handle, worker_handle]
     }
 }
 
@@ -283,7 +283,7 @@ struct TxReceiverHandler {
 }
 
 impl TxReceiverHandler {
-    fn spawn(self, address: Multiaddr) {
+    fn spawn(self, address: Multiaddr) -> JoinHandle<()> {
         tokio::spawn(async move {
             let config = mysten_network::config::Config::new();
             config
@@ -294,7 +294,8 @@ impl TxReceiverHandler {
                 .unwrap()
                 .serve()
                 .await
-        });
+                .unwrap()
+        })
     }
 }
 
@@ -340,7 +341,7 @@ struct WorkerReceiverHandler<PublicKey: VerifyingKey> {
 }
 
 impl<PublicKey: VerifyingKey> WorkerReceiverHandler<PublicKey> {
-    fn spawn(self, address: Multiaddr, max_concurrent_requests: usize) {
+    fn spawn(self, address: Multiaddr, max_concurrent_requests: usize) -> JoinHandle<()> {
         tokio::spawn(async move {
             let mut config = mysten_network::config::Config::new();
             config.concurrency_limit_per_connection = Some(max_concurrent_requests);
@@ -352,7 +353,8 @@ impl<PublicKey: VerifyingKey> WorkerReceiverHandler<PublicKey> {
                 .unwrap()
                 .serve()
                 .await
-        });
+                .unwrap()
+        })
     }
 }
 
@@ -426,7 +428,7 @@ struct PrimaryReceiverHandler<PublicKey: VerifyingKey> {
 }
 
 impl<PublicKey: VerifyingKey> PrimaryReceiverHandler<PublicKey> {
-    fn spawn(self, address: Multiaddr) {
+    fn spawn(self, address: Multiaddr) -> JoinHandle<()> {
         tokio::spawn(async move {
             let config = mysten_network::config::Config::new();
             config
@@ -436,8 +438,8 @@ impl<PublicKey: VerifyingKey> PrimaryReceiverHandler<PublicKey> {
                 .await
                 .unwrap()
                 .serve()
-                .await
-        });
+                .await.unwrap()
+        })
     }
 }
 


### PR DESCRIPTION
Follow up of the #492 .

This PR is giving a generous refactoring in the `Cluster` struct so we have proper organisation of the nodes. Now the cluster is spinning up Authority nodes. Each Authority has `one primary` and `multiple workers`. Now each node type (worker & primary) are responsible for start /stop and report running status - which makes the organisation much cleaner. Helper methods and input configuration has been provided to allow start / stop nodes in a flexible way. Also the transactions addresses of the workers can now be accessed in order to be able to send transactions to the cluster.

As before , the prometheus Registries for the primary & worker nodes can be accessed to observe the metrics.

Next steps: 
1. expose the receiver of the `tx_transaction_confirmation` consensus channel of the primary so tests can be written to monitor the consensus output transactions
2. enable starting the cluster with consensus off (help us test cases with external consensus)

Apart from the above an important next step is to create tests around the bootstrap sequence of nodes to start addressing [this](https://www.notion.so/mystenlabs/Narwhal-Storm-July-11-4f3cc6c4698448c5820d3e949bc3764e#b7b1cec7f6dc42df9fa6938935c9c506)
