### PR TITLE
[testing] staggered network bootstrap

### DIFF
--- a/crypto/src/secp256k1.rs
+++ b/crypto/src/secp256k1.rs
@@ -1,9 +1,9 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use crate::pubkey_bytes::PublicKeyBytes;
-use crate::serde_helpers::keypair_decode_base64;
-use crate::traits::{
-    Authenticator, EncodeDecodeBase64, KeyPair, SigningKey, ToFromBytes, VerifyingKey,
+use crate::{
+    pubkey_bytes::PublicKeyBytes,
+    serde_helpers::keypair_decode_base64,
+    traits::{Authenticator, EncodeDecodeBase64, KeyPair, SigningKey, ToFromBytes, VerifyingKey},
 };
 use base64ct::{Base64, Encoding};
 use once_cell::sync::OnceCell;

--- a/primary/tests/causal_completion_tests.rs
+++ b/primary/tests/causal_completion_tests.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use bytes::Bytes;
 use std::time::Duration;
+use telemetry_subscribers::TelemetryGuards;
 use test_utils::cluster::Cluster;
 use tracing::info;
 use types::{TransactionProto, TransactionsClient};
@@ -13,7 +14,7 @@ type StringTransaction = String;
 async fn test_restore_from_disk() {
     // Enabled debug tracing so we can easily observe the
     // nodes logs.
-    setup_tracing();
+    let _guard = setup_tracing();
 
     let mut cluster = Cluster::new(None, None);
 
@@ -103,7 +104,7 @@ async fn test_read_causal_signed_certificates() {
 
     // Enabled debug tracing so we can easily observe the
     // nodes logs.
-    setup_tracing();
+    let _guard = setup_tracing();
 
     let mut cluster = Cluster::new(None, None);
 
@@ -163,17 +164,18 @@ async fn test_read_causal_signed_certificates() {
     );
 }
 
-fn setup_tracing() {
+fn setup_tracing() -> TelemetryGuards {
     // Setup tracing
     let tracing_level = "debug";
     let network_tracing_level = "info";
 
     let log_filter = format!("{tracing_level},h2={network_tracing_level},tower={network_tracing_level},hyper={network_tracing_level},tonic::transport={network_tracing_level}");
 
-    let _guard = telemetry_subscribers::TelemetryConfig::new("narwhal")
+    telemetry_subscribers::TelemetryConfig::new("narwhal")
         // load env variables
         .with_env()
         // load special log filter
         .with_log_level(&log_filter)
-        .init();
+        .init()
+        .0
 }

--- a/primary/tests/nodes_bootstrapping_tests.rs
+++ b/primary/tests/nodes_bootstrapping_tests.rs
@@ -1,0 +1,76 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use itertools::Itertools;
+use std::{collections::HashMap, time::Duration};
+use test_utils::cluster::Cluster;
+use tracing::info;
+
+/// Nodes will be started in a staggered fashion. This is simulating
+/// a real world scenario where nodes across validators will not start
+/// in the same time.
+#[tokio::test]
+async fn test_node_staggered_starts() {
+    // Enabled debug tracing so we can easily observe the
+    // nodes logs.
+    setup_tracing();
+
+    // 5 minutes
+    let node_staggered_delay = Duration::from_secs(60 * 5);
+
+    let mut cluster = Cluster::new(None, None);
+
+    // Start the cluster in staggered fashion with some delay between the nodes start
+    cluster
+        .start(Some(4), Some(1), Some(node_staggered_delay))
+        .await;
+
+    let mut authorities_current_round = HashMap::new();
+
+    for _ in 0..5 {
+        for authority in cluster.authorities().await {
+            let primary = authority.primary().await;
+            if let Some(metric) = primary.metric("narwhal_primary_current_round") {
+                let value = metric.get_gauge().get_value();
+
+                authorities_current_round.insert(primary.id, value);
+
+                info!(
+                    "[Node {}] Metric narwhal_primary_current_round -> {value}",
+                    primary.id
+                );
+            }
+        }
+
+        tokio::time::sleep(Duration::from_secs(5)).await;
+    }
+
+    // we should have metrics from all the three nodes
+    assert_eq!(authorities_current_round.len(), 4);
+
+    // they should all be above 0
+    assert!(authorities_current_round.values().all(|v| v > &0.0));
+
+    // nodes shouldn't have round diff more than 2
+    let (min, max) = authorities_current_round
+        .values()
+        .into_iter()
+        .minmax()
+        .into_option()
+        .unwrap();
+    assert!(max - min <= 2.0, "Nodes shouldn't be that behind");
+}
+
+fn setup_tracing() {
+    // Setup tracing
+    let tracing_level = "debug";
+    let network_tracing_level = "info";
+
+    let log_filter = format!("{tracing_level},h2={network_tracing_level},tower={network_tracing_level},hyper={network_tracing_level},tonic::transport={network_tracing_level}");
+
+    let _guard = telemetry_subscribers::TelemetryConfig::new("narwhal")
+        // load env variables
+        .with_env()
+        // load special log filter
+        .with_log_level(&log_filter)
+        .init();
+}

--- a/primary/tests/nodes_bootstrapping_tests.rs
+++ b/primary/tests/nodes_bootstrapping_tests.rs
@@ -2,24 +2,26 @@
 // SPDX-License-Identifier: Apache-2.0
 use itertools::Itertools;
 use std::{collections::HashMap, time::Duration};
+use telemetry_subscribers::TelemetryGuards;
 use test_utils::cluster::Cluster;
 use tracing::info;
 
 /// Nodes will be started in a staggered fashion. This is simulating
 /// a real world scenario where nodes across validators will not start
 /// in the same time.
+#[ignore]
 #[tokio::test]
 async fn test_node_staggered_starts() {
     // Enabled debug tracing so we can easily observe the
     // nodes logs.
-    setup_tracing();
+    let _guard = setup_tracing();
 
     let node_staggered_delay = Duration::from_secs(60 * 5); // 5 minutes
 
     // A cluster of 4 nodes will be created
     let cluster = Cluster::new(None, None);
 
-    // Start first authority
+    // ==== Start first authority ====
     cluster.authority(0).start(false, Some(1)).await;
 
     tokio::time::sleep(node_staggered_delay).await;
@@ -32,7 +34,7 @@ async fn test_node_staggered_starts() {
     );
     assert!(rounds.values().all(|v| v == &1.0), "We have (f+2) unavailable nodes and expected all nodes to have made progress up to round 1 only");
 
-    // Start second authority
+    // ==== Start second authority ====
     cluster.authority(1).start(false, Some(1)).await;
 
     tokio::time::sleep(node_staggered_delay).await;
@@ -45,7 +47,7 @@ async fn test_node_staggered_starts() {
     );
     assert!(rounds.values().all(|v| v == &1.0), "We have (f+1) unavailable nodes and expected all nodes to have made progress up to round 1 only");
 
-    // Start third authority
+    // ==== Start third authority ====
     // Now 2f + 1 nodes are becoming available and we expect all the nodes to
     // start making progress (advance in rounds).
     cluster.authority(2).start(false, Some(1)).await;
@@ -60,7 +62,30 @@ async fn test_node_staggered_starts() {
     );
     assert!(rounds.values().all(|v| v > &1.0), "We have only (f) unavailable nodes, so all should have made progress more than just the first round");
 
-    // nodes shouldn't have round diff more than 2
+    // We expect all the nodes to have managed to catch up by now
+    // and be pretty much in similar rounds. The threshold here is
+    // not defined by some rule but more of an expectation.
+    let (min, max) = rounds.values().into_iter().minmax().into_option().unwrap();
+    assert!(max - min <= 2.0, "Nodes shouldn't be that behind");
+
+    // ==== Start fourth authority ====
+    // Now 3f + 1 nodes are becoming available (the whole network) and all the nodes
+    // should make progress
+    cluster.authority(3).start(false, Some(1)).await;
+
+    tokio::time::sleep(node_staggered_delay).await;
+
+    let rounds = authorities_current_round(&cluster).await;
+    assert_eq!(
+        rounds.len(),
+        4,
+        "Expected to have received metrics from all nodes"
+    );
+    assert!(rounds.values().all(|v| v > &1.0), "We have no unavailable nodes, so all should have made progress more than just the first round");
+
+    // We expect all the nodes to have managed to catch up by now
+    // and be pretty much in similar rounds. The threshold here is
+    // not defined by some rule but more of an expectation.
     let (min, max) = rounds.values().into_iter().minmax().into_option().unwrap();
     assert!(max - min <= 2.0, "Nodes shouldn't be that behind");
 }
@@ -85,17 +110,18 @@ async fn authorities_current_round(cluster: &Cluster) -> HashMap<usize, f64> {
     authorities_current_round
 }
 
-fn setup_tracing() {
+fn setup_tracing() -> TelemetryGuards {
     // Setup tracing
     let tracing_level = "debug";
     let network_tracing_level = "info";
 
     let log_filter = format!("{tracing_level},h2={network_tracing_level},tower={network_tracing_level},hyper={network_tracing_level},tonic::transport={network_tracing_level}");
 
-    let _guard = telemetry_subscribers::TelemetryConfig::new("narwhal")
+    telemetry_subscribers::TelemetryConfig::new("narwhal")
         // load env variables
         .with_env()
         // load special log filter
         .with_log_level(&log_filter)
-        .init();
+        .init()
+        .0
 }

--- a/primary/tests/nodes_bootstrapping_tests.rs
+++ b/primary/tests/nodes_bootstrapping_tests.rs
@@ -58,7 +58,7 @@ async fn test_node_staggered_starts() {
         3,
         "Expected to have received commit metrics from only three nodes"
     );
-    assert!(rounds.values().all(|v| v > &1.0), "We have only (f) unavailable nodes, so all should have made progress and committed at least after the first round");
+    assert!(rounds.values().all(|v| *v > 1f64), "We have only (f) unavailable nodes, so all should have made progress and committed at least after the first round");
 
     // We expect all the nodes to have managed to catch up by now
     // and be pretty much in similar rounds. The threshold here is
@@ -79,7 +79,7 @@ async fn test_node_staggered_starts() {
         4,
         "Expected to have received commit metrics from all nodes"
     );
-    assert!(rounds.values().all(|v| v > &1.0), "We have only (f) unavailable nodes, so all should have made progress and committed at least after the first round");
+    assert!(rounds.values().all(|v| v > &1.0), "All nodes are available so all should have made progress and committed at least after the first round");
 
     // We expect all the nodes to have managed to catch up by now
     // and be pretty much in similar rounds. The threshold here is

--- a/test_utils/src/tests/cluster_tests.rs
+++ b/test_utils/src/tests/cluster_tests.rs
@@ -8,28 +8,28 @@ async fn basic_cluster_setup() {
     let mut cluster = Cluster::new(None, None);
 
     // start the cluster will all the possible nodes
-    cluster.start(None, None).await;
+    cluster.start(None, None, None).await;
 
     // give some time for nodes to boostrap
     tokio::time::sleep(Duration::from_secs(2)).await;
 
     // fetch all the running authorities
-    let authorities = cluster.authorities();
+    let authorities = cluster.authorities().await;
 
     assert_eq!(authorities.len(), 4);
 
     // fetch their workers transactions address
-    for authority in cluster.authorities() {
-        assert_eq!(authority.worker_transaction_addresses().len(), 4);
+    for authority in cluster.authorities().await {
+        assert_eq!(authority.worker_transaction_addresses().await.len(), 4);
     }
 
     // now stop all authorities
     for id in 0..4 {
-        cluster.stop_node(id);
+        cluster.stop_node(id).await;
     }
 
     tokio::time::sleep(Duration::from_secs(2)).await;
 
     // No authority should still run
-    assert!(cluster.authorities().is_empty());
+    assert!(cluster.authorities().await.is_empty());
 }


### PR DESCRIPTION
Resolves: https://github.com/MystenLabs/narwhal/issues/540

This PR is introducing two things:

### Test for node staggered starts

A test has been introduced which is bootstrapping the whole network by starting the nodes one by one with some delay between the starts to simulate the real world scenario as the above ticket describes. After each node start we assert the expectations for the rounds advancements. A node which advances in rounds means that it is able to propose new headers, which implies that other nodes are also publishing their headers as well.

The test is passing and it seems that nodes can successfully start in staggered fashion. Unfortunately I can't test any after effects (ex increased CPU utilisation while waiting other nodes to join because of some weird loop logic). I believe some things should still be confirmed in unit tests level (ex do the connection retry functions work as expected?). Maybe we can still test memory via [heap testing](https://docs.rs/dhat/latest/dhat/#heap-usage-testing) as @huitseeker has pointed out in Slack, but don't consider this part of this PR.

### Cluster improvements

Improvements have been made to cluster:
* Before `AuthorityDetails` were cloneable but if made any method call that would lead to some internal mutation (ex start primary) , it would make those changes only to its local copy. So if would retrieve again the authority via the cluster (ex `cluster.authority(0)`) the returned authority and its internals (primary & workers) would be a different copy with different values (ex the Registry in primary would be different).
* Now made the `AuthorityDetails` practically shareable by making their internals sit behind a common reference (using a lock). Now can retrieve the authority perform any call on it (ex start primary etc) and make sure that all the `AuthorityDetails` clones will see the same changes
* Additional helper methods added for node staggered starts (although not used in the included test)
* Additional helper method for easily retrieving metrics
