### PR TITLE
Laura/consensus restore

### DIFF
--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -418,7 +418,6 @@ impl<PublicKey: VerifyingKey> Committee<PublicKey> {
             .map(|(_, worker)| worker.clone())
             .ok_or_else(|| ConfigError::NotInCommittee((*to).encode_base64()))
     }
-
     /// Returns the addresses of all our workers.
     pub fn our_workers(&self, myself: &PublicKey) -> Result<Vec<WorkerAddresses>, ConfigError> {
         let res = self

--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -71,10 +71,7 @@ impl<PublicKey: VerifyingKey> ConsensusState<PublicKey> {
         if last_committed_round == 0 {
             return Self::new(genesis, metrics);
         }
-        metrics
-            .recovered_consensus_state
-            .with_label_values(&[])
-            .inc();
+        metrics.recovered_consensus_state.inc();
 
         let dag =
             Self::construct_dag_from_cert_store(cert_store, last_committed_round, gc_depth).await;
@@ -106,6 +103,7 @@ impl<PublicKey: VerifyingKey> ConsensusState<PublicKey> {
             })))
             .await;
 
+        let num_certs = cert_map.len();
         for (digest, cert) in cert_map {
             let inner = dag.get_mut(&cert.header.round);
             match inner {
@@ -119,6 +117,11 @@ impl<PublicKey: VerifyingKey> ConsensusState<PublicKey> {
                 }
             }
         }
+        info!(
+            "Dag was restored and contains {} certs for {} rounds",
+            num_certs,
+            dag.len()
+        );
 
         dag
     }

--- a/consensus/src/metrics.rs
+++ b/consensus/src/metrics.rs
@@ -1,6 +1,9 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use prometheus::{default_registry, register_int_gauge_vec_with_registry, IntGaugeVec, Registry};
+use prometheus::{
+    default_registry, register_int_counter_with_registry, register_int_gauge_vec_with_registry,
+    IntCounter, IntGaugeVec, Registry,
+};
 
 #[derive(Clone, Debug)]
 pub struct ConsensusMetrics {
@@ -14,7 +17,7 @@ pub struct ConsensusMetrics {
     pub external_consensus_dag_size: IntGaugeVec,
     /// The number of times the consensus state was restored from the consensus store
     /// following a node restart
-    pub recovered_consensus_state: IntGaugeVec,
+    pub recovered_consensus_state: IntCounter,
 }
 
 impl ConsensusMetrics {
@@ -44,10 +47,9 @@ impl ConsensusMetrics {
                 &[],
                 registry
             ).unwrap(),
-            recovered_consensus_state: register_int_gauge_vec_with_registry!(
+            recovered_consensus_state: register_int_counter_with_registry!(
                 "recovered_consensus_state",
                 "The number of times the consensus state was restored from the consensus store following a node restart",
-                &[],
                 registry
             ).unwrap(),
         }

--- a/primary/src/primary.rs
+++ b/primary/src/primary.rs
@@ -488,11 +488,11 @@ impl<PublicKey: VerifyingKey> PrimaryToPrimary for PrimaryReceiverHandler<Public
                 })
                 .await
                 .expect("Failed to send primary message"),
-            _ => self
-                .tx_primary_messages
-                .send(message)
-                .await
-                .expect("Failed to send certificate"),
+            _ => {
+                let res = self.tx_primary_messages.send(message).await;
+
+                res.expect("Failed to send certificate");
+            }
         }
 
         Ok(Response::new(Empty {}))

--- a/primary/tests/causal_completion_tests.rs
+++ b/primary/tests/causal_completion_tests.rs
@@ -1,14 +1,22 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
+use arc_swap::access::{Access, DynAccess};
+use arc_swap::ArcSwap;
+use bytes::Bytes;
+use config::Committee;
+use crypto::ed25519::Ed25519PublicKey;
+use std::ops::Deref;
+use std::sync::Arc;
 use std::time::Duration;
 use test_utils::cluster::Cluster;
