### PR TITLE
fix: do not panic on send failure for `waiter` items

### DIFF
--- a/crypto/src/ed25519.rs
+++ b/crypto/src/ed25519.rs
@@ -5,14 +5,18 @@ use base64ct::{Base64, Encoding};
 use serde::{de, Deserialize, Serialize};
 use serde_with::serde_as;
 use signature::{Signature, Signer, Verifier};
-use std::fmt::{self, Display};
-use std::str::FromStr;
+use std::{
+    fmt::{self, Display},
+    str::FromStr,
+};
 
-use crate::pubkey_bytes::PublicKeyBytes;
-use crate::serde_helpers::Ed25519Signature as Ed25519Sig;
-use crate::traits::{
-    AggregateAuthenticator, Authenticator, EncodeDecodeBase64, KeyPair, SigningKey, ToFromBytes,
-    VerifyingKey,
+use crate::{
+    pubkey_bytes::PublicKeyBytes,
+    serde_helpers::Ed25519Signature as Ed25519Sig,
+    traits::{
+        AggregateAuthenticator, Authenticator, EncodeDecodeBase64, KeyPair, SigningKey,
+        ToFromBytes, VerifyingKey,
+    },
 };
 
 ///

--- a/crypto/src/serde_helpers.rs
+++ b/crypto/src/serde_helpers.rs
@@ -3,10 +3,11 @@
 
 use base64ct::Encoding as _;
 use blst::min_sig as blst;
-use serde::de::{Deserializer, Error};
-use serde::ser::Serializer;
-use serde::Deserialize;
-use serde::Serialize;
+use serde::{
+    de::{Deserializer, Error},
+    ser::Serializer,
+    Deserialize, Serialize,
+};
 use serde_with::{Bytes, DeserializeAs, SerializeAs};
 use std::fmt::Debug;
 

--- a/primary/src/certificate_waiter.rs
+++ b/primary/src/certificate_waiter.rs
@@ -187,11 +187,12 @@ impl<PublicKey: VerifyingKey> CertificateWaiter<PublicKey> {
 
                 self.pending.retain(|_digest, (r, once_cancel)| {
                     if *r <= gc_round {
-                        once_cancel
+                        // note: this send can fail, harmlessly, if the certificate has been delivered (`notify_read`)
+                        // and the present code path fires before the corresponding `waiting` item is unpacked above.
+                        let _ = once_cancel
                             .take()
                             .expect("This should be protected by a write lock")
-                            .send(())
-                            .expect("fatal error sending pending cancellation signal");
+                            .send(());
                         false
                     } else {
                         true

--- a/primary/src/header_waiter.rs
+++ b/primary/src/header_waiter.rs
@@ -344,9 +344,9 @@ impl<PublicKey: VerifyingKey> HeaderWaiter<PublicKey> {
                     .drain()
                     .flat_map(|(digest, (r, handler))| {
                         if r <= gc_round {
-                            handler
-                                .send(())
-                                .expect("fatal error sending pending cancellation signal");
+                            // note: this send can fail, harmlessly, if the certificate has been delivered (`notify_read`)
+                            // and the present code path fires before the corresponding `waiting` item is unpacked above.
+                            let _ = handler.send(());
                             None
                         } else {
                             Some((digest, (r, handler)))


### PR DESCRIPTION
+ adds comment on reason for failure

The panic was introduced in fe7c11c8ef848a2e1c9a88e2002192484958a5f0, and its scope reduced in
d9b0f049938ec8cea11a0afe93db381efc4c67d5, but really should not have been there in the first place.