### PR TITLE
[testing] second node restart

### DIFF
--- a/crypto/src/secp256k1.rs
+++ b/crypto/src/secp256k1.rs
@@ -10,8 +10,10 @@ use once_cell::sync::OnceCell;
 use rust_secp256k1::{constants, rand::rngs::OsRng, Message, PublicKey, Secp256k1, SecretKey};
 use serde::{de, Deserialize, Serialize};
 use signature::{Signature, Signer, Verifier};
-use std::fmt::{self, Debug, Display};
-use std::str::FromStr;
+use std::{
+    fmt::{self, Debug, Display},
+    str::FromStr,
+};
 
 #[readonly::make]
 #[derive(Debug, Clone)]


### PR DESCRIPTION
This PR is introducing the following:

### A new test for the second node restart scenario. 

When we restart 2 nodes back to back we expect them to recover as expected. The scenario is the following:
1. **Spin up a cluster of 4 nodes** and let them advance a bit
2. **Restart first node** and let **it catch up**
3. **Restart second node** and let **it catch up**
4. **Now all nodes** should be in **same commit round** and none should be behind

### A few additions on the cluster struct
* some helper methods to restart a node and retrieve the workers.