### PR TITLE
[network] Don't back off forever on the Semaphore 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2173,6 +2173,7 @@ dependencies = [
 name = "network"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "async-trait",
  "backoff",
  "bincode",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2173,7 +2173,6 @@ dependencies = [
 name = "network"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "async-trait",
  "backoff",
  "bincode",

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -23,7 +23,6 @@ multiaddr = "0.14.0"
 
 mysten-network = { git = "https://github.com/mystenlabs/mysten-infra.git", rev = "123c9e40b529315e1c1d91a54fb717111c3e349c" }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
-anyhow = "1.0.58"
 
 [dev-dependencies]
 bincode = "1.3.3"

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -20,10 +20,10 @@ crypto = { path = "../crypto" }
 tonic = { version = "0.7.2", features = ["tls"] }
 backoff = { version = "0.4.0", features = ["tokio"] }
 multiaddr = "0.14.0"
+anyhow = "1.0.58"
 
 mysten-network = { git = "https://github.com/mystenlabs/mysten-infra.git", rev = "123c9e40b529315e1c1d91a54fb717111c3e349c" }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
-anyhow = "1.0.58"
 
 [dev-dependencies]
 bincode = "1.3.3"

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -23,6 +23,7 @@ multiaddr = "0.14.0"
 
 mysten-network = { git = "https://github.com/mystenlabs/mysten-infra.git", rev = "123c9e40b529315e1c1d91a54fb717111c3e349c" }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
+anyhow = "1.0.58"
 
 [dev-dependencies]
 bincode = "1.3.3"

--- a/network/src/bounded_executor.rs
+++ b/network/src/bounded_executor.rs
@@ -139,7 +139,11 @@ impl BoundedExecutor {
     ///
     /// This function returns a [`JoinHandle`] that the caller can `.await` on for
     /// the results of the overall retry driver.
-    pub fn spawn_with_retries<F, Fut, T, E>(
+    ///
+    /// TODO: this still spawns one task, unconditionally, per call.
+    /// We would instead like to have one central task that drives all retries
+    /// for the whole executor.
+    pub(crate) fn spawn_with_retries<F, Fut, T, E>(
         &self,
         retry_config: crate::RetryConfig,
         mut f: F,

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -20,6 +20,9 @@ pub use crate::{
     worker::WorkerNetwork,
 };
 
+// the result of our network messages
+pub type MessageResult = Result<tonic::Response<types::Empty>, anyhow::Error>;
+
 #[derive(Debug)]
 #[must_use]
 pub struct CancelHandler<T>(tokio::task::JoinHandle<T>);

--- a/network/src/primary.rs
+++ b/network/src/primary.rs
@@ -72,6 +72,12 @@ impl PrimaryNetwork {
         self.send_message(address, message).await
     }
 
+    // Safety
+    // Since this spawns an unbounded task, this should be called in a time-restricted fashion.
+    // Here the callers are [`PrimaryNetwork::broadcast`] and [`PrimaryNetwork::send`],
+    // at respectively N and K calls per round.
+    //  (where N is the number of primaries, K the number of workers for this primary)
+    // See the TODO on spawn_with_retries for lifting this restriction.
     async fn send_message(
         &mut self,
         address: Multiaddr,

--- a/network/src/primary.rs
+++ b/network/src/primary.rs
@@ -89,8 +89,7 @@ impl PrimaryNetwork {
 
         let handle = self
             .executor
-            .spawn_with_retries(self.retry_config, message_send)
-            .await;
+            .spawn_with_retries(self.retry_config, message_send);
 
         CancelHandler(handle)
     }

--- a/network/src/primary.rs
+++ b/network/src/primary.rs
@@ -1,9 +1,8 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{BoundedExecutor, CancelHandler, RetryConfig, MAX_TASK_CONCURRENCY};
+use crate::{BoundedExecutor, CancelHandler, MessageResult, RetryConfig, MAX_TASK_CONCURRENCY};
 use crypto::traits::VerifyingKey;
-use futures::FutureExt;
 use multiaddr::Multiaddr;
 use rand::{prelude::SliceRandom as _, rngs::SmallRng, SeedableRng as _};
 use std::collections::HashMap;
@@ -62,7 +61,7 @@ impl PrimaryNetwork {
         &mut self,
         address: Multiaddr,
         message: &PrimaryMessage<T>,
-    ) -> CancelHandler<()> {
+    ) -> CancelHandler<MessageResult> {
         let message =
             BincodeEncodedPayload::try_from(message).expect("Failed to serialize payload");
         self.send_message(address, message).await
@@ -72,21 +71,25 @@ impl PrimaryNetwork {
         &mut self,
         address: Multiaddr,
         message: BincodeEncodedPayload,
-    ) -> CancelHandler<()> {
+    ) -> CancelHandler<MessageResult> {
         let client = self.client(address);
+
+        let message_send = move || {
+            let mut client = client.clone();
+            let message = message.clone();
+
+            async move {
+                client.send_message(message).await.map_err(|e| {
+                    // this returns a backoff::Error::Transient
+                    // so that if tonic::Status is returned, we retry
+                    Into::<backoff::Error<anyhow::Error>>::into(anyhow::Error::from(e))
+                })
+            }
+        };
+
         let handle = self
             .executor
-            .spawn(
-                self.retry_config
-                    .retry(move || {
-                        let mut client = client.clone();
-                        let message = message.clone();
-                        async move { client.send_message(message).await.map_err(Into::into) }
-                    })
-                    .map(|response| {
-                        response.expect("we retry forever so this shouldn't fail");
-                    }),
-            )
+            .spawn_with_retries(self.retry_config, message_send)
             .await;
 
         CancelHandler(handle)
@@ -96,7 +99,7 @@ impl PrimaryNetwork {
         &mut self,
         addresses: Vec<Multiaddr>,
         message: &PrimaryMessage<T>,
-    ) -> Vec<CancelHandler<()>> {
+    ) -> Vec<CancelHandler<MessageResult>> {
         let message =
             BincodeEncodedPayload::try_from(message).expect("Failed to serialize payload");
         let mut handlers = Vec::new();

--- a/network/src/worker.rs
+++ b/network/src/worker.rs
@@ -86,8 +86,7 @@ impl WorkerNetwork {
 
         let handle = self
             .executor
-            .spawn_with_retries(self.retry_config, message_send)
-            .await;
+            .spawn_with_retries(self.retry_config, message_send);
 
         CancelHandler(handle)
     }

--- a/network/src/worker.rs
+++ b/network/src/worker.rs
@@ -68,6 +68,12 @@ impl WorkerNetwork {
         self.send_message(address, message).await
     }
 
+    // Safety
+    // Since this spawns an unbounded task, this should be called in a time-restricted fashion.
+    // Here the callers are [`WorkerNetwork::broadcast`] and [`WorkerNetwork::send`],
+    // at respectively N and K calls per round.
+    //  (where N is the number of validators, the K is for the number of batches to be reported to the primary)
+    // See the TODO on spawn_with_retries for lifting this restriction.
     async fn send_message(
         &mut self,
         address: Multiaddr,

--- a/primary/src/core.rs
+++ b/primary/src/core.rs
@@ -10,7 +10,7 @@ use crate::{
 use async_recursion::async_recursion;
 use config::{Committee, Epoch};
 use crypto::{traits::VerifyingKey, Hash as _, SignatureService};
-use network::{CancelHandler, PrimaryNetwork};
+use network::{CancelHandler, MessageResult, PrimaryNetwork};
 use std::{
     collections::{HashMap, HashSet},
     sync::{
@@ -86,7 +86,7 @@ pub struct Core<PublicKey: VerifyingKey> {
     /// A network sender to send the batches to the other workers.
     network: PrimaryNetwork,
     /// Keeps the cancel handlers of the messages we sent.
-    cancel_handlers: HashMap<Round, Vec<CancelHandler<()>>>,
+    cancel_handlers: HashMap<Round, Vec<CancelHandler<MessageResult>>>,
     /// Metrics handler
     metrics: Arc<PrimaryMetrics>,
 }

--- a/worker/src/quorum_waiter.rs
+++ b/worker/src/quorum_waiter.rs
@@ -4,7 +4,7 @@
 use config::{Committee, Stake, WorkerId};
 use crypto::traits::VerifyingKey;
 use futures::stream::{futures_unordered::FuturesUnordered, StreamExt as _};
-use network::{CancelHandler, WorkerNetwork};
+use network::{CancelHandler, MessageResult, WorkerNetwork};
 use tokio::{
     sync::{
         mpsc::{Receiver, Sender},
@@ -62,8 +62,8 @@ impl<PublicKey: VerifyingKey> QuorumWaiter<PublicKey> {
     }
 
     /// Helper function. It waits for a future to complete and then delivers a value.
-    async fn waiter(wait_for: CancelHandler<()>, deliver: Stake) -> Stake {
-        wait_for.await;
+    async fn waiter(wait_for: CancelHandler<MessageResult>, deliver: Stake) -> Stake {
+        let _ = wait_for.await;
         deliver
     }
 


### PR DESCRIPTION
## Context
#463 introduced a `BoundedExecutor` to limit the concurrent tasks created for sending messages.

However, as a protocol requirement, some of those tasks are on an unbounded exponential backoff, by which they are retried indefinitely (until cancelled).

## The issue
The {primary, worker} × { `broadcast`, `send` } functions enqueue instances of `{Primary, Worker}::send_message` on the `BoundedExecutor`, and `send_message` is an exponential backoff with infinite retries. These tasks will hence hold a semaphore ticket potentially forever.

## This change
The present change makes those tasks hold a semaphore permit only when they are actively sending a message, re-queuing on the semaphore only once they are done with their backoff wait (out of the semaphore0. This frees up tickets for other network tasks to help make the network progress.

## Future work
The cancellation of our "reliable" network sends is not always as prompt as it could be. Fixing this is the next PR.
