### PR TITLE
[logging] Tracing span verbosity reduction

### DIFF
--- a/consensus/src/dag.rs
+++ b/consensus/src/dag.rs
@@ -285,7 +285,7 @@ impl<PublicKey: VerifyingKey> InnerDag<PublicKey> {
     }
 
     /// Removes certificates from the Dag, reclaiming memory in the process.
-    #[instrument(level = "debug", skip_all, fields(certificate_ids = ?digests), err)]
+    #[instrument(level = "debug", skip_all, fields(num_certificate_ids = digests.len()), err)]
     fn remove(
         &mut self,
         digests: Vec<CertificateDigest>,

--- a/consensus/src/dag.rs
+++ b/consensus/src/dag.rs
@@ -179,7 +179,7 @@ impl<PublicKey: VerifyingKey> InnerDag<PublicKey> {
         }
     }
 
-    #[instrument(level = "debug", skip_all, fields(certificate = ?certificate), err)]
+    #[instrument(level = "trace", skip_all, fields(certificate = ?certificate), err)]
     fn insert(
         &mut self,
         certificate: Certificate<PublicKey>,
@@ -210,13 +210,13 @@ impl<PublicKey: VerifyingKey> InnerDag<PublicKey> {
     /// Returns whether the dag has ever contained a node with the provided digest. The method will return
     /// true either when the node is live (uncompressed) or has been already compressed as still exists
     /// as weak reference.
-    #[instrument(level = "debug", skip_all, fields(digest = ?digest))]
+    #[instrument(level = "trace", skip_all, fields(digest = ?digest))]
     fn has_ever_contained(&self, digest: CertificateDigest) -> bool {
         self.dag.contains(digest)
     }
 
     /// Returns the oldest and newest rounds for which a validator has (live) certificates in the DAG
-    #[instrument(level = "debug", skip_all, fields(origin = ?origin), err)]
+    #[instrument(level = "trace", skip_all, fields(origin = ?origin), err)]
     fn rounds(
         &mut self,
         origin: PublicKey,
@@ -260,7 +260,7 @@ impl<PublicKey: VerifyingKey> InnerDag<PublicKey> {
 
     /// Returns a breadth first traversal of the Dag, starting with the certified collection
     /// passed as argument.
-    #[instrument(level = "debug", skip_all, fields(start_certificate_id = ?start), err)]
+    #[instrument(level = "trace", skip_all, fields(start_certificate_id = ?start), err)]
     fn read_causal(
         &self,
         start: CertificateDigest,
@@ -271,7 +271,7 @@ impl<PublicKey: VerifyingKey> InnerDag<PublicKey> {
 
     /// Returns a breadth first traversal of the Dag, starting with the certified collection
     /// passed as argument.
-    #[instrument(level = "debug", skip_all, fields(origin = ?origin, round = ?round), err)]
+    #[instrument(level = "trace", skip_all, fields(origin = ?origin, round = ?round), err)]
     fn node_read_causal(
         &self,
         origin: PublicKey,
@@ -285,7 +285,7 @@ impl<PublicKey: VerifyingKey> InnerDag<PublicKey> {
     }
 
     /// Removes certificates from the Dag, reclaiming memory in the process.
-    #[instrument(level = "debug", skip_all, fields(num_certificate_ids = digests.len()), err)]
+    #[instrument(level = "trace", skip_all, fields(num_certificate_ids = digests.len()), err)]
     fn remove(
         &mut self,
         digests: Vec<CertificateDigest>,

--- a/primary/src/block_synchronizer/handler.rs
+++ b/primary/src/block_synchronizer/handler.rs
@@ -170,7 +170,7 @@ impl<PublicKey: VerifyingKey> Handler<PublicKey> for BlockSynchronizerHandler<Pu
     /// * Internal: An internal error caused
     /// * BlockDeliveryTimeout: Timed out while waiting for the certificate to become available
     /// after submitting it for processing to core
-    #[instrument(level="debug", skip_all, fields(block_ids = ?block_ids))]
+    #[instrument(level="debug", skip_all, fields(num_block_ids = block_ids.len()))]
     async fn get_and_synchronize_block_headers(
         &self,
         block_ids: Vec<CertificateDigest>,
@@ -235,7 +235,7 @@ impl<PublicKey: VerifyingKey> Handler<PublicKey> for BlockSynchronizerHandler<Pu
         results
     }
 
-    #[instrument(level="debug", skip_all, fields(block_ids = ?block_ids))]
+    #[instrument(level="debug", skip_all, fields(num_block_ids = block_ids.len()))]
     async fn get_block_headers(
         &self,
         block_ids: Vec<CertificateDigest>,

--- a/primary/src/block_synchronizer/mod.rs
+++ b/primary/src/block_synchronizer/mod.rs
@@ -359,7 +359,7 @@ impl<PublicKey: VerifyingKey> BlockSynchronizer<PublicKey> {
     /// logic of waiting and gathering the replies from the primary nodes
     /// for the payload availability. This future is returning the next State
     /// to be executed.
-    #[instrument(level="debug", skip_all, fields(certificates = ?certificates))]
+    #[instrument(level="debug", skip_all, fields(num_certificates = certificates.len()))]
     async fn handle_synchronize_block_payload_command<'a>(
         &mut self,
         certificates: Vec<Certificate<PublicKey>>,

--- a/primary/src/block_waiter.rs
+++ b/primary/src/block_waiter.rs
@@ -367,7 +367,7 @@ impl<PublicKey: VerifyingKey, SynchronizerHandler: Handler<PublicKey> + Send + S
         }
     }
 
-    #[instrument(level="debug", skip_all, fields(block_ids = ?ids))]
+    #[instrument(level="debug", skip_all, fields(num_block_ids = ids.len()))]
     async fn handle_get_blocks_command<'a>(
         &mut self,
         ids: Vec<CertificateDigest>,
@@ -421,7 +421,7 @@ impl<PublicKey: VerifyingKey, SynchronizerHandler: Handler<PublicKey> + Send + S
     /// fetch it via the peers. Otherwise if available on the storage
     /// should return the result immediately. The method is blocking to
     /// retrieve all the results.
-    #[instrument(level = "debug", skip_all, fields(certificate_ids = ?ids))]
+    #[instrument(level = "debug", skip_all, fields(num_certificate_ids = ids.len()))]
     async fn get_certificates(
         &mut self,
         ids: Vec<CertificateDigest>,
@@ -525,7 +525,7 @@ impl<PublicKey: VerifyingKey, SynchronizerHandler: Handler<PublicKey> + Send + S
     // handles received commands and returns back a future if needs to
     // wait for further results. Otherwise, an empty option is returned
     // if no further waiting on processing is needed.
-    #[instrument(level="debug", skip_all, fields(block_ids = ?id))]
+    #[instrument(level="debug", skip_all, fields(block_id = ?id))]
     async fn handle_get_block_command<'a>(
         &mut self,
         id: CertificateDigest,

--- a/primary/src/helper.rs
+++ b/primary/src/helper.rs
@@ -128,7 +128,7 @@ impl<PublicKey: VerifyingKey> Helper<PublicKey> {
     /// certificate & batch data for each certificate digest in digests,
     /// and reports on each fully available item in the request in a
     /// PayloadAvailabilityResponse.
-    #[instrument(level="debug", skip_all, fields(certificate_ids = ?digests), err)]
+    #[instrument(level="debug", skip_all, fields(num_certificate_ids = digests.len()), err)]
     async fn process_payload_availability(
         &mut self,
         digests: Vec<CertificateDigest>,
@@ -201,7 +201,7 @@ impl<PublicKey: VerifyingKey> Helper<PublicKey> {
         Ok(())
     }
 
-    #[instrument(level="debug", skip_all, fields(certificate_ids = ?digests, mode = batch_mode), err)]
+    #[instrument(level="debug", skip_all, fields(num_certificate_ids = digests.len(), mode = batch_mode), err)]
     async fn process_certificates(
         &mut self,
         digests: Vec<CertificateDigest>,


### PR DESCRIPTION
Some of our tracing spans print out lists of requests in-extenso, recording the `Debug` impl of a list of arbitrary length passed as a argument. This leads to 50KB messages.

This converts them to printing just the length of the list.

Also switches the verbosity of spans in consensus::dag to tracing.