### PR TITLE
fix: Make the table of pending certificates concurrency-safe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2354,6 +2354,7 @@ dependencies = [
  "config",
  "consensus",
  "crypto",
+ "dashmap",
  "derive_builder",
  "ed25519-dalek",
  "executor",

--- a/primary/Cargo.toml
+++ b/primary/Cargo.toml
@@ -39,6 +39,7 @@ mysten-network = { git = "https://github.com/mystenlabs/mysten-infra.git", rev =
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 prometheus = "0.13.1"
 once_cell = "1.13.0"
+dashmap = "5.3.4"
 
 [dev-dependencies]
 arc-swap = { version = "1.5.0", features = ["serde"] }


### PR DESCRIPTION
Post #496 and in fact post the oneshot channel changes introduced in #486, the pending table of the `CertificateWaiter` can be accessed concurrently.

In some cases, our benchmark has revealed that the drop triggered by a call to `clear()` can interact with the `drain()` operation to create a double-send on the same `oneshot::Sender`, which panics.
(see comments on https://github.com/MystenLabs/narwhal/commit/29e853d2d65e543fa0f1dbc634d01576c0e8e60e for evidence and re-run the bench locally at that commit to repro)

This is now visible, because the GC actually fires more often post #496. Prior to #486, this issue was invisible, since we were using `mpsc` channels (which allow double sends).

This fixes the benchmark.