### PR TITLE
fix: Correct the generics in ExecutionState

### DIFF
--- a/executor/src/core.rs
+++ b/executor/src/core.rs
@@ -30,7 +30,7 @@ pub mod executor_tests;
 /// consensus messages in the right and complete order. All transactions data referenced by the
 /// certificate should already be downloaded in the temporary storage. This module ensures it does
 /// not processes twice the same transaction (despite crash-recovery).
-pub struct Core<State: ExecutionState, PublicKey: VerifyingKey> {
+pub struct Core<State: ExecutionState<PubKey = PublicKey>, PublicKey: VerifyingKey> {
     /// The temporary storage holding all transactions' data (that may be too big to hold in memory).
     store: Store<BatchDigest, SerializedBatchMessage>,
     /// The (global) state to perform execution.
@@ -45,7 +45,9 @@ pub struct Core<State: ExecutionState, PublicKey: VerifyingKey> {
     execution_indices: ExecutionIndices,
 }
 
-impl<State: ExecutionState, PublicKey: VerifyingKey> Drop for Core<State, PublicKey> {
+impl<State: ExecutionState<PubKey = PublicKey>, PublicKey: VerifyingKey> Drop
+    for Core<State, PublicKey>
+{
     fn drop(&mut self) {
         self.execution_state.release_consensus_write_lock();
     }
@@ -53,7 +55,7 @@ impl<State: ExecutionState, PublicKey: VerifyingKey> Drop for Core<State, Public
 
 impl<State, PublicKey> Core<State, PublicKey>
 where
-    State: ExecutionState + Send + Sync + 'static,
+    State: ExecutionState<PubKey = PublicKey> + Send + Sync + 'static,
     State::Outcome: Send + 'static,
     State::Error: Debug,
     PublicKey: VerifyingKey,

--- a/executor/src/tests/execution_state.rs
+++ b/executor/src/tests/execution_state.rs
@@ -4,7 +4,7 @@ use crate::{ExecutionIndices, ExecutionState, ExecutionStateError};
 use async_trait::async_trait;
 use config::Committee;
 use consensus::ConsensusOutput;
-use crypto::traits::VerifyingKey;
+use crypto::ed25519::Ed25519PublicKey;
 use futures::executor::block_on;
 use std::path::Path;
 use store::{
@@ -39,16 +39,17 @@ impl Default for TestState {
 
 #[async_trait]
 impl ExecutionState for TestState {
+    type PubKey = Ed25519PublicKey;
     type Transaction = u64;
     type Error = TestStateError;
     type Outcome = Vec<u8>;
 
-    async fn handle_consensus_transaction<PublicKey: VerifyingKey>(
+    async fn handle_consensus_transaction(
         &self,
-        _consensus_output: &ConsensusOutput<PublicKey>,
+        _consensus_output: &ConsensusOutput<Ed25519PublicKey>,
         execution_indices: ExecutionIndices,
         transaction: Self::Transaction,
-    ) -> Result<(Self::Outcome, Option<Committee<PublicKey>>), Self::Error> {
+    ) -> Result<(Self::Outcome, Option<Committee<Ed25519PublicKey>>), Self::Error> {
         if transaction == MALFORMED_TRANSACTION {
             Err(Self::Error::ClientError)
         } else if transaction == KILLER_TRANSACTION {

--- a/node/src/execution_state.rs
+++ b/node/src/execution_state.rs
@@ -5,18 +5,20 @@ use config::Committee;
 use consensus::ConsensusOutput;
 use crypto::traits::VerifyingKey;
 use executor::{ExecutionIndices, ExecutionState, ExecutionStateError};
+use std::marker::PhantomData;
 use thiserror::Error;
 
 /// A simple/dumb execution engine.
-pub struct SimpleExecutionState;
+pub struct SimpleExecutionState<PublicKey: VerifyingKey>(PhantomData<PublicKey>);
 
 #[async_trait]
-impl ExecutionState for SimpleExecutionState {
+impl<PublicKey: VerifyingKey> ExecutionState for SimpleExecutionState<PublicKey> {
+    type PubKey = PublicKey;
     type Transaction = String;
     type Error = SimpleExecutionError;
     type Outcome = Vec<u8>;
 
-    async fn handle_consensus_transaction<PublicKey: VerifyingKey>(
+    async fn handle_consensus_transaction(
         &self,
         _consensus_output: &ConsensusOutput<PublicKey>,
         _execution_indices: ExecutionIndices,
@@ -33,6 +35,12 @@ impl ExecutionState for SimpleExecutionState {
 
     async fn load_execution_indices(&self) -> Result<ExecutionIndices, Self::Error> {
         Ok(ExecutionIndices::default())
+    }
+}
+
+impl<PublicKey: VerifyingKey> Default for SimpleExecutionState<PublicKey> {
+    fn default() -> Self {
+        Self(PhantomData)
     }
 }
 

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -124,7 +124,7 @@ impl Node {
     where
         PublicKey: VerifyingKey,
         Keys: KeyPair<PubKey = PublicKey> + Signer<PublicKey::Sig> + Send + 'static,
-        State: ExecutionState + Send + Sync + 'static,
+        State: ExecutionState<PubKey = PublicKey> + Send + Sync + 'static,
         State::Outcome: Send + 'static,
         State::Error: Debug,
     {
@@ -237,7 +237,7 @@ impl Node {
     ) -> SubscriberResult<Vec<JoinHandle<()>>>
     where
         PublicKey: VerifyingKey,
-        State: ExecutionState + Send + Sync + 'static,
+        State: ExecutionState<PubKey = PublicKey> + Send + Sync + 'static,
         State::Outcome: Send + 'static,
         State::Error: Debug,
     {

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -167,7 +167,7 @@ async fn run(matches: &ArgMatches<'_>) -> Result<()> {
                 &store,
                 parameters.clone(),
                 /* consensus */ !sub_matches.is_present("consensus-disabled"),
-                /* execution_state */ Arc::new(SimpleExecutionState),
+                /* execution_state */ Arc::new(SimpleExecutionState::default()),
                 tx_transaction_confirmation,
                 &registry,
             )

--- a/node/src/restarter.rs
+++ b/node/src/restarter.rs
@@ -26,7 +26,7 @@ impl NodeRestarter {
         mut rx_reconfigure: Receiver<(Keys, Committee<Keys::PubKey>)>,
         tx_output: Sender<ExecutorOutput<State>>,
     ) where
-        State: ExecutionState + Send + Sync + 'static,
+        State: ExecutionState<PubKey = Keys::PubKey> + Send + Sync + 'static,
         State::Outcome: Send + 'static,
         State::Error: Debug,
         Keys: KeyPair + Send + 'static,

--- a/node/tests/reconfigure.rs
+++ b/node/tests/reconfigure.rs
@@ -48,16 +48,17 @@ impl SimpleExecutionState {
 
 #[async_trait::async_trait]
 impl ExecutionState for SimpleExecutionState {
+    type PubKey = Ed25519PublicKey;
     type Transaction = u64;
     type Error = SimpleExecutionError;
     type Outcome = u64;
 
-    async fn handle_consensus_transaction<PublicKey: VerifyingKey>(
+    async fn handle_consensus_transaction(
         &self,
-        _consensus_output: &ConsensusOutput<PublicKey>,
+        _consensus_output: &ConsensusOutput<Ed25519PublicKey>,
         execution_indices: ExecutionIndices,
         transaction: Self::Transaction,
-    ) -> Result<(Self::Outcome, Option<Committee<PublicKey>>), Self::Error> {
+    ) -> Result<(Self::Outcome, Option<Committee<Ed25519PublicKey>>), Self::Error> {
         // Change epoch every few certificates. Note that empty certificates are not provided to
         // this function (they are immediately skipped).
         let mut epoch = self.committee.lock().unwrap().epoch();

--- a/test_utils/src/cluster.rs
+++ b/test_utils/src/cluster.rs
@@ -284,7 +284,7 @@ impl PrimaryNodeDetails {
             &primary_store,
             self.parameters.clone(),
             /* consensus */ self.internal_consensus_enabled,
-            /* execution_state */ Arc::new(SimpleExecutionState),
+            /* execution_state */ Arc::new(SimpleExecutionState::default()),
             tx_transaction_confirmation,
             &registry,
         )


### PR DESCRIPTION
This is a follow-up of #583. The `ExecutionState` trait incorrectly required one of its methods (`handle_consensus_transaction`) to be generic in a `PublicKey: VerifyingKey` parameter.
The Sui code base has no such genericity, making the implementation difficult. Moreover, the parameter is not needed in the first place (the `ExecutionState` implementations work fine with one single instantiated type for public keys).