### PR TITLE
[network] refactor: Network renamings

### DIFF
--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -23,17 +23,18 @@ pub use crate::{
 // the result of our network messages
 pub type MessageResult = Result<tonic::Response<types::Empty>, anyhow::Error>;
 
+/// This adapter will make a [`tokio::task::JoinHandle`] abort its handled task when the handle is dropped.
 #[derive(Debug)]
 #[must_use]
-pub struct CancelHandler<T>(pub tokio::task::JoinHandle<T>);
+pub struct CancelOnDropHandler<T>(tokio::task::JoinHandle<T>);
 
-impl<T> Drop for CancelHandler<T> {
+impl<T> Drop for CancelOnDropHandler<T> {
     fn drop(&mut self) {
         self.0.abort();
     }
 }
 
-impl<T> std::future::Future for CancelHandler<T> {
+impl<T> std::future::Future for CancelOnDropHandler<T> {
     type Output = T;
 
     fn poll(

--- a/network/src/primary.rs
+++ b/network/src/primary.rs
@@ -139,8 +139,8 @@ impl PrimaryNetwork {
             .await
     }
 
-    /// Pick a few addresses at random (specified by `nodes`) and try (best-effort) to send the
-    /// message only to them. This is useful to pick nodes with whom to sync.
+    /// Broadcasts a message to all `addresses` passed as an argument.
+    /// The attempts to send individual messages are best effort and will not be retried.
     pub async fn unreliable_broadcast<T: VerifyingKey>(
         &mut self,
         addresses: Vec<Multiaddr>,
@@ -230,7 +230,9 @@ impl PrimaryToWorkerNetwork {
         PrimaryToWorkerClient::new(channel)
     }
 
-    pub async fn send<T: VerifyingKey>(
+    /// Sends a message to an `address` passed as an argument.
+    /// The attempt to send a message is best effort and will not be retried.
+    pub async fn unreliable_send<T: VerifyingKey>(
         &mut self,
         address: Multiaddr,
         message: &PrimaryWorkerMessage<T>,
@@ -245,7 +247,9 @@ impl PrimaryToWorkerNetwork {
             .await
     }
 
-    pub async fn broadcast<T: VerifyingKey>(
+    /// Broadcasts a message to all `addresses` passed as an argument.
+    /// The attempts to send individual messages are best effort and will not be retried.
+    pub async fn unreliable_broadcast<T: VerifyingKey>(
         &mut self,
         addresses: Vec<Multiaddr>,
         message: &PrimaryWorkerMessage<T>,

--- a/network/src/worker.rs
+++ b/network/src/worker.rs
@@ -1,6 +1,8 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use crate::{BoundedExecutor, CancelHandler, MessageResult, RetryConfig, MAX_TASK_CONCURRENCY};
+use crate::{
+    BoundedExecutor, CancelOnDropHandler, MessageResult, RetryConfig, MAX_TASK_CONCURRENCY,
+};
 use crypto::traits::VerifyingKey;
 use multiaddr::Multiaddr;
 use rand::{prelude::SliceRandom as _, rngs::SmallRng, SeedableRng as _};
@@ -64,7 +66,7 @@ impl WorkerNetwork {
         &mut self,
         address: Multiaddr,
         message: &WorkerMessage<T>,
-    ) -> CancelHandler<MessageResult> {
+    ) -> CancelOnDropHandler<MessageResult> {
         let message =
             BincodeEncodedPayload::try_from(message).expect("Failed to serialize payload");
         self.send_message(address, message).await
@@ -80,7 +82,7 @@ impl WorkerNetwork {
         &mut self,
         address: Multiaddr,
         message: BincodeEncodedPayload,
-    ) -> CancelHandler<MessageResult> {
+    ) -> CancelOnDropHandler<MessageResult> {
         let client = self.client(address.clone());
 
         let message_send = move || {
@@ -102,14 +104,14 @@ impl WorkerNetwork {
             .or_insert_with(default_executor)
             .spawn_with_retries(self.retry_config, message_send);
 
-        CancelHandler(handle)
+        CancelOnDropHandler(handle)
     }
 
     pub async fn broadcast<T: VerifyingKey>(
         &mut self,
         addresses: Vec<Multiaddr>,
         message: &WorkerMessage<T>,
-    ) -> Vec<CancelHandler<MessageResult>> {
+    ) -> Vec<CancelOnDropHandler<MessageResult>> {
         let message =
             BincodeEncodedPayload::try_from(message).expect("Failed to serialize payload");
         let mut handlers = Vec::new();
@@ -207,7 +209,7 @@ impl WorkerToPrimaryNetwork {
         &mut self,
         address: Multiaddr,
         message: &WorkerPrimaryMessage<PublicKey>,
-    ) -> CancelHandler<MessageResult> {
+    ) -> CancelOnDropHandler<MessageResult> {
         let new_client = match &self.address {
             None => true,
             Some(x) if x != &address => true,
@@ -239,6 +241,6 @@ impl WorkerToPrimaryNetwork {
             .executor
             .spawn_with_retries(self.retry_config, message_send);
 
-        CancelHandler(handle)
+        CancelOnDropHandler(handle)
     }
 }

--- a/node/src/restarter.rs
+++ b/node/src/restarter.rs
@@ -100,7 +100,9 @@ impl NodeRestarter {
             let message = PrimaryWorkerMessage::<Keys::PubKey>::Reconfigure(
                 ReconfigureNotification::Shutdown,
             );
-            let worker_cancel_handles = worker_network.broadcast(addresses, &message).await;
+            let worker_cancel_handles = worker_network
+                .unreliable_broadcast(addresses, &message)
+                .await;
 
             // Ensure the message has been received.
             primary_cancel_handle

--- a/node/tests/reconfigure.rs
+++ b/node/tests/reconfigure.rs
@@ -292,7 +292,9 @@ async fn epoch_change() {
                 let message = PrimaryWorkerMessage::Reconfigure(
                     ReconfigureNotification::NewCommittee(committee.clone()),
                 );
-                let worker_cancel_handles = worker_network.broadcast(addresses, &message).await;
+                let worker_cancel_handles = worker_network
+                    .unreliable_broadcast(addresses, &message)
+                    .await;
 
                 // Ensure the message has been received.
                 primary_cancel_handle.await.unwrap();

--- a/primary/src/block_remover.rs
+++ b/primary/src/block_remover.rs
@@ -341,9 +341,9 @@ impl<PublicKey: VerifyingKey> BlockRemover<PublicKey> {
                 // whatever this is. Otherwise, we are sending back an error
                 // response.
                 if cleanup_successful.is_ok() {
-                    Self::broadcast(senders, result).await;
+                    Self::unreliable_broadcast(senders, result).await;
                 } else {
-                    Self::broadcast(
+                    Self::unreliable_broadcast(
                         senders,
                         Err(BlockRemoverError {
                             ids: block_ids,
@@ -357,7 +357,7 @@ impl<PublicKey: VerifyingKey> BlockRemover<PublicKey> {
     }
 
     /// Helper method to broadcast the result_to_send to all the senders.
-    async fn broadcast(
+    async fn unreliable_broadcast(
         senders: Vec<Sender<BlockRemoverResult<RemoveBlocksResponse>>>,
         result_to_send: BlockRemoverResult<RemoveBlocksResponse>,
     ) {
@@ -543,7 +543,7 @@ impl<PublicKey: VerifyingKey> BlockRemover<PublicKey> {
 
             // send the request
             self.worker_network
-                .send(worker_address.clone(), &message)
+                .unreliable_send(worker_address.clone(), &message)
                 .await;
 
             debug!(

--- a/primary/src/block_synchronizer/mod.rs
+++ b/primary/src/block_synchronizer/mod.rs
@@ -683,7 +683,9 @@ impl<PublicKey: VerifyingKey> BlockSynchronizer<PublicKey> {
 
             let message =
                 PrimaryWorkerMessage::Synchronize(batch_ids.clone(), primary_peer_name.clone());
-            self.worker_network.send(worker_address, &message).await;
+            self.worker_network
+                .unreliable_send(worker_address, &message)
+                .await;
 
             debug!(
                 "Sent request for batch ids {:?} to worker id {}",

--- a/primary/src/block_waiter.rs
+++ b/primary/src/block_waiter.rs
@@ -713,7 +713,9 @@ impl<PublicKey: VerifyingKey, SynchronizerHandler: Handler<PublicKey> + Send + S
 
             let message = PrimaryWorkerMessage::<PublicKey>::RequestBatch(digest);
 
-            self.worker_network.send(worker_address, &message).await;
+            self.worker_network
+                .unreliable_send(worker_address, &message)
+                .await;
 
             // mark it as pending batch. Since we assume that batches are unique
             // per block, a clean up on a block request will also clean

--- a/primary/src/core.rs
+++ b/primary/src/core.rs
@@ -10,7 +10,7 @@ use crate::{
 use async_recursion::async_recursion;
 use config::{Committee, Epoch};
 use crypto::{traits::VerifyingKey, Hash as _, SignatureService};
-use network::{CancelHandler, MessageResult, PrimaryNetwork};
+use network::{CancelOnDropHandler, MessageResult, PrimaryNetwork};
 use std::{
     collections::{HashMap, HashSet},
     sync::{
@@ -86,7 +86,7 @@ pub struct Core<PublicKey: VerifyingKey> {
     /// A network sender to send the batches to the other workers.
     network: PrimaryNetwork,
     /// Keeps the cancel handlers of the messages we sent.
-    cancel_handlers: HashMap<Round, Vec<CancelHandler<MessageResult>>>,
+    cancel_handlers: HashMap<Round, Vec<CancelOnDropHandler<MessageResult>>>,
     /// Metrics handler
     metrics: Arc<PrimaryMetrics>,
 }

--- a/primary/src/header_waiter.rs
+++ b/primary/src/header_waiter.rs
@@ -215,7 +215,7 @@ impl<PublicKey: VerifyingKey> HeaderWaiter<PublicKey> {
                                 // TODO [issue #423]: This network transmission needs to be reliable. The worker may crash-recover
                                 // or a committee change may change the worker's IP address.
                                 let message = PrimaryWorkerMessage::Synchronize(digests, author.clone());
-                                self.worker_network.send(address, &message).await;
+                                self.worker_network.unreliable_send(address, &message).await;
                             }
                         }
 

--- a/primary/src/state_handler.rs
+++ b/primary/src/state_handler.rs
@@ -80,7 +80,9 @@ impl<PublicKey: VerifyingKey> StateHandler<PublicKey> {
                 .map(|x| x.primary_to_worker)
                 .collect();
             let message = PrimaryWorkerMessage::<PublicKey>::Cleanup(round);
-            self.worker_network.broadcast(addresses, &message).await;
+            self.worker_network
+                .unreliable_broadcast(addresses, &message)
+                .await;
         }
     }
 

--- a/primary/tests/epoch_change.rs
+++ b/primary/tests/epoch_change.rs
@@ -4,7 +4,7 @@ use arc_swap::ArcSwap;
 use config::{Committee, Epoch, Parameters};
 use crypto::{ed25519::Ed25519PublicKey, traits::KeyPair};
 use futures::future::join_all;
-use network::{CancelHandler, WorkerToPrimaryNetwork};
+use network::{CancelOnDropHandler, WorkerToPrimaryNetwork};
 use node::NodeStorage;
 use primary::{NetworkModel, Primary, CHANNEL_CAPACITY};
 use prometheus::Registry;
@@ -89,7 +89,7 @@ async fn test_simple_epoch_change() {
         let message = WorkerPrimaryMessage::Reconfigure(ReconfigureNotification::NewCommittee(
             new_committee.clone(),
         ));
-        let mut _do_not_drop: Vec<CancelHandler<_>> = Vec::new();
+        let mut _do_not_drop: Vec<CancelOnDropHandler<_>> = Vec::new();
         for address in addresses {
             _do_not_drop.push(
                 WorkerToPrimaryNetwork::default()
@@ -251,7 +251,7 @@ async fn test_partial_committee_change() {
     let message = WorkerPrimaryMessage::Reconfigure(ReconfigureNotification::NewCommittee(
         committee_1.clone(),
     ));
-    let mut _do_not_drop: Vec<CancelHandler<_>> = Vec::new();
+    let mut _do_not_drop: Vec<CancelOnDropHandler<_>> = Vec::new();
     for address in addresses {
         _do_not_drop.push(
             WorkerToPrimaryNetwork::default()
@@ -339,7 +339,7 @@ async fn test_restart_with_new_committee_change() {
         .collect();
     let message =
         WorkerPrimaryMessage::<Ed25519PublicKey>::Reconfigure(ReconfigureNotification::Shutdown);
-    let mut _do_not_drop: Vec<CancelHandler<_>> = Vec::new();
+    let mut _do_not_drop: Vec<CancelOnDropHandler<_>> = Vec::new();
     for address in addresses {
         _do_not_drop.push(
             WorkerToPrimaryNetwork::default()
@@ -411,7 +411,7 @@ async fn test_restart_with_new_committee_change() {
         let message = WorkerPrimaryMessage::<Ed25519PublicKey>::Reconfigure(
             ReconfigureNotification::Shutdown,
         );
-        let mut _do_not_drop: Vec<CancelHandler<_>> = Vec::new();
+        let mut _do_not_drop: Vec<CancelOnDropHandler<_>> = Vec::new();
         for address in addresses {
             _do_not_drop.push(
                 WorkerToPrimaryNetwork::default()

--- a/worker/src/quorum_waiter.rs
+++ b/worker/src/quorum_waiter.rs
@@ -4,7 +4,7 @@
 use config::{Committee, Stake, WorkerId};
 use crypto::traits::VerifyingKey;
 use futures::stream::{futures_unordered::FuturesUnordered, StreamExt as _};
-use network::{CancelHandler, MessageResult, WorkerNetwork};
+use network::{CancelOnDropHandler, MessageResult, WorkerNetwork};
 use tokio::{
     sync::{
         mpsc::{Receiver, Sender},
@@ -64,7 +64,7 @@ impl<PublicKey: VerifyingKey> QuorumWaiter<PublicKey> {
     }
 
     /// Helper function. It waits for a future to complete and then delivers a value.
-    async fn waiter(wait_for: CancelHandler<MessageResult>, deliver: Stake) -> Stake {
+    async fn waiter(wait_for: CancelOnDropHandler<MessageResult>, deliver: Stake) -> Stake {
         let _ = wait_for.await;
         deliver
     }


### PR DESCRIPTION
These renamings will help clarify and regularize the semantics of our network-related functions.

`CancelHandler` -> `CancelOnDropHandler`
unreliable `broadcast` -> `unreliable_broadcast`
Extracted from a larger, still-upcoming PR.