### PR TITLE
[fix] linter issue

### DIFF
--- a/primary/tests/nodes_bootstrapping_tests.rs
+++ b/primary/tests/nodes_bootstrapping_tests.rs
@@ -99,7 +99,7 @@ async fn test_second_node_restart() {
     let node_advance_delay = Duration::from_secs(60);
 
     // A cluster of 4 nodes will be created
-    let mut cluster = Cluster::new(None, None);
+    let mut cluster = Cluster::new(None, None, true);
 
     // ===== Start the cluster ====
     cluster.start(Some(4), Some(1), None).await;


### PR DESCRIPTION
Linter complains in main (for good reason!) as a parameter is missing from the `Cluster` in the `test_second_node_restart` test