### PR TITLE
[testing] support external consensus for Cluster

### DIFF
--- a/crypto/src/secp256k1.rs
+++ b/crypto/src/secp256k1.rs
@@ -10,8 +10,10 @@ use once_cell::sync::OnceCell;
 use rust_secp256k1::{constants, rand::rngs::OsRng, Message, PublicKey, Secp256k1, SecretKey};
 use serde::{de, Deserialize, Serialize};
 use signature::{Signature, Signer, Verifier};
-use std::fmt::{self, Debug, Display};
-use std::str::FromStr;
+use std::{
+    fmt::{self, Debug, Display},
+    str::FromStr,
+};
 
 #[readonly::make]
 #[derive(Debug, Clone)]

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -141,8 +141,11 @@ impl Node {
         let (dag, network_model) = if !internal_consensus {
             debug!("Consensus is disabled: the primary will run w/o Tusk");
             let consensus_metrics = Arc::new(ConsensusMetrics::new(registry));
-            let (_handle, dag) =
+            let (handle, dag) =
                 Dag::new(&*committee.load(), rx_new_certificates, consensus_metrics);
+
+            handles.push(handle);
+
             (Some(Arc::new(dag)), NetworkModel::Asynchronous)
         } else {
             let consensus_handles = Self::spawn_consensus(

--- a/primary/src/grpc_server/mod.rs
+++ b/primary/src/grpc_server/mod.rs
@@ -12,7 +12,7 @@ use consensus::dag::Dag;
 use crypto::traits::VerifyingKey;
 use multiaddr::Multiaddr;
 use std::{sync::Arc, time::Duration};
-use tokio::sync::mpsc::Sender;
+use tokio::{sync::mpsc::Sender, task::JoinHandle};
 use tracing::{error, info};
 use types::{ConfigurationServer, ProposerServer, ValidatorServer};
 
@@ -49,7 +49,7 @@ impl<PublicKey: VerifyingKey, SynchronizerHandler: Handler<PublicKey> + Send + S
         dag: Option<Arc<Dag<PublicKey>>>,
         committee: SharedCommittee<PublicKey>,
         endpoints_metrics: EndpointMetrics,
-    ) {
+    ) -> JoinHandle<()> {
         tokio::spawn(async move {
             let _ = Self {
                 socket_addr,
@@ -65,7 +65,7 @@ impl<PublicKey: VerifyingKey, SynchronizerHandler: Handler<PublicKey> + Send + S
             .run()
             .await
             .map_err(|e| error!("{:?}", e));
-        });
+        })
     }
 
     async fn run(&mut self) -> Result<(), Box<dyn std::error::Error>> {

--- a/primary/tests/causal_completion_tests.rs
+++ b/primary/tests/causal_completion_tests.rs
@@ -16,7 +16,7 @@ async fn test_restore_from_disk() {
     // nodes logs.
     let _guard = setup_tracing();
 
-    let mut cluster = Cluster::new(None, None);
+    let mut cluster = Cluster::new(None, None, true);
 
     // start the cluster
     cluster.start(Some(4), Some(1), None).await;
@@ -106,7 +106,7 @@ async fn test_read_causal_signed_certificates() {
     // nodes logs.
     let _guard = setup_tracing();
 
-    let mut cluster = Cluster::new(None, None);
+    let mut cluster = Cluster::new(None, None, true);
 
     // start the cluster
     cluster.start(Some(4), Some(1), None).await;

--- a/primary/tests/nodes_bootstrapping_tests.rs
+++ b/primary/tests/nodes_bootstrapping_tests.rs
@@ -19,7 +19,7 @@ async fn test_node_staggered_starts() {
     let node_staggered_delay = Duration::from_secs(60 * 5); // 5 minutes
 
     // A cluster of 4 nodes will be created
-    let cluster = Cluster::new(None, None);
+    let cluster = Cluster::new(None, None, true);
 
     // ==== Start first authority ====
     cluster.authority(0).start(false, Some(1)).await;

--- a/test_utils/src/tests/cluster_tests.rs
+++ b/test_utils/src/tests/cluster_tests.rs
@@ -45,11 +45,6 @@ async fn cluster_setup_with_consensus_disabled() {
     // give some time for nodes to boostrap
     tokio::time::sleep(Duration::from_secs(2)).await;
 
-    // fetch all the running authorities
-    let authorities = cluster.authorities().await;
-
-    assert_eq!(authorities.len(), 2);
-
     // connect to the gRPC address and send a simple request
     let authority = cluster.authority(0);
 

--- a/test_utils/src/tests/cluster_tests.rs
+++ b/test_utils/src/tests/cluster_tests.rs
@@ -2,10 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 use crate::cluster::Cluster;
 use std::time::Duration;
+use types::{PublicKeyProto, RoundsRequest};
 
 #[tokio::test]
 async fn basic_cluster_setup() {
-    let mut cluster = Cluster::new(None, None);
+    let mut cluster = Cluster::new(None, None, true);
 
     // start the cluster will all the possible nodes
     cluster.start(None, None, None).await;
@@ -32,4 +33,37 @@ async fn basic_cluster_setup() {
 
     // No authority should still run
     assert!(cluster.authorities().await.is_empty());
+}
+
+#[tokio::test]
+async fn cluster_setup_with_consensus_disabled() {
+    let mut cluster = Cluster::new(None, None, false);
+
+    // start the cluster will all the possible nodes
+    cluster.start(Some(2), Some(1), None).await;
+
+    // give some time for nodes to boostrap
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // fetch all the running authorities
+    let authorities = cluster.authorities().await;
+
+    assert_eq!(authorities.len(), 2);
+
+    // connect to the gRPC address and send a simple request
+    let authority = cluster.authority(0);
+
+    let mut client = authority.new_proposer_client().await;
+
+    // send a sample rounds request
+    let request = tonic::Request::new(RoundsRequest {
+        public_key: Some(PublicKeyProto::from(authority.name.clone())),
+    });
+    let response = client.rounds(request).await;
+
+    // Should get back a successful response
+    let r = response.ok().unwrap().into_inner();
+
+    assert_eq!(0, r.oldest_round);
+    assert_eq!(0, r.newest_round);
 }


### PR DESCRIPTION
This PR is enhancing the Cluster testing util to support running the cluster with internal consensus disabled - so we can manage the node via the gRPC interface that we have introduced. Some necessary changes have been made to ensure that JoinHandles are returned and allow us to shutdown the nodes properly. Also a helper method has been introduced in Cluster to allow us create a new proposer client seamlessly.