### PR TITLE
feat: update the mysten-infra pointer & switch to telemetry-subscribers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -789,6 +789,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae5588f6b3c3cb05239e90bd110f257254aecd01e4635400391aeae07497845"
+dependencies = [
+ "cfg-if",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -824,6 +838,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f25d8400f4a7a5778f0e4e52384a48cbd9b5c495d110786187fc750075277a2"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -831,6 +855,31 @@ checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
 dependencies = [
  "cfg-if",
  "lazy_static",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab9f7409c70a38a56216480fba371ee460207dd8926ccf5b4160591759559170"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "libc",
+ "mio",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ae1b35a484aa10e07fe0638d02301c5ad24de82d310ccbd2f3693da5f09bf1c"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -1401,6 +1450,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1ebd34e35c46e00bb73e81363248d627782724609fe1b6396f553f68fe3862e"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1675,6 +1734,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "integer-encoding"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
+
+[[package]]
 name = "itertools"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1712,6 +1777,12 @@ checksum = "671a26f820db17c2a2750743f1dd03bafd15b98c9f30c7c2628c024c05d73397"
 dependencies = [
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "json"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
 
 [[package]]
 name = "keccak"
@@ -2060,6 +2131,7 @@ dependencies = [
  "serde-reflection",
  "serde_yaml",
  "structopt",
+ "telemetry-subscribers",
  "test_utils",
  "thiserror",
  "tokio",
@@ -2182,6 +2254,60 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "opentelemetry"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6105e89802af13fdf48c49d7646d3b533a70e536d818aae7e78ba0433d01acb8"
+dependencies = [
+ "async-trait",
+ "crossbeam-channel",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "js-sys",
+ "lazy_static",
+ "percent-encoding",
+ "pin-project",
+ "rand 0.8.5",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "opentelemetry-jaeger"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8c0b12cd9e3f9b35b52f6e0dac66866c519b26f424f4bbf96e3fe8bfbdc5229"
+dependencies = [
+ "async-trait",
+ "lazy_static",
+ "opentelemetry",
+ "opentelemetry-semantic-conventions",
+ "thiserror",
+ "thrift",
+ "tokio",
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "985cc35d832d412224b2cffe2f9194b1b89b6aa5d0bef76d080dce09d90e62bd"
+dependencies = [
+ "opentelemetry",
+]
+
+[[package]]
+name = "ordered-float"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3305af35278dd29f46fcdd139e0b1fbfae2153f0e5928b39b035542dd31e37b7"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "os_str_bytes"
@@ -2434,6 +2560,7 @@ dependencies = [
  "prost",
  "rand 0.7.3",
  "serde",
+ "telemetry-subscribers",
  "tempfile",
  "test_utils",
  "thiserror",
@@ -2442,7 +2569,6 @@ dependencies = [
  "tonic",
  "tower",
  "tracing",
- "tracing-subscriber 0.3.14",
  "tracing-test",
  "typed-store",
  "types",
@@ -3159,6 +3285,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a253b5e89e2698464fc26b545c9edceb338e18a89effeeecfea192c3025be29d"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3325,6 +3472,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "telemetry-subscribers"
+version = "0.1.0"
+source = "git+https://github.com/mystenlabs/mysten-infra.git?rev=49613b62072eba3f3b2316f54fbe6a9e1926697b#49613b62072eba3f3b2316f54fbe6a9e1926697b"
+dependencies = [
+ "crossterm",
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry-jaeger",
+ "tokio",
+ "tracing",
+ "tracing-appender",
+ "tracing-bunyan-formatter",
+ "tracing-chrome",
+ "tracing-opentelemetry",
+ "tracing-subscriber 0.3.14",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3437,6 +3602,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
 dependencies = [
  "num_cpus",
+]
+
+[[package]]
+name = "thrift"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b82ca8f46f95b3ce96081fe3dd89160fdea970c254bb72925255d1b62aae692e"
+dependencies = [
+ "byteorder",
+ "integer-encoding",
+ "log",
+ "ordered-float",
+ "threadpool",
 ]
 
 [[package]]
@@ -3691,6 +3869,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d48f71a791638519505cefafe162606f706c25592e4bde4d97600c0195312e"
+dependencies = [
+ "crossbeam-channel",
+ "time",
+ "tracing-subscriber 0.3.14",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3699,6 +3888,35 @@ dependencies = [
  "proc-macro2 1.0.39",
  "quote 1.0.18",
  "syn 1.0.96",
+]
+
+[[package]]
+name = "tracing-bunyan-formatter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a788f2119fde477cd33823330c14004fa8cdac6892fd6f12181bbda9dbf14fc9"
+dependencies = [
+ "gethostname",
+ "log",
+ "serde",
+ "serde_json",
+ "time",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber 0.3.14",
+]
+
+[[package]]
+name = "tracing-chrome"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1ac1f6a3a47e9c755e65ef974653c978da2246487a16044a8ee1d9a0a67257c"
+dependencies = [
+ "crossbeam",
+ "json",
+ "tracing",
+ "tracing-subscriber 0.3.14",
 ]
 
 [[package]]
@@ -3730,6 +3948,20 @@ dependencies = [
  "lazy_static",
  "log",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.17.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbbe89715c1dbbb790059e2565353978564924ee85017b5fff365c872ff6721f"
+dependencies = [
+ "once_cell",
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber 0.3.14",
 ]
 
 [[package]]
@@ -3792,7 +4024,7 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 [[package]]
 name = "typed-store"
 version = "0.1.0"
-source = "git+https://github.com/mystenlabs/mysten-infra.git?rev=7e9b7568fc7184b4938976330122f3c8064e3236#7e9b7568fc7184b4938976330122f3c8064e3236"
+source = "git+https://github.com/mystenlabs/mysten-infra.git?rev=49613b62072eba3f3b2316f54fbe6a9e1926697b#49613b62072eba3f3b2316f54fbe6a9e1926697b"
 dependencies = [
  "bincode",
  "collectable",
@@ -4256,10 +4488,13 @@ dependencies = [
  "core2",
  "criterion",
  "criterion-plot",
+ "crossbeam",
  "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-epoch",
+ "crossbeam-queue",
  "crossbeam-utils",
+ "crossterm",
  "crypto-common",
  "crypto-mac",
  "csv",
@@ -4305,6 +4540,7 @@ dependencies = [
  "futures-task",
  "futures-util",
  "generic-array",
+ "gethostname",
  "getrandom 0.1.16",
  "getrandom 0.2.6",
  "gimli",
@@ -4332,10 +4568,12 @@ dependencies = [
  "indenter",
  "indexmap",
  "instant",
+ "integer-encoding",
  "itertools",
  "itoa 0.4.8",
  "itoa 1.0.2",
  "jobserver",
+ "json",
  "keccak",
  "lazy_static",
  "lazycell",
@@ -4375,6 +4613,10 @@ dependencies = [
  "once_cell",
  "oorandom",
  "opaque-debug",
+ "opentelemetry",
+ "opentelemetry-jaeger",
+ "opentelemetry-semantic-conventions",
+ "ordered-float",
  "os_str_bytes",
  "parking_lot",
  "parking_lot_core",
@@ -4476,6 +4718,7 @@ dependencies = [
  "syn 1.0.96",
  "sync_wrapper",
  "synstructure",
+ "telemetry-subscribers",
  "tempfile",
  "termcolor",
  "termtree",
@@ -4484,6 +4727,8 @@ dependencies = [
  "thiserror",
  "thiserror-impl",
  "thread_local",
+ "threadpool",
+ "thrift",
  "time",
  "tinytemplate",
  "tinyvec",
@@ -4503,10 +4748,14 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+ "tracing-appender",
  "tracing-attributes",
+ "tracing-bunyan-formatter",
+ "tracing-chrome",
  "tracing-core",
  "tracing-futures",
  "tracing-log",
+ "tracing-opentelemetry",
  "tracing-subscriber 0.2.25",
  "tracing-subscriber 0.3.14",
  "tracing-test",

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -16,7 +16,7 @@ rand = { version = "0.7.3", optional = true }
 rocksdb = { version = "0.18.0", features = ["snappy", "lz4", "zstd", "zlib"], default-features = false }
 serde = { version = "1.0.139", features = ["derive"] }
 serde_bytes = "0.11.6"
-store = { git = "https://github.com/mystenlabs/mysten-infra.git", package = "typed-store", rev = "7e9b7568fc7184b4938976330122f3c8064e3236" }
+store = { git = "https://github.com/mystenlabs/mysten-infra.git", package = "typed-store", rev = "49613b62072eba3f3b2316f54fbe6a9e1926697b" }
 thiserror = "1.0.31"
 tokio = { version = "1.20.0", features = ["sync"] }
 tracing = "0.1.35"

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -27,7 +27,7 @@ multiaddr = "0.14.0"
 types = { path = "../types" }
 worker = { path = "../worker" }
 
-store = { git = "https://github.com/mystenlabs/mysten-infra.git", package = "typed-store", rev = "7e9b7568fc7184b4938976330122f3c8064e3236" }
+store = { git = "https://github.com/mystenlabs/mysten-infra.git", package = "typed-store", rev = "49613b62072eba3f3b2316f54fbe6a9e1926697b" }
 mysten-network = { git = "https://github.com/mystenlabs/mysten-infra.git", rev = "c6dc7a23a40b3517f138d122a76d3bc15f844f67" }
 
 workspace-hack = { version = "0.1", path = "../workspace-hack" }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -15,7 +15,7 @@ cfg-if = "1.0.0"
 clap = "2.34"
 futures = "0.3.21"
 rand = "0.7.3"
-store = { git = "https://github.com/mystenlabs/mysten-infra.git", package = "typed-store", rev = "7e9b7568fc7184b4938976330122f3c8064e3236" }
+store = { git = "https://github.com/mystenlabs/mysten-infra.git", package = "typed-store", rev = "49613b62072eba3f3b2316f54fbe6a9e1926697b" }
 thiserror = "1.0.31"
 tokio = { version = "1.20.0", features = ["full"] }
 tokio-stream = "0.1.9"
@@ -23,6 +23,7 @@ tokio-util = { version = "0.7.3", features = ["codec"] }
 tracing = "0.1.35"
 tracing-log = "0.1.3"
 tracing-subscriber = { version = "0.3.14", features = ["time", "env-filter"] }
+telemetry-subscribers = { git = "https://github.com/mystenlabs/mysten-infra.git", rev = "49613b62072eba3f3b2316f54fbe6a9e1926697b" }
 url = "2.2.2"
 
 config = { path = "../config" }

--- a/primary/Cargo.toml
+++ b/primary/Cargo.toml
@@ -34,7 +34,7 @@ crypto = { path = "../crypto" }
 network = { path = "../network" }
 types = { path = "../types" }
 
-store = { git = "https://github.com/mystenlabs/mysten-infra.git", package = "typed-store", rev = "7e9b7568fc7184b4938976330122f3c8064e3236" }
+store = { git = "https://github.com/mystenlabs/mysten-infra.git", package = "typed-store", rev = "49613b62072eba3f3b2316f54fbe6a9e1926697b" }
 mysten-network = { git = "https://github.com/mystenlabs/mysten-infra.git", rev = "c6dc7a23a40b3517f138d122a76d3bc15f844f67" }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 prometheus = "0.13.1"
@@ -54,7 +54,7 @@ async-trait = "0.1.56"
 executor = { path = "../executor" }
 thiserror = "1.0.31"
 tracing = "0.1.35"
-tracing-subscriber = { version = "0.3.14", features = ["time", "env-filter"] }
+telemetry-subscribers = { git = "https://github.com/mystenlabs/mysten-infra.git", rev = "49613b62072eba3f3b2316f54fbe6a9e1926697b" }
 
 [features]
 benchmark = []

--- a/primary/tests/causal_completion_tests.rs
+++ b/primary/tests/causal_completion_tests.rs
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use std::time::Duration;
 use test_utils::cluster::Cluster;
-use tracing::{info, subscriber::set_global_default};
-use tracing_subscriber::filter::{EnvFilter, LevelFilter};
+use tracing::info;
 
 #[ignore]
 #[tokio::test]
@@ -86,15 +85,12 @@ fn setup_tracing() {
     let tracing_level = "debug";
     let network_tracing_level = "info";
 
-    let filter = EnvFilter::builder()
-        .with_default_directive(LevelFilter::INFO.into())
-        .parse(format!(
-            "{tracing_level},h2={network_tracing_level},tower={network_tracing_level},hyper={network_tracing_level},tonic::transport={network_tracing_level}"
-        )).unwrap();
-    let env_filter = EnvFilter::try_from_default_env().unwrap_or(filter);
-    let subscriber_builder =
-        tracing_subscriber::fmt::Subscriber::builder().with_env_filter(env_filter);
+    let log_filter = format!("{tracing_level},h2={network_tracing_level},tower={network_tracing_level},hyper={network_tracing_level},tonic::transport={network_tracing_level}");
 
-    let subscriber = subscriber_builder.with_writer(std::io::stderr).finish();
-    set_global_default(subscriber).expect("Failed to set subscriber");
+    let _guard = telemetry_subscribers::TelemetryConfig::new("narwhal")
+        // load env variables
+        .with_env()
+        // load special log filter
+        .with_log_level(&log_filter)
+        .init();
 }

--- a/test_utils/Cargo.toml
+++ b/test_utils/Cargo.toml
@@ -33,6 +33,6 @@ worker = { path = "../worker"}
 node = { path = "../node"}
 executor = { path = "../executor"}
 
-store = { git = "https://github.com/mystenlabs/mysten-infra.git", package = "typed-store", rev = "7e9b7568fc7184b4938976330122f3c8064e3236" }
+store = { git = "https://github.com/mystenlabs/mysten-infra.git", package = "typed-store", rev = "49613b62072eba3f3b2316f54fbe6a9e1926697b" }
 mysten-network = { git = "https://github.com/mystenlabs/mysten-infra.git", rev = "c6dc7a23a40b3517f138d122a76d3bc15f844f67" }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -18,7 +18,7 @@ proptest-derive = "0.3.0"
 prost = "0.10.4"
 rand = "0.7.3"
 serde = { version = "1.0.139", features = ["derive"] }
-store = { git = "https://github.com/mystenlabs/mysten-infra.git", package = "typed-store", rev = "7e9b7568fc7184b4938976330122f3c8064e3236" }
+store = { git = "https://github.com/mystenlabs/mysten-infra.git", package = "typed-store", rev = "49613b62072eba3f3b2316f54fbe6a9e1926697b" }
 thiserror = "1.0.31"
 tokio = { version = "1.20.0", features = ["sync", "rt", "macros"] }
 tokio-util = { version = "0.7.3", features = ["codec"] }

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -28,7 +28,7 @@ network = { path = "../network" }
 primary = { path = "../primary" }
 types = { path = "../types" }
 
-store = { git = "https://github.com/mystenlabs/mysten-infra.git", package = "typed-store", rev = "7e9b7568fc7184b4938976330122f3c8064e3236" }
+store = { git = "https://github.com/mystenlabs/mysten-infra.git", package = "typed-store", rev = "49613b62072eba3f3b2316f54fbe6a9e1926697b" }
 mysten-network = { git = "https://github.com/mystenlabs/mysten-infra.git", rev = "c6dc7a23a40b3517f138d122a76d3bc15f844f67" }
 prometheus = "0.13.1"
 workspace-hack = { version = "0.1", path = "../workspace-hack" }

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -67,10 +67,13 @@ constant_time_eq = { version = "0.1", default-features = false }
 core2 = { version = "0.4", default-features = false, features = ["alloc"] }
 criterion = { version = "0.3", features = ["cargo_bench_support"] }
 criterion-plot = { version = "0.4", default-features = false }
+crossbeam = { version = "0.8", features = ["alloc", "crossbeam-channel", "crossbeam-deque", "crossbeam-epoch", "crossbeam-queue", "std"] }
 crossbeam-channel = { version = "0.5", features = ["crossbeam-utils", "std"] }
 crossbeam-deque = { version = "0.8", features = ["crossbeam-epoch", "crossbeam-utils", "std"] }
 crossbeam-epoch = { version = "0.9", default-features = false, features = ["alloc", "lazy_static", "std"] }
+crossbeam-queue = { version = "0.3", default-features = false, features = ["alloc", "std"] }
 crossbeam-utils = { version = "0.8", features = ["lazy_static", "std"] }
+crossterm = { version = "0.24" }
 crypto-common = { version = "0.1", default-features = false, features = ["std"] }
 crypto-mac = { version = "0.8", default-features = false, features = ["std"] }
 csv = { version = "1", default-features = false }
@@ -100,12 +103,13 @@ fragile = { version = "1", default-features = false }
 futures = { version = "0.3", features = ["alloc", "async-await", "executor", "futures-executor", "std"] }
 futures-channel = { version = "0.3", features = ["alloc", "futures-sink", "sink", "std"] }
 futures-core = { version = "0.3", features = ["alloc", "std"] }
-futures-executor = { version = "0.3", default-features = false, features = ["std"] }
+futures-executor = { version = "0.3", features = ["std"] }
 futures-io = { version = "0.3", default-features = false, features = ["std"] }
 futures-sink = { version = "0.3", features = ["alloc", "std"] }
 futures-task = { version = "0.3", default-features = false, features = ["alloc", "std"] }
 futures-util = { version = "0.3", default-features = false, features = ["alloc", "async-await", "async-await-macro", "channel", "futures-channel", "futures-io", "futures-macro", "futures-sink", "io", "memchr", "sink", "slab", "std"] }
 generic-array = { version = "0.14", default-features = false, features = ["more_lengths"] }
+gethostname = { version = "0.2", default-features = false }
 getrandom-c65f7effa3be6d31 = { package = "getrandom", version = "0.1", default-features = false, features = ["std"] }
 getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
 gimli = { version = "0.26", default-features = false, features = ["read", "read-core"] }
@@ -130,9 +134,11 @@ idna = { version = "0.2", default-features = false }
 indenter = { version = "0.3" }
 indexmap = { version = "1", default-features = false, features = ["std"] }
 instant = { version = "0.1", default-features = false }
+integer-encoding = { version = "3", default-features = false }
 itertools = { version = "0.10", features = ["use_alloc", "use_std"] }
 itoa-9fbad63c4bcf4a8f = { package = "itoa", version = "0.4", features = ["std"] }
 itoa-dff4ba8e3ae991db = { package = "itoa", version = "1", default-features = false }
+json = { version = "0.12", default-features = false }
 keccak = { version = "0.1", default-features = false }
 lazy_static = { version = "1", default-features = false }
 libc = { version = "0.2", features = ["std"] }
@@ -166,6 +172,10 @@ object = { version = "0.28", default-features = false, features = ["archive", "c
 once_cell = { version = "1", features = ["alloc", "race", "std"] }
 oorandom = { version = "11", default-features = false }
 opaque-debug = { version = "0.3", default-features = false }
+opentelemetry = { version = "0.17", features = ["async-trait", "crossbeam-channel", "percent-encoding", "pin-project", "rand", "rt-tokio", "tokio", "tokio-stream", "trace"] }
+opentelemetry-jaeger = { version = "0.16", features = ["rt-tokio", "tokio"] }
+opentelemetry-semantic-conventions = { version = "0.9", default-features = false }
+ordered-float = { version = "1", features = ["std"] }
 os_str_bytes = { version = "6", default-features = false, features = ["raw_os_str"] }
 parking_lot = { version = "0.12" }
 parking_lot_core = { version = "0.9", default-features = false }
@@ -240,6 +250,7 @@ structopt = { version = "0.3" }
 subtle = { version = "2", default-features = false, features = ["std"] }
 syn-dff4ba8e3ae991db = { package = "syn", version = "1", features = ["clone-impls", "derive", "extra-traits", "full", "parsing", "printing", "proc-macro", "quote", "visit", "visit-mut"] }
 sync_wrapper = { version = "0.1", default-features = false }
+telemetry-subscribers = { git = "https://github.com/mystenlabs/mysten-infra.git", rev = "49613b62072eba3f3b2316f54fbe6a9e1926697b", features = ["chrome", "jaeger", "opentelemetry", "opentelemetry-jaeger", "tracing-chrome", "tracing-opentelemetry"] }
 tempfile = { version = "3", default-features = false }
 termcolor = { version = "1", default-features = false }
 termtree = { version = "0.2", default-features = false }
@@ -247,6 +258,8 @@ textwrap-a6292c17cd707f01 = { package = "textwrap", version = "0.11", default-fe
 textwrap-3575ec1268b04181 = { package = "textwrap", version = "0.15", default-features = false }
 thiserror = { version = "1", default-features = false }
 thread_local = { version = "1", default-features = false }
+threadpool = { version = "1", default-features = false }
+thrift = { version = "0.15", default-features = false }
 time = { version = "0.3", features = ["alloc", "formatting", "itoa", "std"] }
 tinytemplate = { version = "1", default-features = false }
 tinyvec = { version = "1", features = ["alloc", "tinyvec_macros"] }
@@ -264,14 +277,18 @@ tower-http = { version = "0.3", features = ["map-response-body", "propagate-head
 tower-layer = { version = "0.3", default-features = false }
 tower-service = { version = "0.3", default-features = false }
 tracing = { version = "0.1", features = ["attributes", "log", "std", "tracing-attributes"] }
+tracing-appender = { version = "0.2", default-features = false }
+tracing-bunyan-formatter = { version = "0.3" }
+tracing-chrome = { version = "0.6", default-features = false }
 tracing-core = { version = "0.1", features = ["once_cell", "std"] }
 tracing-futures = { version = "0.2", features = ["pin-project", "std", "std-future"] }
 tracing-log = { version = "0.1", features = ["log-tracer", "std", "trace-logger"] }
+tracing-opentelemetry = { version = "0.17", features = ["tracing-log"] }
 tracing-subscriber-6f8ce4dd05d13bba = { package = "tracing-subscriber", version = "0.2", default-features = false }
 tracing-subscriber-468e82937335b1c9 = { package = "tracing-subscriber", version = "0.3", features = ["alloc", "ansi", "ansi_term", "env-filter", "fmt", "matchers", "once_cell", "regex", "registry", "sharded-slab", "smallvec", "std", "thread_local", "time", "tracing", "tracing-log"] }
 tracing-test = { version = "0.2", default-features = false }
 try-lock = { version = "0.2", default-features = false }
-typed-store = { git = "https://github.com/mystenlabs/mysten-infra.git", rev = "7e9b7568fc7184b4938976330122f3c8064e3236", default-features = false }
+typed-store = { git = "https://github.com/mystenlabs/mysten-infra.git", rev = "49613b62072eba3f3b2316f54fbe6a9e1926697b", default-features = false }
 typenum = { version = "1", default-features = false }
 unicode-bidi = { version = "0.3", features = ["hardcoded-data", "std"] }
 unicode-ident = { version = "1", default-features = false }


### PR DESCRIPTION
Advantage: we get the dynamically resettable log level + the same infra as everyone else + once we integrate [tracing_loki](https://github.com/hrxi/tracing-loki) we get that in Narwhal staging deployments as well.