-use tracing::info;
+use test_utils::{committee, transaction};
+use tracing::{info, subscriber::set_global_default};
+use tracing_subscriber::filter::{EnvFilter, LevelFilter};
+use types::{TransactionProto, TransactionsClient};
 
 #[ignore]
 #[tokio::test]
 async fn test_read_causal_signed_certificates() {
-    const CURRENT_ROUND_METRIC: &str = "narwhal_primary_current_round";
-
     // Enabled debug tracing so we can easily observe the
     // nodes logs.
     setup_tracing();
@@ -18,25 +26,26 @@ async fn test_read_causal_signed_certificates() {
     // start the cluster
     cluster.start(Some(4), Some(1)).await;
 
-    // Let primaries advance little bit
-    tokio::time::sleep(Duration::from_secs(10)).await;
+    let multiaddr = cluster.authorities()[0].worker(0).transactions_address;
+    let addr = multiaddr.to_string();
 
-    // Ensure all nodes advanced
-    for authority in cluster.authorities() {
-        let metric_family = authority.primary.registry.gather();
+    let committee = arc_swap::access::Access::load(&cluster.committee_shared).deref();
 
-        for metric in metric_family {
-            if metric.get_name() == CURRENT_ROUND_METRIC {
-                let value = metric.get_metric().first().unwrap().get_gauge().get_value();
+    let id = 0;
+    let name = cluster.authority(0).name;
+    let address = c.worker(&name, &id).unwrap().transactions;
+    let config = mysten_network::config::Config::new();
+    let channel = config.connect_lazy(&address).unwrap();
+    let mut client = TransactionsClient::new(channel);
 
-                info!("Metrics name {} -> {:?}", metric.get_name(), value);
-
-                // If the current round is increasing then it means that the
-                // node starts catching up and is proposing.
-                assert!(value > 1.0, "Node didn't progress further than the round 1");
-            }
-        }
+    for tx in vec![transaction(), transaction(), transaction()] {
+        let txn = TransactionProto {
+            transaction: Bytes::from(tx.clone()),
+        };
+        client.submit_transaction(txn).await.unwrap();
     }
+    // Let transactions get submitted
+    tokio::time::sleep(Duration::from_secs(5)).await;
 
     // Now stop node 0
     cluster.stop_node(0);
@@ -50,8 +59,16 @@ async fn test_read_causal_signed_certificates() {
     // Now check that the current round advances. Give the opportunity with a few
     // iterations. If metric hasn't picked up then we know that node can't make
     // progress.
-    let mut node_made_progress = false;
+    let mut node_recovered_state = false;
     let node = cluster.authority(0);
+
+    // let mut receiver = node.primary.tx_transaction_confirmation.subscribe();
+    // loop {
+    //     if let Ok(result) = receiver.recv().await {
+    //         assert!(result.0.is_ok());
+    //         break;
+    //     }
+    // }
 
     for _ in 0..10 {
         tokio::time::sleep(Duration::from_secs(1)).await;
@@ -59,25 +76,18 @@ async fn test_read_causal_signed_certificates() {
         let metric_family = node.primary.registry.gather();
 
         for metric in metric_family {
-            if metric.get_name() == CURRENT_ROUND_METRIC {
+            if metric.get_name() == "recovered_consensus_state" {
                 let value = metric.get_metric().first().unwrap().get_gauge().get_value();
-
-                info!("Metrics name {} -> {:?}", metric.get_name(), value);
-
-                // If the current round is increasing then it means that the
-                // node starts catching up and is proposing.
-                if value > 1.0 {
-                    node_made_progress = true;
+                info!("Found metric for recovered consensus state.");
+                if value > 0.0 {
+                    node_recovered_state = true;
                     break;
                 }
             }
         }
     }
 
-    assert!(
-        node_made_progress,
-        "Node 0 didn't make progress - causal completion didn't succeed"
-    );
+    assert!(node_recovered_state, "Node recovered state");
 }
 
 fn setup_tracing() {

--- a/primary/tests/causal_completion_tests.rs
+++ b/primary/tests/causal_completion_tests.rs
@@ -95,7 +95,7 @@ async fn test_restore_from_disk() {
         }
     }
 
-    assert!(node_recovered_state, "Node recovered state");
+    assert!(node_recovered_state, "Node did not recover state from disk");
 }
 
 fn string_transaction() -> StringTransaction {

--- a/primary/tests/causal_completion_tests.rs
+++ b/primary/tests/causal_completion_tests.rs
@@ -1,7 +1,5 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use arc_swap::access::{Access, DynAccess};
-use arc_swap::ArcSwap;
 use bytes::Bytes;
 use config::Committee;
 use crypto::ed25519::Ed25519PublicKey;
@@ -9,7 +7,7 @@ use std::ops::Deref;
 use std::sync::Arc;
 use std::time::Duration;
 use test_utils::cluster::Cluster;
-use test_utils::{committee, transaction};
+use test_utils::transaction;
 use tracing::{info, subscriber::set_global_default};
 use tracing_subscriber::filter::{EnvFilter, LevelFilter};
 use types::{TransactionProto, TransactionsClient};
@@ -26,17 +24,7 @@ async fn test_read_causal_signed_certificates() {
     // start the cluster
     cluster.start(Some(4), Some(1)).await;
 
-    let multiaddr = cluster.authorities()[0].worker(0).transactions_address;
-    let addr = multiaddr.to_string();
-
-    let committee = arc_swap::access::Access::load(&cluster.committee_shared).deref();
-
-    let id = 0;
-    let name = cluster.authority(0).name;
-    let address = c.worker(&name, &id).unwrap().transactions;
-    let config = mysten_network::config::Config::new();
-    let channel = config.connect_lazy(&address).unwrap();
-    let mut client = TransactionsClient::new(channel);
+    let mut client = TransactionsClient::new(cluster.worker_channel.clone());
 
     for tx in vec![transaction(), transaction(), transaction()] {
         let txn = TransactionProto {

--- a/test_utils/src/cluster.rs
+++ b/test_utils/src/cluster.rs
@@ -20,6 +20,7 @@ use tokio::{
     sync::{broadcast::Sender, mpsc::channel},
     task::JoinHandle,
 };
+use tonic::transport::Channel;
 use tracing::info;
 
 #[cfg(test)]
@@ -31,6 +32,7 @@ pub struct Cluster {
     pub committee_shared: SharedCommittee<Ed25519PublicKey>,
     #[allow(dead_code)]
     parameters: Parameters,
+    pub worker_channel: Channel,
 }
 
 impl Cluster {
@@ -43,13 +45,15 @@ impl Cluster {
         parameters: Option<Parameters>,
         input_committee: Option<Committee<Ed25519PublicKey>>,
     ) -> Self {
+        let k = keys(None);
+        let name = k[0].public().clone();
         let c = input_committee.unwrap_or_else(|| committee(None));
+        let address = c.worker(&name, &0).unwrap().transactions;
         let shared_committee = Arc::new(ArcSwap::from_pointee(c));
         let params = parameters.unwrap_or_else(Self::parameters);
 
         info!("###### Creating new cluster ######");
         info!("Validator keys:");
-        let k = keys(None);
         let mut nodes = HashMap::new();
 
         for (id, key_pair) in k.into_iter().enumerate() {
@@ -60,10 +64,14 @@ impl Cluster {
             nodes.insert(id, authority);
         }
 
+        let config = mysten_network::config::Config::new();
+        let worker_channel = config.connect_lazy(&address).unwrap();
+
         Self {
             authorities: nodes,
             committee_shared: shared_committee,
             parameters: params,
+            worker_channel,
         }
     }
 

--- a/test_utils/src/cluster.rs
+++ b/test_utils/src/cluster.rs
@@ -28,7 +28,7 @@ pub mod cluster_tests;
 
 pub struct Cluster {
     authorities: HashMap<usize, AuthorityDetails>,
-    committee_shared: Arc<ArcSwap<Committee<Ed25519PublicKey>>>,
+    pub committee_shared: SharedCommittee<Ed25519PublicKey>,
     #[allow(dead_code)]
     parameters: Parameters,
 }

--- a/test_utils/src/cluster.rs
+++ b/test_utils/src/cluster.rs
@@ -256,8 +256,7 @@ impl PrimaryNodeDetails {
                 if let Err(e) = t.clone().0 {
                     println!("The result from consensus is an error: {:?}", e);
                 }
-                let res = transactions_sender.send(t);
-                res.expect("Couldn't send message to broadcast channel");
+                _ = transactions_sender.send(t);
             }
         });
 


### PR DESCRIPTION
https://github.com/MystenLabs/narwhal/issues/543

Switches the metric type for tracking consensus restores from a gauge to a counter, and uses the metric to test that the consensus was restored on startup. Verified with debugger that the construction of the dag is correctly done using the certificates.

This also adds [logging the disk recovery]( https://github.com/MystenLabs/narwhal/issues/542)