### PR TITLE
Added a control system to limit the emission of headers under low volume

### DIFF
--- a/benchmark/benchmark/logs.py
+++ b/benchmark/benchmark/logs.py
@@ -91,7 +91,7 @@ class LogParser:
         rate = int(search(r'Transactions rate: (\d+)', log).group(1))
 
         tmp = search(r'(.*?) .* Start ', log).group(1)
-        start = self._to_posix(tmp)
+        start = self._to_posix(tmp[:24])
 
         misses = len(findall(r'rate too high', log))
 
@@ -158,7 +158,7 @@ class LogParser:
         return sizes, samples, ip
 
     def _to_posix(self, string):
-        x = parser.isoparse(string)
+        x = parser.isoparse(string[:24])
         return datetime.timestamp(x)
 
     def _consensus_throughput(self):

--- a/crypto/src/secp256k1.rs
+++ b/crypto/src/secp256k1.rs
@@ -10,8 +10,10 @@ use once_cell::sync::OnceCell;
 use rust_secp256k1::{constants, rand::rngs::OsRng, Message, PublicKey, Secp256k1, SecretKey};
 use serde::{de, Deserialize, Serialize};
 use signature::{Signature, Signer, Verifier};
-use std::fmt::{self, Debug, Display};
-use std::str::FromStr;
+use std::{
+    fmt::{self, Debug, Display},
+    str::FromStr,
+};
 
 #[readonly::make]
 #[derive(Debug, Clone)]

--- a/primary/src/primary.rs
+++ b/primary/src/primary.rs
@@ -304,7 +304,7 @@ impl Primary {
             /* rx_core */ rx_parents,
             /* rx_workers */ rx_our_digests,
             /* tx_core */ tx_headers,
-            node_metrics,
+            node_metrics.clone(),
         );
 
         // The `Helper` is dedicated to reply to certificates & payload availability requests
@@ -341,6 +341,7 @@ impl Primary {
             rx_consensus,
             rx_state_handler,
             tx_reconfigure,
+            Some(node_metrics.core_metrics.clone()),
         );
 
         // NOTE: This log entry is used to compute performance.
@@ -540,6 +541,7 @@ impl<PublicKey: VerifyingKey> WorkerToPrimary for WorkerReceiverHandler<PublicKe
                     .batches_received
                     .with_label_values(&[&worker_id.to_string(), "our_batch"])
                     .inc();
+                self.metrics.core_metrics.inc_batches();
                 self.tx_our_digests
                     .send((digest, worker_id))
                     .await
@@ -550,6 +552,7 @@ impl<PublicKey: VerifyingKey> WorkerToPrimary for WorkerReceiverHandler<PublicKe
                     .batches_received
                     .with_label_values(&[&worker_id.to_string(), "others_batch"])
                     .inc();
+                self.metrics.core_metrics.inc_batches();
                 self.tx_others_digests
                     .send((digest, worker_id))
                     .await

--- a/primary/src/proposer.rs
+++ b/primary/src/proposer.rs
@@ -243,11 +243,14 @@ impl<PublicKey: VerifyingKey> Proposer<PublicKey> {
                 // observe a weighted average of how many batches we commit per round and compute
                 // a multiplier of the max header delay to try to hit this number of rounds
                 // between 1 and `max_multiplier`.
+
+                // The number of rounds since we last committed.
                 let round_diff = self.round - self.metrics.core_metrics.last_commit_round();
+                // The number of additional batches since we last committed.
                 let batch_diff = self.metrics.core_metrics.current_batches()
                     - self.metrics.core_metrics.last_commit_batches();
                 if round_diff > 0 {
-                    // Compute the weighted average
+                    // Compute the weighted average of batches per round included.
                     ave_batch_per_round = (1.0 - weighted_ave_latest) * ave_batch_per_round
                         + (batch_diff as f64) * weighted_ave_latest / (round_diff as f64);
                 }


### PR DESCRIPTION
This PR is a quick one as I am re-learning the N+T codebase. What is does:
- It records the number of batches (own + other) seen by the primary.
- It records the number of batches between the last commit (although not sure they are committed) and the current round (not sure they are included in the round). 
- It derives a multiplier applied to the inter header timer to try to ensure some minimum of batches are included per header.

Note that the estimation of progress is very rough, and the control logic is also very simple. However, in my tests this successfully slows rounds down when no traffic is sequenced, and picks up again when there is some volume. Slowing down emission when nearly no traffic exists is really the objective here.