### PR TITLE
[refactor] The Great Genericity Simplification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4316,6 +4316,7 @@ dependencies = [
  "rustversion",
  "serde",
  "serde_test",
+ "signature",
  "thiserror",
  "tokio",
  "tokio-util",

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -9,7 +9,7 @@
 )]
 
 use arc_swap::ArcSwap;
-use crypto::traits::{EncodeDecodeBase64, VerifyingKey};
+use crypto::{traits::EncodeDecodeBase64, PublicKey};
 use multiaddr::Multiaddr;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::{
@@ -320,18 +320,17 @@ pub struct Authority {
     pub workers: HashMap<WorkerId, WorkerAddresses>,
 }
 
-pub type SharedCommittee<PK> = Arc<ArcSwap<Committee<PK>>>;
+pub type SharedCommittee = Arc<ArcSwap<Committee>>;
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
-pub struct Committee<PublicKey: VerifyingKey> {
+pub struct Committee {
     /// The authorities of epoch.
-    #[serde(bound(deserialize = "PublicKey: VerifyingKey"))]
     pub authorities: BTreeMap<PublicKey, Authority>,
     /// The epoch number of this committee
     pub epoch: Epoch,
 }
 
-impl<PublicKey: VerifyingKey> std::fmt::Display for Committee<PublicKey> {
+impl std::fmt::Display for Committee {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
@@ -345,7 +344,7 @@ impl<PublicKey: VerifyingKey> std::fmt::Display for Committee<PublicKey> {
     }
 }
 
-impl<PublicKey: VerifyingKey> Committee<PublicKey> {
+impl Committee {
     /// Returns the number of authorities.
     pub fn epoch(&self) -> Epoch {
         self.epoch

--- a/config/tests/config_tests.rs
+++ b/config/tests/config_tests.rs
@@ -7,7 +7,7 @@ use config::{
     Committee, ConsensusAPIGrpcParameters, Epoch, Parameters, PrimaryAddresses,
     PrometheusMetricsParameters, Stake,
 };
-use crypto::{ed25519::Ed25519PublicKey, traits::KeyPair};
+use crypto::{traits::KeyPair as _, PublicKey};
 use insta::assert_json_snapshot;
 use rand::seq::SliceRandom;
 use test_utils::make_authority_with_port_getter;
@@ -79,7 +79,7 @@ fn update_primary_network_info_test() {
         .into_iter()
         .zip(addresses)
         .map(|((pk, stk), addr)| (pk, (stk, addr)))
-        .collect::<BTreeMap<Ed25519PublicKey, (Stake, PrimaryAddresses)>>();
+        .collect::<BTreeMap<PublicKey, (Stake, PrimaryAddresses)>>();
 
     let mut comm = committee;
     let res = comm.update_primary_network_info(new_info.clone());

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -16,7 +16,7 @@ pub mod tusk;
 mod utils;
 
 pub use crate::{consensus::Consensus, subscriber::SubscriberHandler};
-use crypto::traits::VerifyingKey;
+
 use serde::{Deserialize, Serialize};
 use std::ops::RangeInclusive;
 use types::{Certificate, SequenceNumber};
@@ -26,10 +26,9 @@ pub const DEFAULT_CHANNEL_SIZE: usize = 1_000;
 
 /// The output format of the consensus.
 #[derive(Serialize, Deserialize, Clone, Debug)]
-#[serde(bound(deserialize = "PublicKey: VerifyingKey"))]
-pub struct ConsensusOutput<PublicKey: VerifyingKey> {
+pub struct ConsensusOutput {
     /// The sequenced certificate.
-    pub certificate: Certificate<PublicKey>,
+    pub certificate: Certificate,
     /// The (global) index associated with this certificate.
     pub consensus_index: SequenceNumber,
 }

--- a/consensus/src/subscriber.rs
+++ b/consensus/src/subscriber.rs
@@ -1,7 +1,6 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use crate::{ConsensusOutput, ConsensusSyncRequest};
-use crypto::traits::VerifyingKey;
 use std::sync::Arc;
 use tokio::{
     sync::{
@@ -18,33 +17,33 @@ use types::{Certificate, CertificateDigest, ConsensusStore, ReconfigureNotificat
 pub mod subscriber_tests;
 
 /// Convenience alias indicating the persistent storage holding certificates.
-type CertificateStore<PublicKey> = store::Store<CertificateDigest, Certificate<PublicKey>>;
+type CertificateStore = store::Store<CertificateDigest, Certificate>;
 
 /// Pushes the consensus output to subscriber clients and helps them to remain up to date.
-pub struct SubscriberHandler<PublicKey: VerifyingKey> {
+pub struct SubscriberHandler {
     // The persistent store holding the consensus state.
-    consensus_store: Arc<ConsensusStore<PublicKey>>,
+    consensus_store: Arc<ConsensusStore>,
     // The persistent store holding the certificates.
-    certificate_store: CertificateStore<PublicKey>,
+    certificate_store: CertificateStore,
     /// Receive reconfiguration update.
-    rx_reconfigure: watch::Receiver<ReconfigureNotification<PublicKey>>,
+    rx_reconfigure: watch::Receiver<ReconfigureNotification>,
     // Channel to receive the output of consensus.
-    rx_sequence: Receiver<ConsensusOutput<PublicKey>>,
+    rx_sequence: Receiver<ConsensusOutput>,
     /// Channel to receive sync requests from the client.
     rx_client: Receiver<ConsensusSyncRequest>,
     /// Channel to send new consensus outputs to the client.
-    tx_client: Sender<ConsensusOutput<PublicKey>>,
+    tx_client: Sender<ConsensusOutput>,
 }
 
-impl<PublicKey: VerifyingKey> SubscriberHandler<PublicKey> {
+impl SubscriberHandler {
     /// Spawn a new subscriber handler in a dedicated tokio task.
     pub fn spawn(
-        consensus_store: Arc<ConsensusStore<PublicKey>>,
-        certificate_store: CertificateStore<PublicKey>,
-        rx_reconfigure: watch::Receiver<ReconfigureNotification<PublicKey>>,
-        rx_sequence: Receiver<ConsensusOutput<PublicKey>>,
+        consensus_store: Arc<ConsensusStore>,
+        certificate_store: CertificateStore,
+        rx_reconfigure: watch::Receiver<ReconfigureNotification>,
+        rx_sequence: Receiver<ConsensusOutput>,
         rx_client: Receiver<ConsensusSyncRequest>,
-        tx_client: Sender<ConsensusOutput<PublicKey>>,
+        tx_client: Sender<ConsensusOutput>,
     ) -> JoinHandle<()> {
         tokio::spawn(async move {
             Self {

--- a/consensus/src/tests/bullshark_tests.rs
+++ b/consensus/src/tests/bullshark_tests.rs
@@ -17,7 +17,7 @@ use tokio::sync::mpsc::channel;
 use tokio::sync::watch;
 use types::{CertificateDigest, ReconfigureNotification};
 
-pub fn make_consensus_store(store_path: &std::path::Path) -> Arc<ConsensusStore<Ed25519PublicKey>> {
+pub fn make_consensus_store(store_path: &std::path::Path) -> Arc<ConsensusStore> {
     const LAST_COMMITTED_CF: &str = "last_committed";
     const SEQUENCE_CF: &str = "sequence";
 
@@ -34,14 +34,14 @@ pub fn make_consensus_store(store_path: &std::path::Path) -> Arc<ConsensusStore<
 
 pub fn make_certificate_store(
     store_path: &std::path::Path,
-) -> store::Store<CertificateDigest, Certificate<Ed25519PublicKey>> {
+) -> store::Store<CertificateDigest, Certificate> {
     const CERTIFICATES_CF: &str = "certificates";
 
     let rocksdb =
         rocks::open_cf(store_path, None, &[CERTIFICATES_CF]).expect("Failed creating database");
 
     let certificate_map = reopen!(&rocksdb,
-        CERTIFICATES_CF;<CertificateDigest, Certificate<Ed25519PublicKey>>
+        CERTIFICATES_CF;<CertificateDigest, Certificate>
     );
 
     store::Store::new(certificate_map)

--- a/consensus/src/tests/bullshark_tests.rs
+++ b/consensus/src/tests/bullshark_tests.rs
@@ -4,9 +4,9 @@
 use super::*;
 
 use crate::{metrics::ConsensusMetrics, Consensus};
-use crypto::ed25519::Ed25519PublicKey;
 #[allow(unused_imports)]
 use crypto::traits::KeyPair;
+use crypto::PublicKey;
 use prometheus::Registry;
 #[cfg(test)]
 use std::collections::{BTreeSet, VecDeque};
@@ -25,7 +25,7 @@ pub fn make_consensus_store(store_path: &std::path::Path) -> Arc<ConsensusStore>
         .expect("Failed to create database");
 
     let (last_committed_map, sequence_map) = reopen!(&rocksdb,
-        LAST_COMMITTED_CF;<Ed25519PublicKey, Round>,
+        LAST_COMMITTED_CF;<PublicKey, Round>,
         SEQUENCE_CF;<SequenceNumber, CertificateDigest>
     );
 

--- a/consensus/src/tests/tusk_tests.rs
+++ b/consensus/src/tests/tusk_tests.rs
@@ -17,7 +17,7 @@ use tokio::sync::mpsc::channel;
 use tokio::sync::watch;
 use types::{CertificateDigest, ReconfigureNotification};
 
-pub fn make_consensus_store(store_path: &std::path::Path) -> Arc<ConsensusStore<Ed25519PublicKey>> {
+pub fn make_consensus_store(store_path: &std::path::Path) -> Arc<ConsensusStore> {
     const LAST_COMMITTED_CF: &str = "last_committed";
     const SEQUENCE_CF: &str = "sequence";
 
@@ -34,14 +34,14 @@ pub fn make_consensus_store(store_path: &std::path::Path) -> Arc<ConsensusStore<
 
 pub fn make_certificate_store(
     store_path: &std::path::Path,
-) -> store::Store<CertificateDigest, Certificate<Ed25519PublicKey>> {
+) -> store::Store<CertificateDigest, Certificate> {
     const CERTIFICATES_CF: &str = "certificates";
 
     let rocksdb =
         rocks::open_cf(store_path, None, &[CERTIFICATES_CF]).expect("Failed creating database");
 
     let certificate_map = reopen!(&rocksdb,
-        CERTIFICATES_CF;<CertificateDigest, Certificate<Ed25519PublicKey>>
+        CERTIFICATES_CF;<CertificateDigest, Certificate>
     );
 
     store::Store::new(certificate_map)

--- a/consensus/src/tests/tusk_tests.rs
+++ b/consensus/src/tests/tusk_tests.rs
@@ -4,9 +4,9 @@
 use super::*;
 
 use crate::{metrics::ConsensusMetrics, Consensus};
-use crypto::ed25519::Ed25519PublicKey;
 #[allow(unused_imports)]
 use crypto::traits::KeyPair;
+use crypto::PublicKey;
 use prometheus::Registry;
 #[cfg(test)]
 use std::collections::{BTreeSet, VecDeque};
@@ -25,7 +25,7 @@ pub fn make_consensus_store(store_path: &std::path::Path) -> Arc<ConsensusStore>
         .expect("Failed to create database");
 
     let (last_committed_map, sequence_map) = reopen!(&rocksdb,
-        LAST_COMMITTED_CF;<Ed25519PublicKey, Round>,
+        LAST_COMMITTED_CF;<PublicKey, Round>,
         SEQUENCE_CF;<SequenceNumber, CertificateDigest>
     );
 

--- a/consensus/src/tusk.rs
+++ b/consensus/src/tusk.rs
@@ -6,10 +6,7 @@ use crate::{
     utils, ConsensusOutput, SequenceNumber,
 };
 use config::{Committee, Stake};
-use crypto::{
-    traits::{EncodeDecodeBase64, VerifyingKey},
-    Hash,
-};
+use crypto::{traits::EncodeDecodeBase64, Hash};
 use std::{collections::HashMap, sync::Arc};
 use tracing::debug;
 use types::{Certificate, CertificateDigest, ConsensusStore, Round, StoreResult};
@@ -18,22 +15,22 @@ use types::{Certificate, CertificateDigest, ConsensusStore, Round, StoreResult};
 #[path = "tests/tusk_tests.rs"]
 pub mod tusk_tests;
 
-pub struct Tusk<PublicKey: VerifyingKey> {
+pub struct Tusk {
     /// The committee information.
-    pub committee: Committee<PublicKey>,
+    pub committee: Committee,
     /// Persistent storage to safe ensure crash-recovery.
-    pub store: Arc<ConsensusStore<PublicKey>>,
+    pub store: Arc<ConsensusStore>,
     /// The depth of the garbage collector.
     pub gc_depth: Round,
 }
 
-impl<PublicKey: VerifyingKey> ConsensusProtocol<PublicKey> for Tusk<PublicKey> {
+impl ConsensusProtocol for Tusk {
     fn process_certificate(
         &mut self,
-        state: &mut ConsensusState<PublicKey>,
+        state: &mut ConsensusState,
         consensus_index: SequenceNumber,
-        certificate: Certificate<PublicKey>,
-    ) -> StoreResult<Vec<ConsensusOutput<PublicKey>>> {
+        certificate: Certificate,
+    ) -> StoreResult<Vec<ConsensusOutput>> {
         debug!("Processing {:?}", certificate);
         let round = certificate.round();
         let mut consensus_index = consensus_index;
@@ -127,19 +124,15 @@ impl<PublicKey: VerifyingKey> ConsensusProtocol<PublicKey> for Tusk<PublicKey> {
         Ok(sequence)
     }
 
-    fn update_committee(&mut self, new_committee: Committee<PublicKey>) -> StoreResult<()> {
+    fn update_committee(&mut self, new_committee: Committee) -> StoreResult<()> {
         self.committee = new_committee;
         self.store.clear()
     }
 }
 
-impl<PublicKey: VerifyingKey> Tusk<PublicKey> {
+impl Tusk {
     /// Create a new Tusk consensus instance.
-    pub fn new(
-        committee: Committee<PublicKey>,
-        store: Arc<ConsensusStore<PublicKey>>,
-        gc_depth: Round,
-    ) -> Self {
+    pub fn new(committee: Committee, store: Arc<ConsensusStore>, gc_depth: Round) -> Self {
         Self {
             committee,
             store,
@@ -150,10 +143,10 @@ impl<PublicKey: VerifyingKey> Tusk<PublicKey> {
     /// Returns the certificate (and the certificate's digest) originated by the leader of the
     /// specified round (if any).
     fn leader<'a>(
-        committee: &Committee<PublicKey>,
+        committee: &Committee,
         round: Round,
-        dag: &'a Dag<PublicKey>,
-    ) -> Option<&'a (CertificateDigest, Certificate<PublicKey>)> {
+        dag: &'a Dag,
+    ) -> Option<&'a (CertificateDigest, Certificate)> {
         // TODO: We should elect the leader of round r-2 using the common coin revealed at round r.
         // At this stage, we are guaranteed to have 2f+1 certificates from round r (which is enough to
         // compute the coin). We currently just use round-robin.

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -54,8 +54,6 @@ pub mod secp256k1;
 
 pub mod traits;
 
-pub type CryptoError = ed25519_dalek::ed25519::Error;
-
 pub const DIGEST_LEN: usize = 32;
 
 pub fn blake2b_256<F: Fn(&mut blake2::VarBlake2b)>(closure: F) -> [u8; DIGEST_LEN] {

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -54,15 +54,23 @@ pub mod hkdf;
 pub mod pubkey_bytes;
 pub mod serde_helpers;
 
+////////////////////////////////////////////////////////////////////////
+/// Type aliases selecting the signature algorithm for the code base.
+////////////////////////////////////////////////////////////////////////
 // Here we select the types that are used by default in the code base.
 // The whole code base should only:
 // - refer to those aliases and not use the individual scheme implementations
 // - not use the schemes in a way that break genericity (e.g. using their Struct impl functions)
 // - swap one of those aliases to point to another type if necessary
+//
+// Beware: if you change those aliases to point to another scheme implementation, you will have
+// to change all four aliases to point to concrete types that work with each other. Failure to do
+// so will result in a ton of compilation errors, and worse: it will not make sense!
 pub type PublicKey = ed25519::Ed25519PublicKey;
 pub type Signature = ed25519::Ed25519Signature;
 pub type PrivateKey = ed25519::Ed25519PrivateKey;
 pub type KeyPair = ed25519::Ed25519KeyPair;
+////////////////////////////////////////////////////////////////////////
 
 pub const DIGEST_LEN: usize = 32;
 

--- a/crypto/src/tests/bls12377_tests.rs
+++ b/crypto/src/tests/bls12377_tests.rs
@@ -6,7 +6,7 @@ use crate::{
         BLS12377AggregateSignature, BLS12377KeyPair, BLS12377PrivateKey, BLS12377PublicKey,
         BLS12377PublicKeyBytes, BLS12377Signature,
     },
-    traits::{AggregateAuthenticator, EncodeDecodeBase64, ToFromBytes, VerifyingKey},
+    traits::{AggregateAuthenticator, EncodeDecodeBase64, KeyPair, ToFromBytes, VerifyingKey},
 };
 use rand::{rngs::StdRng, SeedableRng as _};
 use signature::{Signer, Verifier};

--- a/crypto/src/tests/bls12381_tests.rs
+++ b/crypto/src/tests/bls12381_tests.rs
@@ -7,7 +7,7 @@ use crate::{
         BLS12381PublicKeyBytes, BLS12381Signature,
     },
     hkdf::hkdf_generate_from_ikm,
-    traits::{AggregateAuthenticator, EncodeDecodeBase64, ToFromBytes, VerifyingKey},
+    traits::{AggregateAuthenticator, EncodeDecodeBase64, KeyPair, ToFromBytes, VerifyingKey},
 };
 use rand::{rngs::StdRng, SeedableRng as _};
 use sha3::Sha3_256;

--- a/crypto/src/tests/ed25519_tests.rs
+++ b/crypto/src/tests/ed25519_tests.rs
@@ -9,7 +9,7 @@ use crate::{
         Ed25519PublicKeyBytes, Ed25519Signature,
     },
     hkdf::hkdf_generate_from_ikm,
-    traits::{AggregateAuthenticator, EncodeDecodeBase64, ToFromBytes, VerifyingKey},
+    traits::{AggregateAuthenticator, EncodeDecodeBase64, KeyPair, ToFromBytes, VerifyingKey},
 };
 
 use blake2::digest::Update;

--- a/crypto/src/tests/secp256k1_tests.rs
+++ b/crypto/src/tests/secp256k1_tests.rs
@@ -7,7 +7,7 @@ use crate::{
         Secp256k1KeyPair, Secp256k1PrivateKey, Secp256k1PublicKey, Secp256k1PublicKeyBytes,
         Secp256k1Signature,
     },
-    traits::{EncodeDecodeBase64, ToFromBytes},
+    traits::{EncodeDecodeBase64, KeyPair, ToFromBytes},
 };
 
 use rand::{rngs::StdRng, SeedableRng as _};

--- a/executor/src/tests/execution_state.rs
+++ b/executor/src/tests/execution_state.rs
@@ -4,7 +4,7 @@ use crate::{ExecutionIndices, ExecutionState, ExecutionStateError};
 use async_trait::async_trait;
 use config::Committee;
 use consensus::ConsensusOutput;
-use crypto::ed25519::Ed25519PublicKey;
+
 use futures::executor::block_on;
 use std::path::Path;
 use store::{
@@ -39,17 +39,16 @@ impl Default for TestState {
 
 #[async_trait]
 impl ExecutionState for TestState {
-    type PubKey = Ed25519PublicKey;
     type Transaction = u64;
     type Error = TestStateError;
     type Outcome = Vec<u8>;
 
     async fn handle_consensus_transaction(
         &self,
-        _consensus_output: &ConsensusOutput<Ed25519PublicKey>,
+        _consensus_output: &ConsensusOutput,
         execution_indices: ExecutionIndices,
         transaction: Self::Transaction,
-    ) -> Result<(Self::Outcome, Option<Committee<Ed25519PublicKey>>), Self::Error> {
+    ) -> Result<(Self::Outcome, Option<Committee>), Self::Error> {
         if transaction == MALFORMED_TRANSACTION {
             Err(Self::Error::ClientError)
         } else if transaction == KILLER_TRANSACTION {

--- a/executor/src/tests/executor_tests.rs
+++ b/executor/src/tests/executor_tests.rs
@@ -5,7 +5,7 @@ use crate::{
     execution_state::{TestState, KILLER_TRANSACTION, MALFORMED_TRANSACTION},
     fixtures::{test_batch, test_certificate, test_store, test_u64_certificates},
 };
-use crypto::ed25519::Ed25519PublicKey;
+
 use std::sync::Arc;
 use test_utils::committee;
 use tokio::sync::mpsc::channel;
@@ -23,7 +23,7 @@ async fn execute_transactions() {
     // Spawn the executor.
     let store = test_store();
     let execution_state = Arc::new(TestState::default());
-    Core::<TestState, Ed25519PublicKey>::spawn(
+    Core::<TestState>::spawn(
         store.clone(),
         execution_state.clone(),
         rx_reconfigure,
@@ -70,7 +70,7 @@ async fn execute_empty_certificate() {
     // Spawn the executor.
     let store = test_store();
     let execution_state = Arc::new(TestState::default());
-    Core::<TestState, Ed25519PublicKey>::spawn(
+    Core::<TestState>::spawn(
         store.clone(),
         execution_state.clone(),
         rx_reconfigure,
@@ -126,7 +126,7 @@ async fn execute_malformed_transactions() {
     // Spawn the executor.
     let store = test_store();
     let execution_state = Arc::new(TestState::default());
-    Core::<TestState, Ed25519PublicKey>::spawn(
+    Core::<TestState>::spawn(
         store.clone(),
         execution_state.clone(),
         rx_reconfigure,
@@ -188,7 +188,7 @@ async fn internal_error_execution() {
     // Spawn the executor.
     let store = test_store();
     let execution_state = Arc::new(TestState::default());
-    Core::<TestState, Ed25519PublicKey>::spawn(
+    Core::<TestState>::spawn(
         store.clone(),
         execution_state.clone(),
         rx_reconfigure,
@@ -240,7 +240,7 @@ async fn crash_recovery() {
     // Spawn the executor.
     let store = test_store();
     let execution_state = Arc::new(TestState::default());
-    Core::<TestState, Ed25519PublicKey>::spawn(
+    Core::<TestState>::spawn(
         store.clone(),
         execution_state.clone(),
         rx_reconfigure,
@@ -295,7 +295,7 @@ async fn crash_recovery() {
     let (tx_output, mut rx_output) = channel(10);
     let (_tx_reconfigure, rx_reconfigure) = watch::channel(reconfigure_notification);
 
-    Core::<TestState, Ed25519PublicKey>::spawn(
+    Core::<TestState>::spawn(
         store.clone(),
         execution_state.clone(),
         rx_reconfigure,

--- a/executor/src/tests/fixtures.rs
+++ b/executor/src/tests/fixtures.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use config::WorkerId;
-use crypto::ed25519::Ed25519PublicKey;
 use rand::{rngs::StdRng, RngCore, SeedableRng};
 use serde::Serialize;
 use std::collections::BTreeMap;
@@ -22,14 +21,14 @@ pub fn test_batch<T: Serialize>(transactions: Vec<T>) -> (BatchDigest, Serialize
         .iter()
         .map(|x| bincode::serialize(x).unwrap())
         .collect();
-    let message = WorkerMessage::<Ed25519PublicKey>::Batch(Batch(batch));
+    let message = WorkerMessage::Batch(Batch(batch));
     let serialized = bincode::serialize(&message).unwrap();
     let digest = serialized_batch_digest(&serialized).unwrap();
     (digest, serialized)
 }
 
 /// A test certificate with a specific payload.
-pub fn test_certificate(payload: BTreeMap<BatchDigest, WorkerId>) -> Certificate<Ed25519PublicKey> {
+pub fn test_certificate(payload: BTreeMap<BatchDigest, WorkerId>) -> Certificate {
     Certificate {
         header: Header {
             payload,
@@ -53,10 +52,7 @@ pub fn test_u64_certificates(
     certificates: usize,
     batches_per_certificate: usize,
     transactions_per_batch: usize,
-) -> Vec<(
-    Certificate<Ed25519PublicKey>,
-    Vec<(BatchDigest, SerializedBatchMessage)>,
-)> {
+) -> Vec<(Certificate, Vec<(BatchDigest, SerializedBatchMessage)>)> {
     let mut rng = StdRng::from_seed([0; 32]);
     (0..certificates)
         .map(|_| {

--- a/executor/src/tests/sequencer.rs
+++ b/executor/src/tests/sequencer.rs
@@ -1,24 +1,24 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use consensus::{ConsensusOutput, ConsensusSyncRequest};
-use crypto::traits::VerifyingKey;
+
 use tokio::sync::mpsc::{Receiver, Sender};
 use tracing::warn;
 use types::{Certificate, SequenceNumber};
 
-pub struct MockSequencer<PublicKey: VerifyingKey> {
-    rx_sequence: Receiver<Certificate<PublicKey>>,
+pub struct MockSequencer {
+    rx_sequence: Receiver<Certificate>,
     rx_client: Receiver<ConsensusSyncRequest>,
-    tx_client: Sender<ConsensusOutput<PublicKey>>,
+    tx_client: Sender<ConsensusOutput>,
     consensus_index: SequenceNumber,
-    sequence: Vec<ConsensusOutput<PublicKey>>,
+    sequence: Vec<ConsensusOutput>,
 }
 
-impl<PublicKey: VerifyingKey> MockSequencer<PublicKey> {
+impl MockSequencer {
     pub fn spawn(
-        rx_sequence: Receiver<Certificate<PublicKey>>,
+        rx_sequence: Receiver<Certificate>,
         rx_client: Receiver<ConsensusSyncRequest>,
-        tx_client: Sender<ConsensusOutput<PublicKey>>,
+        tx_client: Sender<ConsensusOutput>,
     ) {
         tokio::spawn(async move {
             Self {

--- a/executor/src/tests/subscriber_tests.rs
+++ b/executor/src/tests/subscriber_tests.rs
@@ -5,19 +5,18 @@ use crate::{
     fixtures::{test_store, test_u64_certificates},
     sequencer::MockSequencer,
 };
-use crypto::ed25519::Ed25519PublicKey;
 use test_utils::committee;
 use tokio::sync::mpsc::{channel, Sender};
 use types::Certificate;
 
 /// Spawn a mock consensus core and a test subscriber.
 async fn spawn_consensus_and_subscriber(
-    rx_sequence: Receiver<Certificate<Ed25519PublicKey>>,
-    tx_batch_loader: Sender<ConsensusOutput<Ed25519PublicKey>>,
-    tx_executor: Sender<ConsensusOutput<Ed25519PublicKey>>,
+    rx_sequence: Receiver<Certificate>,
+    tx_batch_loader: Sender<ConsensusOutput>,
+    tx_executor: Sender<ConsensusOutput>,
 ) -> (
     Store<BatchDigest, SerializedBatchMessage>,
-    watch::Sender<ReconfigureNotification<Ed25519PublicKey>>,
+    watch::Sender<ReconfigureNotification>,
 ) {
     let (tx_consensus_to_client, rx_consensus_to_client) = channel(10);
     let (tx_client_to_consensus, rx_client_to_consensus) = channel(10);
@@ -32,7 +31,7 @@ async fn spawn_consensus_and_subscriber(
     // Spawn a test subscriber.
     let store = test_store();
     let next_consensus_index = SequenceNumber::default();
-    Subscriber::<Ed25519PublicKey>::spawn(
+    Subscriber::spawn(
         store.clone(),
         rx_reconfigure,
         rx_consensus_to_client,
@@ -127,7 +126,7 @@ async fn synchronize() {
     // Spawn a subscriber.
     let store = test_store();
     let next_consensus_index = SequenceNumber::default();
-    Subscriber::<Ed25519PublicKey>::spawn(
+    Subscriber::spawn(
         store.clone(),
         rx_reconfigure,
         rx_consensus_to_client,

--- a/network/src/primary.rs
+++ b/network/src/primary.rs
@@ -4,7 +4,6 @@
 use crate::{
     BoundedExecutor, CancelOnDropHandler, MessageResult, RetryConfig, MAX_TASK_CONCURRENCY,
 };
-use crypto::traits::VerifyingKey;
 use multiaddr::Multiaddr;
 use rand::{prelude::SliceRandom as _, rngs::SmallRng, SeedableRng as _};
 use std::collections::HashMap;
@@ -64,10 +63,10 @@ impl PrimaryNetwork {
         PrimaryToPrimaryClient::new(channel)
     }
 
-    pub async fn send<T: VerifyingKey>(
+    pub async fn send(
         &mut self,
         address: Multiaddr,
-        message: &PrimaryMessage<T>,
+        message: &PrimaryMessage,
     ) -> CancelOnDropHandler<MessageResult> {
         let message =
             BincodeEncodedPayload::try_from(message).expect("Failed to serialize payload");
@@ -109,10 +108,10 @@ impl PrimaryNetwork {
         CancelOnDropHandler(handle)
     }
 
-    pub async fn broadcast<T: VerifyingKey>(
+    pub async fn broadcast(
         &mut self,
         addresses: Vec<Multiaddr>,
-        message: &PrimaryMessage<T>,
+        message: &PrimaryMessage,
     ) -> Vec<CancelOnDropHandler<MessageResult>> {
         let message =
             BincodeEncodedPayload::try_from(message).expect("Failed to serialize payload");
@@ -124,10 +123,10 @@ impl PrimaryNetwork {
         handlers
     }
 
-    pub async fn unreliable_send<T: VerifyingKey>(
+    pub async fn unreliable_send(
         &mut self,
         address: Multiaddr,
-        message: &PrimaryMessage<T>,
+        message: &PrimaryMessage,
     ) -> JoinHandle<()> {
         let message =
             BincodeEncodedPayload::try_from(message).expect("Failed to serialize payload");
@@ -143,10 +142,10 @@ impl PrimaryNetwork {
 
     /// Broadcasts a message to all `addresses` passed as an argument.
     /// The attempts to send individual messages are best effort and will not be retried.
-    pub async fn unreliable_broadcast<T: VerifyingKey>(
+    pub async fn unreliable_broadcast(
         &mut self,
         addresses: Vec<Multiaddr>,
-        message: &PrimaryMessage<T>,
+        message: &PrimaryMessage,
     ) -> Vec<JoinHandle<()>> {
         let message =
             BincodeEncodedPayload::try_from(message).expect("Failed to serialize payload");
@@ -170,10 +169,10 @@ impl PrimaryNetwork {
 
     /// Pick a few addresses at random (specified by `nodes`) and try (best-effort) to send the
     /// message only to them. This is useful to pick nodes with whom to sync.
-    pub async fn lucky_broadcast<T: VerifyingKey>(
+    pub async fn lucky_broadcast(
         &mut self,
         mut addresses: Vec<Multiaddr>,
-        message: &PrimaryMessage<T>,
+        message: &PrimaryMessage,
         nodes: usize,
     ) -> Vec<JoinHandle<()>> {
         addresses.shuffle(&mut self.rng);
@@ -234,10 +233,10 @@ impl PrimaryToWorkerNetwork {
 
     /// Sends a message to an `address` passed as an argument.
     /// The attempt to send a message is best effort and will not be retried.
-    pub async fn unreliable_send<T: VerifyingKey>(
+    pub async fn unreliable_send(
         &mut self,
         address: Multiaddr,
-        message: &PrimaryWorkerMessage<T>,
+        message: &PrimaryWorkerMessage,
     ) -> JoinHandle<()> {
         let message =
             BincodeEncodedPayload::try_from(message).expect("Failed to serialize payload");
@@ -251,10 +250,10 @@ impl PrimaryToWorkerNetwork {
 
     /// Broadcasts a message to all `addresses` passed as an argument.
     /// The attempts to send individual messages are best effort and will not be retried.
-    pub async fn unreliable_broadcast<T: VerifyingKey>(
+    pub async fn unreliable_broadcast(
         &mut self,
         addresses: Vec<Multiaddr>,
-        message: &PrimaryWorkerMessage<T>,
+        message: &PrimaryWorkerMessage,
     ) -> Vec<JoinHandle<()>> {
         let message =
             BincodeEncodedPayload::try_from(message).expect("Failed to serialize payload");

--- a/network/src/worker.rs
+++ b/network/src/worker.rs
@@ -3,7 +3,6 @@
 use crate::{
     BoundedExecutor, CancelOnDropHandler, MessageResult, RetryConfig, MAX_TASK_CONCURRENCY,
 };
-use crypto::traits::VerifyingKey;
 use multiaddr::Multiaddr;
 use rand::{prelude::SliceRandom as _, rngs::SmallRng, SeedableRng as _};
 use std::collections::HashMap;
@@ -62,10 +61,10 @@ impl WorkerNetwork {
         WorkerToWorkerClient::new(channel)
     }
 
-    pub async fn send<T: VerifyingKey>(
+    pub async fn send(
         &mut self,
         address: Multiaddr,
-        message: &WorkerMessage<T>,
+        message: &WorkerMessage,
     ) -> CancelOnDropHandler<MessageResult> {
         let message =
             BincodeEncodedPayload::try_from(message).expect("Failed to serialize payload");
@@ -107,10 +106,10 @@ impl WorkerNetwork {
         CancelOnDropHandler(handle)
     }
 
-    pub async fn broadcast<T: VerifyingKey>(
+    pub async fn broadcast(
         &mut self,
         addresses: Vec<Multiaddr>,
-        message: &WorkerMessage<T>,
+        message: &WorkerMessage,
     ) -> Vec<CancelOnDropHandler<MessageResult>> {
         let message =
             BincodeEncodedPayload::try_from(message).expect("Failed to serialize payload");
@@ -122,10 +121,10 @@ impl WorkerNetwork {
         handlers
     }
 
-    pub async fn unreliable_send<T: VerifyingKey>(
+    pub async fn unreliable_send(
         &mut self,
         address: Multiaddr,
-        message: &WorkerMessage<T>,
+        message: &WorkerMessage,
     ) -> JoinHandle<()> {
         let message =
             BincodeEncodedPayload::try_from(message).expect("Failed to serialize payload");
@@ -150,10 +149,10 @@ impl WorkerNetwork {
 
     /// Pick a few addresses at random (specified by `nodes`) and try (best-effort) to send the
     /// message only to them. This is useful to pick nodes with whom to sync.
-    pub async fn lucky_broadcast<T: VerifyingKey>(
+    pub async fn lucky_broadcast(
         &mut self,
         mut addresses: Vec<Multiaddr>,
-        message: &WorkerMessage<T>,
+        message: &WorkerMessage,
         nodes: usize,
     ) -> Vec<JoinHandle<()>> {
         addresses.shuffle(&mut self.rng);
@@ -205,10 +204,10 @@ impl WorkerToPrimaryNetwork {
     // Since this spawns an unbounded task, this should be called in a time-restricted fashion.
     // Here the callers are [`WorkerToPrimaryNetwork::send`].
     // See the TODO on spawn_with_retries for lifting this restriction.
-    pub async fn send<PublicKey: VerifyingKey>(
+    pub async fn send(
         &mut self,
         address: Multiaddr,
-        message: &WorkerPrimaryMessage<PublicKey>,
+        message: &WorkerPrimaryMessage,
     ) -> CancelOnDropHandler<MessageResult> {
         let new_client = match &self.address {
             None => true,

--- a/node/src/execution_state.rs
+++ b/node/src/execution_state.rs
@@ -3,27 +3,24 @@
 use async_trait::async_trait;
 use config::Committee;
 use consensus::ConsensusOutput;
-use crypto::traits::VerifyingKey;
 use executor::{ExecutionIndices, ExecutionState, ExecutionStateError};
-use std::marker::PhantomData;
 use thiserror::Error;
 
 /// A simple/dumb execution engine.
-pub struct SimpleExecutionState<PublicKey: VerifyingKey>(PhantomData<PublicKey>);
+pub struct SimpleExecutionState;
 
 #[async_trait]
-impl<PublicKey: VerifyingKey> ExecutionState for SimpleExecutionState<PublicKey> {
-    type PubKey = PublicKey;
+impl ExecutionState for SimpleExecutionState {
     type Transaction = String;
     type Error = SimpleExecutionError;
     type Outcome = Vec<u8>;
 
     async fn handle_consensus_transaction(
         &self,
-        _consensus_output: &ConsensusOutput<PublicKey>,
+        _consensus_output: &ConsensusOutput,
         _execution_indices: ExecutionIndices,
         _transaction: Self::Transaction,
-    ) -> Result<(Self::Outcome, Option<Committee<PublicKey>>), Self::Error> {
+    ) -> Result<(Self::Outcome, Option<Committee>), Self::Error> {
         Ok((Vec::default(), None))
     }
 
@@ -38,9 +35,9 @@ impl<PublicKey: VerifyingKey> ExecutionState for SimpleExecutionState<PublicKey>
     }
 }
 
-impl<PublicKey: VerifyingKey> Default for SimpleExecutionState<PublicKey> {
+impl Default for SimpleExecutionState {
     fn default() -> Self {
-        Self(PhantomData)
+        Self
     }
 }
 

--- a/node/src/generate_format.rs
+++ b/node/src/generate_format.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use config::{Authority, Committee, Epoch, PrimaryAddresses, WorkerAddresses};
 use crypto::{
-    ed25519::{Ed25519KeyPair, Ed25519PublicKey},
+    ed25519::Ed25519KeyPair,
     traits::{KeyPair, Signer},
     Digest, Hash,
 };
@@ -79,7 +79,7 @@ fn get_registry() -> Result<Registry> {
             .collect(),
     };
 
-    let certificates: Vec<Certificate<Ed25519PublicKey>> = Certificate::genesis(&committee);
+    let certificates: Vec<Certificate> = Certificate::genesis(&committee);
 
     // The values have to be "complete" in a data-centric sense, but not "correct" cryptographically.
     let mut header = Header {
@@ -104,11 +104,9 @@ fn get_registry() -> Result<Registry> {
     tracer.trace_value(&mut samples, &header)?;
     tracer.trace_value(&mut samples, &certificate)?;
 
-    let cleanup = PrimaryWorkerMessage::<Ed25519PublicKey>::Cleanup(1u64);
-    let request_batch =
-        PrimaryWorkerMessage::<Ed25519PublicKey>::RequestBatch(BatchDigest([0u8; 32]));
-    let delete_batch =
-        PrimaryWorkerMessage::<Ed25519PublicKey>::DeleteBatches(vec![BatchDigest([0u8; 32])]);
+    let cleanup = PrimaryWorkerMessage::Cleanup(1u64);
+    let request_batch = PrimaryWorkerMessage::RequestBatch(BatchDigest([0u8; 32]));
+    let delete_batch = PrimaryWorkerMessage::DeleteBatches(vec![BatchDigest([0u8; 32])]);
     let sync = PrimaryWorkerMessage::Synchronize(vec![BatchDigest([0u8; 32])], pk.clone());
     let reconfigure =
         PrimaryWorkerMessage::Reconfigure(ReconfigureNotification::NewCommittee(committee));
@@ -137,7 +135,7 @@ fn get_registry() -> Result<Registry> {
     // tracer.trace_type::<PrimaryWorkerMessage<Ed25519PublicKey>>(&samples)?;
 
     // The final entry points that we must document
-    tracer.trace_type::<WorkerPrimaryMessage<Ed25519PublicKey>>(&samples)?;
+    tracer.trace_type::<WorkerPrimaryMessage>(&samples)?;
     tracer.trace_type::<WorkerPrimaryError>(&samples)?;
     tracer.registry()
 }

--- a/node/src/generate_format.rs
+++ b/node/src/generate_format.rs
@@ -2,9 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 use config::{Authority, Committee, Epoch, PrimaryAddresses, WorkerAddresses};
 use crypto::{
-    ed25519::Ed25519KeyPair,
-    traits::{KeyPair, Signer},
-    Digest, Hash,
+    traits::{KeyPair as _, Signer},
+    Digest, Hash, KeyPair,
 };
 use primary::PrimaryWorkerMessage;
 use rand::{prelude::StdRng, SeedableRng};
@@ -25,7 +24,7 @@ fn get_registry() -> Result<Registry> {
     // with all the base types contained in messages, especially the ones with custom serializers;
     // or involving generics (see [serde_reflection documentation](https://docs.rs/serde-reflection/latest/serde_reflection/)).
     let mut rng = StdRng::from_seed([0; 32]);
-    let kp = Ed25519KeyPair::generate(&mut rng);
+    let kp = KeyPair::generate(&mut rng);
     let pk = kp.public().clone();
 
     tracer.trace_value(&mut samples, &pk)?;
@@ -35,7 +34,7 @@ fn get_registry() -> Result<Registry> {
     tracer.trace_value(&mut samples, &signature)?;
 
     // Trace the correspondng header
-    let keys: Vec<_> = (0..4).map(|_| Ed25519KeyPair::generate(&mut rng)).collect();
+    let keys: Vec<_> = (0..4).map(|_| KeyPair::generate(&mut rng)).collect();
     let committee = Committee {
         epoch: Epoch::default(),
         authorities: keys

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -12,7 +12,7 @@ use anyhow::{Context, Result};
 use arc_swap::ArcSwap;
 use clap::{crate_name, crate_version, App, AppSettings, ArgMatches, SubCommand};
 use config::{Committee, Import, Parameters, WorkerId};
-use crypto::{ed25519::Ed25519KeyPair, generate_production_keypair, traits::KeyPair};
+use crypto::{generate_production_keypair, traits::KeyPair as _, KeyPair};
 use executor::{SerializedTransaction, SubscriberResult};
 use futures::future::join_all;
 use node::{
@@ -115,7 +115,7 @@ async fn main() -> Result<()> {
 
     match matches.subcommand() {
         ("generate_keys", Some(sub_matches)) => {
-            let kp = generate_production_keypair::<Ed25519KeyPair>();
+            let kp = generate_production_keypair::<KeyPair>();
             config::Export::export(&kp, sub_matches.value_of("filename").unwrap())
                 .context("Failed to generate key pair")?
         }
@@ -133,7 +133,7 @@ async fn run(matches: &ArgMatches<'_>) -> Result<()> {
     let store_path = matches.value_of("store").unwrap();
 
     // Read the committee and node's keypair from file.
-    let keypair = Ed25519KeyPair::import(key_file).context("Failed to load the node's keypair")?;
+    let keypair = KeyPair::import(key_file).context("Failed to load the node's keypair")?;
     let committee = Arc::new(ArcSwap::from_pointee(
         Committee::import(committee_file).context("Failed to load the committee information")?,
     ));

--- a/node/src/metrics.rs
+++ b/node/src/metrics.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use axum::{http::StatusCode, routing::get, Extension, Router};
 use config::WorkerId;
-use crypto::ed25519::Ed25519PublicKey;
+use crypto::PublicKey;
 use prometheus::{Registry, TextEncoder};
 use std::{collections::HashMap, net::SocketAddr};
 use tokio::task::JoinHandle;
@@ -11,14 +11,14 @@ const METRICS_ROUTE: &str = "/metrics";
 const PRIMARY_METRICS_PREFIX: &str = "narwhal_primary";
 const WORKER_METRICS_PREFIX: &str = "narwhal_worker";
 
-pub fn primary_metrics_registry(name: Ed25519PublicKey) -> Registry {
+pub fn primary_metrics_registry(name: PublicKey) -> Registry {
     let mut labels = HashMap::new();
     labels.insert("node_name".to_string(), name.to_string());
 
     Registry::new_custom(Some(PRIMARY_METRICS_PREFIX.to_string()), Some(labels)).unwrap()
 }
 
-pub fn worker_metrics_registry(worker_id: WorkerId, name: Ed25519PublicKey) -> Registry {
+pub fn worker_metrics_registry(worker_id: WorkerId, name: PublicKey) -> Registry {
     let mut labels = HashMap::new();
     labels.insert("node_name".to_string(), name.to_string());
     labels.insert("worker_id".to_string(), worker_id.to_string());

--- a/node/tests/README.md
+++ b/node/tests/README.md
@@ -19,11 +19,11 @@ narwhal/node(main)» ruplacer --subvert 'DeleteBatches' 'RemoveBatches' --go    
 ./node/tests/staged/narwhal.yaml:70 - DeleteBatches:
 ./node/tests/staged/narwhal.yaml:70 + RemoveBatches:
 
-./node/src/generate_format.rs:102 - PrimaryWorkerMessage::<Ed25519PublicKey>::DeleteBatches(vec![BatchDigest([0u8; 32])]);
-./node/src/generate_format.rs:102 + PrimaryWorkerMessage::<Ed25519PublicKey>::RemoveBatches(vec![BatchDigest([0u8; 32])]);
+./node/src/generate_format.rs:102 - PrimaryWorkerMessage::DeleteBatches(vec![BatchDigest([0u8; 32])]);
+./node/src/generate_format.rs:102 + PrimaryWorkerMessage::RemoveBatches(vec![BatchDigest([0u8; 32])]);
 
-./worker/src/tests/synchronizer_tests.rs:201 - let message = PrimaryWorkerMessage::<Ed25519PublicKey>::DeleteBatches(batch_digests.clone());
-./worker/src/tests/synchronizer_tests.rs:201 + let message = PrimaryWorkerMessage::<Ed25519PublicKey>::RemoveBatches(batch_digests.clone());
+./worker/src/tests/synchronizer_tests.rs:201 - let message = PrimaryWorkerMessage::DeleteBatches(batch_digests.clone());
+./worker/src/tests/synchronizer_tests.rs:201 + let message = PrimaryWorkerMessage::RemoveBatches(batch_digests.clone());
 
 ./worker/src/synchronizer.rs:191 - PrimaryWorkerMessage::DeleteBatches(digests) => {
 ./worker/src/synchronizer.rs:191 + PrimaryWorkerMessage::RemoveBatches(digests) => {

--- a/node/tests/reconfigure.rs
+++ b/node/tests/reconfigure.rs
@@ -4,7 +4,7 @@ use arc_swap::ArcSwap;
 use bytes::Bytes;
 use config::{Committee, Parameters};
 use consensus::ConsensusOutput;
-use crypto::{ed25519::Ed25519KeyPair, traits::KeyPair, PublicKey};
+use crypto::{traits::KeyPair as _, KeyPair, PublicKey};
 use executor::{ExecutionIndices, ExecutionState, ExecutionStateError};
 use futures::future::join_all;
 use network::{PrimaryToWorkerNetwork, WorkerToPrimaryNetwork};
@@ -26,14 +26,14 @@ use types::{ReconfigureNotification, TransactionProto, TransactionsClient, Worke
 struct SimpleExecutionState {
     index: usize,
     committee: Arc<Mutex<Committee>>,
-    tx_reconfigure: Sender<(Ed25519KeyPair, Committee)>,
+    tx_reconfigure: Sender<(KeyPair, Committee)>,
 }
 
 impl SimpleExecutionState {
     pub fn new(
         index: usize,
         committee: Committee,
-        tx_reconfigure: Sender<(Ed25519KeyPair, Committee)>,
+        tx_reconfigure: Sender<(KeyPair, Committee)>,
     ) -> Self {
         Self {
             index,

--- a/node/tests/staged/narwhal.yaml
+++ b/node/tests/staged/narwhal.yaml
@@ -25,8 +25,8 @@ Certificate:
     - votes:
         SEQ:
           TUPLE:
-            - TYPENAME: PublicKey
-            - TYPENAME: Signature
+            - TYPENAME: Ed25519PublicKey
+            - TYPENAME: Ed25519Signature
 CertificateDigest:
   NEWTYPESTRUCT:
     TUPLEARRAY:
@@ -37,18 +37,18 @@ Committee:
     - authorities:
         MAP:
           KEY:
-            TYPENAME: PublicKey
+            TYPENAME: Ed25519PublicKey
           VALUE:
             TYPENAME: Authority
     - epoch: U64
-PublicKey:
+Ed25519PublicKey:
   NEWTYPESTRUCT: STR
-Signature:
+Ed25519Signature:
   NEWTYPESTRUCT: BYTES
 Header:
   STRUCT:
     - author:
-        TYPENAME: PublicKey
+        TYPENAME: Ed25519PublicKey
     - round: U64
     - epoch: U64
     - payload:
@@ -62,7 +62,7 @@ Header:
     - id:
         TYPENAME: HeaderDigest
     - signature:
-        TYPENAME: Signature
+        TYPENAME: Ed25519Signature
 HeaderDigest:
   NEWTYPESTRUCT:
     TUPLEARRAY:
@@ -79,7 +79,7 @@ PrimaryWorkerMessage:
         TUPLE:
           - SEQ:
               TYPENAME: BatchDigest
-          - TYPENAME: PublicKey
+          - TYPENAME: Ed25519PublicKey
     1:
       Cleanup:
         NEWTYPE: U64

--- a/node/tests/staged/narwhal.yaml
+++ b/node/tests/staged/narwhal.yaml
@@ -25,8 +25,8 @@ Certificate:
     - votes:
         SEQ:
           TUPLE:
-            - TYPENAME: Ed25519PublicKey
-            - TYPENAME: Ed25519Signature
+            - TYPENAME: PublicKey
+            - TYPENAME: Signature
 CertificateDigest:
   NEWTYPESTRUCT:
     TUPLEARRAY:
@@ -37,18 +37,18 @@ Committee:
     - authorities:
         MAP:
           KEY:
-            TYPENAME: Ed25519PublicKey
+            TYPENAME: PublicKey
           VALUE:
             TYPENAME: Authority
     - epoch: U64
-Ed25519PublicKey:
+PublicKey:
   NEWTYPESTRUCT: STR
-Ed25519Signature:
+Signature:
   NEWTYPESTRUCT: BYTES
 Header:
   STRUCT:
     - author:
-        TYPENAME: Ed25519PublicKey
+        TYPENAME: PublicKey
     - round: U64
     - epoch: U64
     - payload:
@@ -62,7 +62,7 @@ Header:
     - id:
         TYPENAME: HeaderDigest
     - signature:
-        TYPENAME: Ed25519Signature
+        TYPENAME: Signature
 HeaderDigest:
   NEWTYPESTRUCT:
     TUPLEARRAY:
@@ -79,7 +79,7 @@ PrimaryWorkerMessage:
         TUPLE:
           - SEQ:
               TYPENAME: BatchDigest
-          - TYPENAME: Ed25519PublicKey
+          - TYPENAME: PublicKey
     1:
       Cleanup:
         NEWTYPE: U64

--- a/primary/src/aggregators.rs
+++ b/primary/src/aggregators.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use config::{Committee, Stake};
-use crypto::traits::{EncodeDecodeBase64, VerifyingKey};
+use crypto::{traits::EncodeDecodeBase64, PublicKey, Signature};
 use std::collections::HashSet;
 use types::{
     ensure,
@@ -12,13 +12,13 @@ use types::{
 };
 
 /// Aggregates votes for a particular header into a certificate.
-pub struct VotesAggregator<PublicKey: VerifyingKey> {
+pub struct VotesAggregator {
     weight: Stake,
-    votes: Vec<(PublicKey, PublicKey::Sig)>,
+    votes: Vec<(PublicKey, Signature)>,
     used: HashSet<PublicKey>,
 }
 
-impl<PublicKey: VerifyingKey> VotesAggregator<PublicKey> {
+impl VotesAggregator {
     pub fn new() -> Self {
         Self {
             weight: 0,
@@ -29,10 +29,10 @@ impl<PublicKey: VerifyingKey> VotesAggregator<PublicKey> {
 
     pub fn append(
         &mut self,
-        vote: Vote<PublicKey>,
-        committee: &Committee<PublicKey>,
-        header: &Header<PublicKey>,
-    ) -> DagResult<Option<Certificate<PublicKey>>> {
+        vote: Vote,
+        committee: &Committee,
+        header: &Header,
+    ) -> DagResult<Option<Certificate>> {
         let author = vote.author;
 
         // Ensure it is the first time this authority votes.
@@ -55,13 +55,13 @@ impl<PublicKey: VerifyingKey> VotesAggregator<PublicKey> {
 }
 
 /// Aggregate certificates and check if we reach a quorum.
-pub struct CertificatesAggregator<PublicKey: VerifyingKey> {
+pub struct CertificatesAggregator {
     weight: Stake,
-    certificates: Vec<Certificate<PublicKey>>,
+    certificates: Vec<Certificate>,
     used: HashSet<PublicKey>,
 }
 
-impl<PublicKey: VerifyingKey> CertificatesAggregator<PublicKey> {
+impl CertificatesAggregator {
     pub fn new() -> Self {
         Self {
             weight: 0,
@@ -72,9 +72,9 @@ impl<PublicKey: VerifyingKey> CertificatesAggregator<PublicKey> {
 
     pub fn append(
         &mut self,
-        certificate: Certificate<PublicKey>,
-        committee: &Committee<PublicKey>,
-    ) -> Option<Vec<Certificate<PublicKey>>> {
+        certificate: Certificate,
+        committee: &Committee,
+    ) -> Option<Vec<Certificate>> {
         let origin = certificate.origin();
 
         // Ensure it is the first time this authority votes.

--- a/primary/src/block_synchronizer/mod.rs
+++ b/primary/src/block_synchronizer/mod.rs
@@ -107,7 +107,7 @@ enum State {
     PayloadAvailabilityReceived {
         request_id: RequestID,
         certificates: HashMap<CertificateDigest, BlockSynchronizeResult<BlockHeader>>,
-        peers: Peers<PublicKey, Certificate>,
+        peers: Peers<Certificate>,
     },
     PayloadSynchronized {
         request_id: RequestID,
@@ -625,7 +625,7 @@ impl BlockSynchronizer {
     async fn handle_synchronize_block_payloads<'a>(
         &mut self,
         request_id: RequestID,
-        mut peers: Peers<PublicKey, Certificate>,
+        mut peers: Peers<Certificate>,
     ) -> Vec<BoxFuture<'a, State>> {
         // Important step to do that first, so we give the opportunity
         // to other future requests (with same set of ids) making a request.
@@ -783,7 +783,7 @@ impl BlockSynchronizer {
         let timer = sleep(fetch_certificates_timeout);
         tokio::pin!(timer);
 
-        let mut peers = Peers::<PublicKey, Certificate>::new(SmallRng::from_entropy());
+        let mut peers = Peers::<Certificate>::new(SmallRng::from_entropy());
 
         loop {
             tokio::select! {
@@ -871,7 +871,7 @@ impl BlockSynchronizer {
         let timer = sleep(fetch_certificates_timeout);
         tokio::pin!(timer);
 
-        let mut peers = Peers::<PublicKey, Certificate>::new(SmallRng::from_entropy());
+        let mut peers = Peers::<Certificate>::new(SmallRng::from_entropy());
 
         loop {
             tokio::select! {
@@ -949,7 +949,7 @@ impl BlockSynchronizer {
     // communicate the result for each requested certificate (if found, then
     // certificate it self , or if error then the type of the error).
     fn resolve_block_synchronize_result(
-        peers: &Peers<PublicKey, Certificate>,
+        peers: &Peers<Certificate>,
         block_ids: Vec<CertificateDigest>,
         timeout: bool,
     ) -> HashMap<CertificateDigest, BlockSynchronizeResult<BlockHeader>> {

--- a/primary/src/block_synchronizer/tests/handler_tests.rs
+++ b/primary/src/block_synchronizer/tests/handler_tests.rs
@@ -8,7 +8,7 @@ use crate::{
     common::create_db_stores,
     BlockHeader, MockBlockSynchronizer,
 };
-use crypto::{ed25519::Ed25519PublicKey, Hash};
+use crypto::Hash;
 use std::{collections::HashSet, time::Duration};
 use test_utils::{certificate, fixture_header_with_payload};
 use tokio::sync::mpsc::channel;
@@ -234,7 +234,7 @@ async fn test_synchronize_block_payload() {
     };
 
     // AND a certificate with payload already available
-    let cert_stored: Certificate<Ed25519PublicKey> = certificate(&fixture_header_with_payload(1));
+    let cert_stored: Certificate = certificate(&fixture_header_with_payload(1));
     for e in cert_stored.clone().header.payload {
         payload_store.write(e, 1).await;
     }

--- a/primary/src/grpc_server/configuration.rs
+++ b/primary/src/grpc_server/configuration.rs
@@ -1,18 +1,18 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use config::{PrimaryAddresses, SharedCommittee};
-use crypto::traits::VerifyingKey;
+use crypto::{traits::ToFromBytes, PublicKey};
 use std::collections::BTreeMap;
 use tonic::{Request, Response, Status};
 use types::{Configuration, Empty, NewEpochRequest, NewNetworkInfoRequest, PublicKeyProto};
 
-pub struct NarwhalConfiguration<PublicKey: VerifyingKey> {
+pub struct NarwhalConfiguration {
     /// The committee
-    committee: SharedCommittee<PublicKey>,
+    committee: SharedCommittee,
 }
 
-impl<PublicKey: VerifyingKey> NarwhalConfiguration<PublicKey> {
-    pub fn new(committee: SharedCommittee<PublicKey>) -> Self {
+impl NarwhalConfiguration {
+    pub fn new(committee: SharedCommittee) -> Self {
         Self { committee }
     }
 
@@ -38,7 +38,7 @@ impl<PublicKey: VerifyingKey> NarwhalConfiguration<PublicKey> {
 }
 
 #[tonic::async_trait]
-impl<PublicKey: VerifyingKey> Configuration for NarwhalConfiguration<PublicKey> {
+impl Configuration for NarwhalConfiguration {
     async fn new_epoch(
         &self,
         request: Request<NewEpochRequest>,

--- a/primary/src/grpc_server/proposer.rs
+++ b/primary/src/grpc_server/proposer.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use config::SharedCommittee;
 use consensus::dag::Dag;
-use crypto::traits::VerifyingKey;
+use crypto::{traits::ToFromBytes, PublicKey};
 use std::sync::Arc;
 use tonic::{Request, Response, Status};
 use types::{
@@ -10,16 +10,16 @@ use types::{
     RoundsResponse,
 };
 
-pub struct NarwhalProposer<PublicKey: VerifyingKey> {
+pub struct NarwhalProposer {
     /// The dag that holds the available certificates to propose
-    dag: Option<Arc<Dag<PublicKey>>>,
+    dag: Option<Arc<Dag>>,
 
     /// The committee
-    committee: SharedCommittee<PublicKey>,
+    committee: SharedCommittee,
 }
 
-impl<PublicKey: VerifyingKey> NarwhalProposer<PublicKey> {
-    pub fn new(dag: Option<Arc<Dag<PublicKey>>>, committee: SharedCommittee<PublicKey>) -> Self {
+impl NarwhalProposer {
+    pub fn new(dag: Option<Arc<Dag>>, committee: SharedCommittee) -> Self {
         Self { dag, committee }
     }
 
@@ -45,7 +45,7 @@ impl<PublicKey: VerifyingKey> NarwhalProposer<PublicKey> {
 }
 
 #[tonic::async_trait]
-impl<PublicKey: VerifyingKey> Proposer for NarwhalProposer<PublicKey> {
+impl Proposer for NarwhalProposer {
     /// Retrieves the min & max rounds that contain collections available for
     /// block proposal for the dictated validator.
     /// by the provided public key.

--- a/primary/src/grpc_server/validator.rs
+++ b/primary/src/grpc_server/validator.rs
@@ -7,7 +7,6 @@ use crate::{
     BlockRemoverCommand,
 };
 use consensus::dag::Dag;
-use crypto::traits::VerifyingKey;
 use tokio::{
     sync::{
         mpsc::{channel, Sender},
@@ -23,28 +22,23 @@ use types::{
     Validator,
 };
 
-pub struct NarwhalValidator<
-    PublicKey: VerifyingKey,
-    SynchronizerHandler: Handler<PublicKey> + Send + Sync + 'static,
-> {
+pub struct NarwhalValidator<SynchronizerHandler: Handler + Send + Sync + 'static> {
     tx_get_block_commands: Sender<BlockCommand>,
     tx_block_removal_commands: Sender<BlockRemoverCommand>,
     get_collections_timeout: Duration,
     remove_collections_timeout: Duration,
     block_synchronizer_handler: Arc<SynchronizerHandler>,
-    dag: Option<Arc<Dag<PublicKey>>>,
+    dag: Option<Arc<Dag>>,
 }
 
-impl<PublicKey: VerifyingKey, SynchronizerHandler: Handler<PublicKey> + Send + Sync + 'static>
-    NarwhalValidator<PublicKey, SynchronizerHandler>
-{
+impl<SynchronizerHandler: Handler + Send + Sync + 'static> NarwhalValidator<SynchronizerHandler> {
     pub fn new(
         tx_get_block_commands: Sender<BlockCommand>,
         tx_block_removal_commands: Sender<BlockRemoverCommand>,
         get_collections_timeout: Duration,
         remove_collections_timeout: Duration,
         block_synchronizer_handler: Arc<SynchronizerHandler>,
-        dag: Option<Arc<Dag<PublicKey>>>,
+        dag: Option<Arc<Dag>>,
     ) -> Self {
         Self {
             tx_get_block_commands,
@@ -58,8 +52,8 @@ impl<PublicKey: VerifyingKey, SynchronizerHandler: Handler<PublicKey> + Send + S
 }
 
 #[tonic::async_trait]
-impl<PublicKey: VerifyingKey, SynchronizerHandler: Handler<PublicKey> + Send + Sync + 'static>
-    Validator for NarwhalValidator<PublicKey, SynchronizerHandler>
+impl<SynchronizerHandler: Handler + Send + Sync + 'static> Validator
+    for NarwhalValidator<SynchronizerHandler>
 {
     async fn read_causal(
         &self,

--- a/primary/src/tests/common.rs
+++ b/primary/src/tests/common.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use bincode::deserialize;
 use config::WorkerId;
-use crypto::ed25519::Ed25519PublicKey;
+
 use serde::de::DeserializeOwned;
 use std::time::Duration;
 use store::{reopen, rocks, rocks::DBMap, Store};
@@ -13,8 +13,8 @@ use crate::PayloadToken;
 use tokio::{task::JoinHandle, time::timeout};
 
 pub fn create_db_stores() -> (
-    Store<HeaderDigest, Header<Ed25519PublicKey>>,
-    Store<CertificateDigest, Certificate<Ed25519PublicKey>>,
+    Store<HeaderDigest, Header>,
+    Store<CertificateDigest, Certificate>,
     Store<(BatchDigest, WorkerId), PayloadToken>,
 ) {
     // Create a new test store.
@@ -22,8 +22,8 @@ pub fn create_db_stores() -> (
         .expect("Failed creating database");
 
     let (header_map, certificate_map, payload_map) = reopen!(&rocksdb,
-        HEADERS_CF;<HeaderDigest, Header<Ed25519PublicKey>>,
-        CERTIFICATES_CF;<CertificateDigest, Certificate<Ed25519PublicKey>>,
+        HEADERS_CF;<HeaderDigest, Header>,
+        CERTIFICATES_CF;<CertificateDigest, Certificate>,
         PAYLOAD_CF;<(BatchDigest, WorkerId), PayloadToken>);
 
     (

--- a/primary/src/tests/core_tests.rs
+++ b/primary/src/tests/core_tests.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use super::*;
 use crate::common::create_db_stores;
-use crypto::{ed25519::Ed25519PublicKey, traits::KeyPair};
+use crypto::traits::KeyPair;
 use prometheus::Registry;
 use test_utils::{
     certificate, committee, fixture_batch_with_transactions, header, headers, keys, votes,
@@ -160,7 +160,7 @@ async fn process_header_missing_parent() {
 
     // Send a header to the core.
     let kp = keys(None).pop().unwrap();
-    let builder = types::HeaderBuilder::<Ed25519PublicKey>::default();
+    let builder = types::HeaderBuilder::default();
     let header = builder
         .author(name.clone())
         .round(1)
@@ -240,7 +240,7 @@ async fn process_header_missing_payload() {
     let keys = keys(None);
     let kp = keys.get(1).unwrap();
     let name = kp.public().clone();
-    let builder = types::HeaderBuilder::<Ed25519PublicKey>::default();
+    let builder = types::HeaderBuilder::default();
     let header = builder
         .author(name.clone())
         .round(1)

--- a/primary/src/tests/header_waiter_tests.rs
+++ b/primary/src/tests/header_waiter_tests.rs
@@ -7,7 +7,7 @@ use crate::{
     PrimaryWorkerMessage,
 };
 use core::sync::atomic::AtomicU64;
-use crypto::{ed25519::Ed25519PublicKey, Hash};
+use crypto::Hash;
 use prometheus::Registry;
 use std::{sync::Arc, time::Duration};
 use test_utils::{fixture_header_with_payload, resolve_name_and_committee};
@@ -70,7 +70,7 @@ async fn successfully_synchronize_batches() {
         .unwrap()
         .primary_to_worker;
 
-    let handle = worker_listener::<PrimaryWorkerMessage<Ed25519PublicKey>>(1, worker_address);
+    let handle = worker_listener::<PrimaryWorkerMessage>(1, worker_address);
 
     // THEN
     if let Ok(Ok(mut result)) = timeout(Duration::from_millis(4_000), handle).await {

--- a/primary/src/tests/helper_tests.rs
+++ b/primary/src/tests/helper_tests.rs
@@ -3,7 +3,7 @@
 use crate::{common::create_db_stores, helper::Helper, primary::PrimaryMessage, PayloadToken};
 use bincode::Options;
 use config::WorkerId;
-use crypto::{ed25519::Ed25519PublicKey, Hash};
+use crypto::Hash;
 use itertools::Itertools;
 use std::{
     borrow::Borrow,
@@ -79,7 +79,7 @@ async fn test_process_certificates_stream_mode() {
             .await
             .unwrap()
             .unwrap();
-        let message: PrimaryMessage<Ed25519PublicKey> = received.deserialize().unwrap();
+        let message: PrimaryMessage = received.deserialize().unwrap();
         let cert = match message {
             PrimaryMessage::Certificate(certificate) => certificate,
             msg => {
@@ -161,7 +161,7 @@ async fn test_process_certificates_batch_mode() {
         .await
         .unwrap()
         .unwrap();
-    let message: PrimaryMessage<Ed25519PublicKey> = received.deserialize().unwrap();
+    let message: PrimaryMessage = received.deserialize().unwrap();
     let result_certificates = match message {
         PrimaryMessage::CertificatesBatchResponse { certificates, .. } => certificates,
         msg => {
@@ -261,7 +261,7 @@ async fn test_process_payload_availability_success() {
         .await
         .unwrap()
         .unwrap();
-    let message: PrimaryMessage<Ed25519PublicKey> = received.deserialize().unwrap();
+    let message: PrimaryMessage = received.deserialize().unwrap();
     let payload_availability = match message {
         PrimaryMessage::PayloadAvailabilityResponse {
             payload_availability,
@@ -305,11 +305,10 @@ async fn test_process_payload_availability_when_failures() {
         .expect("Failed creating database");
 
     let (certificate_map, payload_map) = reopen!(&rocksdb,
-        CERTIFICATES_CF;<CertificateDigest, Certificate<Ed25519PublicKey>>,
+        CERTIFICATES_CF;<CertificateDigest, Certificate>,
         PAYLOAD_CF;<(BatchDigest, WorkerId), PayloadToken>);
 
-    let certificate_store: Store<CertificateDigest, Certificate<Ed25519PublicKey>> =
-        Store::new(certificate_map);
+    let certificate_store: Store<CertificateDigest, Certificate> = Store::new(certificate_map);
     let payload_store: Store<(types::BatchDigest, WorkerId), PayloadToken> =
         Store::new(payload_map);
 
@@ -383,7 +382,7 @@ async fn test_process_payload_availability_when_failures() {
         .await
         .unwrap()
         .unwrap();
-    let message: PrimaryMessage<Ed25519PublicKey> = received.deserialize().unwrap();
+    let message: PrimaryMessage = received.deserialize().unwrap();
     let payload_availability = match message {
         PrimaryMessage::PayloadAvailabilityResponse {
             payload_availability,

--- a/primary/src/utils.rs
+++ b/primary/src/utils.rs
@@ -1,18 +1,14 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use config::WorkerId;
-use crypto::traits::VerifyingKey;
 use std::collections::HashMap;
 use types::{BatchDigest, Certificate};
 
 // a helper method that collects all the batches from each certificate and maps
 // them by the worker id.
-pub fn map_certificate_batches_by_worker<PublicKey>(
-    certificates: &[Certificate<PublicKey>],
-) -> HashMap<WorkerId, Vec<BatchDigest>>
-where
-    PublicKey: VerifyingKey,
-{
+pub fn map_certificate_batches_by_worker(
+    certificates: &[Certificate],
+) -> HashMap<WorkerId, Vec<BatchDigest>> {
     let mut batches_by_worker: HashMap<WorkerId, Vec<BatchDigest>> = HashMap::new();
     for certificate in certificates.iter() {
         for (batch_id, worker_id) in &certificate.header.payload {

--- a/primary/tests/epoch_change.rs
+++ b/primary/tests/epoch_change.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use arc_swap::ArcSwap;
 use config::{Committee, Epoch, Parameters};
-use crypto::{ed25519::Ed25519PublicKey, traits::KeyPair};
+use crypto::traits::KeyPair;
 use futures::future::join_all;
 use network::{CancelOnDropHandler, WorkerToPrimaryNetwork};
 use node::NodeStorage;
@@ -337,8 +337,7 @@ async fn test_restart_with_new_committee_change() {
         .values()
         .map(|authority| authority.primary.worker_to_primary.clone())
         .collect();
-    let message =
-        WorkerPrimaryMessage::<Ed25519PublicKey>::Reconfigure(ReconfigureNotification::Shutdown);
+    let message = WorkerPrimaryMessage::Reconfigure(ReconfigureNotification::Shutdown);
     let mut _do_not_drop: Vec<CancelOnDropHandler<_>> = Vec::new();
     for address in addresses {
         _do_not_drop.push(
@@ -408,9 +407,7 @@ async fn test_restart_with_new_committee_change() {
             .values()
             .map(|authority| authority.primary.worker_to_primary.clone())
             .collect();
-        let message = WorkerPrimaryMessage::<Ed25519PublicKey>::Reconfigure(
-            ReconfigureNotification::Shutdown,
-        );
+        let message = WorkerPrimaryMessage::Reconfigure(ReconfigureNotification::Shutdown);
         let mut _do_not_drop: Vec<CancelOnDropHandler<_>> = Vec::new();
         for address in addresses {
             _do_not_drop.push(

--- a/primary/tests/integration_tests_proposer_api.rs
+++ b/primary/tests/integration_tests_proposer_api.rs
@@ -227,7 +227,7 @@ async fn test_node_read_causal_signed_certificates() {
 
     // Make the data store.
     let primary_store_1 = NodeStorage::reopen(temp_dir());
-    let primary_store_2: NodeStorage<Ed25519PublicKey> = NodeStorage::reopen(temp_dir());
+    let primary_store_2: NodeStorage = NodeStorage::reopen(temp_dir());
 
     let mut collection_ids: Vec<CertificateDigest> = Vec::new();
 

--- a/primary/tests/integration_tests_proposer_api.rs
+++ b/primary/tests/integration_tests_proposer_api.rs
@@ -5,9 +5,8 @@ use bytes::Bytes;
 use config::{Epoch, Parameters};
 use consensus::{dag::Dag, metrics::ConsensusMetrics};
 use crypto::{
-    ed25519::Ed25519PublicKey,
-    traits::{KeyPair, ToFromBytes},
-    Hash,
+    traits::{KeyPair as _, ToFromBytes},
+    Hash, PublicKey,
 };
 use node::NodeStorage;
 use primary::{NetworkModel, Primary, CHANNEL_CAPACITY};
@@ -49,7 +48,7 @@ async fn test_rounds_errors() {
                     .to_string(),
         },
         TestCase {
-            public_key: Bytes::from(Ed25519PublicKey::default().as_bytes().to_vec()),
+            public_key: Bytes::from(PublicKey::default().as_bytes().to_vec()),
             test_case_name: "Valid public key, but authority not found in committee".to_string(),
             expected_error: "Invalid public key: unknown authority".to_string(),
         },

--- a/primary/tests/integration_tests_validator_api.rs
+++ b/primary/tests/integration_tests_validator_api.rs
@@ -91,7 +91,7 @@ async fn test_get_collections() {
             .expect("couldn't store batches");
         if n != 4 {
             // Add batches to the workers store
-            let message = WorkerMessage::<Ed25519PublicKey>::Batch(batch.clone());
+            let message = WorkerMessage::Batch(batch.clone());
             let serialized_batch = bincode::serialize(&message).unwrap();
             store
                 .batch_store
@@ -274,7 +274,7 @@ async fn test_remove_collections() {
             .expect("couldn't store batches");
         if n != 4 {
             // Add batches to the workers store
-            let message = WorkerMessage::<Ed25519PublicKey>::Batch(batch.clone());
+            let message = WorkerMessage::Batch(batch.clone());
             let serialized_batch = bincode::serialize(&message).unwrap();
             store
                 .batch_store
@@ -418,7 +418,7 @@ async fn test_read_causal_signed_certificates() {
 
     // Make the data store.
     let primary_store_1 = NodeStorage::reopen(temp_dir());
-    let primary_store_2: NodeStorage<Ed25519PublicKey> = NodeStorage::reopen(temp_dir());
+    let primary_store_2: NodeStorage = NodeStorage::reopen(temp_dir());
 
     let mut collection_ids: Vec<CertificateDigest> = Vec::new();
 
@@ -616,7 +616,7 @@ async fn test_read_causal_unsigned_certificates() {
 
     // Make the data store.
     let primary_store_1 = NodeStorage::reopen(temp_dir());
-    let primary_store_2: NodeStorage<Ed25519PublicKey> = NodeStorage::reopen(temp_dir());
+    let primary_store_2: NodeStorage = NodeStorage::reopen(temp_dir());
 
     let mut collection_ids: Vec<CertificateDigest> = Vec::new();
 
@@ -977,22 +977,22 @@ async fn test_get_collections_with_missing_certificates() {
 
 async fn fixture_certificate(
     key: &Ed25519KeyPair,
-    header_store: Store<HeaderDigest, Header<Ed25519PublicKey>>,
-    certificate_store: Store<CertificateDigest, Certificate<Ed25519PublicKey>>,
+    header_store: Store<HeaderDigest, Header>,
+    certificate_store: Store<CertificateDigest, Certificate>,
     payload_store: Store<(BatchDigest, WorkerId), PayloadToken>,
     batch_store: Store<BatchDigest, SerializedBatchMessage>,
-) -> (Certificate<Ed25519PublicKey>, Batch) {
+) -> (Certificate, Batch) {
     let batch = fixture_batch_with_transactions(10);
     let worker_id = 0;
 
-    let message = WorkerMessage::<Ed25519PublicKey>::Batch(batch.clone());
+    let message = WorkerMessage::Batch(batch.clone());
     let serialized_batch = bincode::serialize(&message).unwrap();
     let batch_digest = batch.digest();
 
     let mut payload = BTreeMap::new();
     payload.insert(batch_digest, worker_id);
 
-    let builder = types::HeaderBuilder::<Ed25519PublicKey>::default();
+    let builder = types::HeaderBuilder::default();
     let header = builder
         .author(key.public().clone())
         .round(1)

--- a/primary/tests/integration_tests_validator_api.rs
+++ b/primary/tests/integration_tests_validator_api.rs
@@ -3,11 +3,7 @@ use arc_swap::ArcSwap;
 // SPDX-License-Identifier: Apache-2.0
 use config::{Parameters, WorkerId};
 use consensus::{dag::Dag, metrics::ConsensusMetrics};
-use crypto::{
-    ed25519::{Ed25519KeyPair, Ed25519PublicKey},
-    traits::KeyPair,
-    Hash,
-};
+use crypto::{traits::KeyPair as _, Hash, KeyPair, PublicKey};
 use node::NodeStorage;
 use primary::{NetworkModel, PayloadToken, Primary, CHANNEL_CAPACITY};
 use prometheus::Registry;
@@ -652,7 +648,7 @@ async fn test_read_causal_unsigned_certificates() {
             .authorities
             .keys()
             .cloned()
-            .collect::<Vec<Ed25519PublicKey>>(),
+            .collect::<Vec<PublicKey>>(),
     );
 
     collection_ids.extend(
@@ -976,7 +972,7 @@ async fn test_get_collections_with_missing_certificates() {
 }
 
 async fn fixture_certificate(
-    key: &Ed25519KeyPair,
+    key: &KeyPair,
     header_store: Store<HeaderDigest, Header>,
     certificate_store: Store<CertificateDigest, Certificate>,
     payload_store: Store<(BatchDigest, WorkerId), PayloadToken>,

--- a/test_utils/src/cluster.rs
+++ b/test_utils/src/cluster.rs
@@ -30,7 +30,7 @@ pub mod cluster_tests;
 
 pub struct Cluster {
     authorities: HashMap<usize, AuthorityDetails>,
-    pub committee_shared: SharedCommittee<Ed25519PublicKey>,
+    pub committee_shared: SharedCommittee,
     #[allow(dead_code)]
     parameters: Parameters,
 }
@@ -47,7 +47,7 @@ impl Cluster {
     /// DAG externally.
     pub fn new(
         parameters: Option<Parameters>,
-        input_committee: Option<Committee<Ed25519PublicKey>>,
+        input_committee: Option<Committee>,
         internal_consensus_enabled: bool,
     ) -> Self {
         let c = input_committee.unwrap_or_else(|| committee(None));
@@ -213,7 +213,7 @@ pub struct PrimaryNodeDetails {
     pub tx_transaction_confirmation: Sender<(SubscriberResult<Vec<u8>>, SerializedTransaction)>,
     registry: Registry,
     store_path: PathBuf,
-    committee: SharedCommittee<Ed25519PublicKey>,
+    committee: SharedCommittee,
     parameters: Parameters,
     handlers: Rc<RefCell<Vec<JoinHandle<()>>>>,
     internal_consensus_enabled: bool,
@@ -224,7 +224,7 @@ impl PrimaryNodeDetails {
         id: usize,
         key_pair: Ed25519KeyPair,
         parameters: Parameters,
-        committee: SharedCommittee<Ed25519PublicKey>,
+        committee: SharedCommittee,
         internal_consensus_enabled: bool,
     ) -> Self {
         // used just to initialise the struct value
@@ -277,7 +277,7 @@ impl PrimaryNodeDetails {
             channel(Node::CHANNEL_CAPACITY);
 
         // Primary node
-        let primary_store: NodeStorage<Ed25519PublicKey> = NodeStorage::reopen(store_path.clone());
+        let primary_store: NodeStorage = NodeStorage::reopen(store_path.clone());
         let mut primary_handlers = Node::spawn_primary(
             self.key_pair.copy(),
             self.committee.clone(),
@@ -339,7 +339,7 @@ pub struct WorkerNodeDetails {
     pub transactions_address: Multiaddr,
     pub registry: Registry,
     name: Ed25519PublicKey,
-    committee: SharedCommittee<Ed25519PublicKey>,
+    committee: SharedCommittee,
     parameters: Parameters,
     store_path: PathBuf,
     handlers: Arc<ArcSwap<Vec<JoinHandle<()>>>>,
@@ -351,7 +351,7 @@ impl WorkerNodeDetails {
         name: Ed25519PublicKey,
         parameters: Parameters,
         transactions_address: Multiaddr,
-        committee: SharedCommittee<Ed25519PublicKey>,
+        committee: SharedCommittee,
     ) -> Self {
         Self {
             id,
@@ -437,7 +437,7 @@ impl AuthorityDetails {
         id: usize,
         key_pair: Ed25519KeyPair,
         parameters: Parameters,
-        committee: SharedCommittee<Ed25519PublicKey>,
+        committee: SharedCommittee,
         internal_consensus_enabled: bool,
     ) -> Self {
         // Create all the nodes we have in the committee

--- a/test_utils/src/cluster.rs
+++ b/test_utils/src/cluster.rs
@@ -3,10 +3,7 @@
 use crate::{committee, keys, temp_dir};
 use arc_swap::ArcSwap;
 use config::{Committee, Parameters, SharedCommittee, WorkerId};
-use crypto::{
-    ed25519::{Ed25519KeyPair, Ed25519PublicKey},
-    traits::KeyPair,
-};
+use crypto::{traits::KeyPair as _, KeyPair, PublicKey};
 use executor::{SerializedTransaction, SubscriberResult, DEFAULT_CHANNEL_SIZE};
 use multiaddr::Multiaddr;
 use node::{
@@ -209,7 +206,7 @@ impl Cluster {
 #[derive(Clone)]
 pub struct PrimaryNodeDetails {
     pub id: usize,
-    pub key_pair: Arc<Ed25519KeyPair>,
+    pub key_pair: Arc<KeyPair>,
     pub tx_transaction_confirmation: Sender<(SubscriberResult<Vec<u8>>, SerializedTransaction)>,
     registry: Registry,
     store_path: PathBuf,
@@ -222,7 +219,7 @@ pub struct PrimaryNodeDetails {
 impl PrimaryNodeDetails {
     fn new(
         id: usize,
-        key_pair: Ed25519KeyPair,
+        key_pair: KeyPair,
         parameters: Parameters,
         committee: SharedCommittee,
         internal_consensus_enabled: bool,
@@ -338,7 +335,7 @@ pub struct WorkerNodeDetails {
     pub id: WorkerId,
     pub transactions_address: Multiaddr,
     pub registry: Registry,
-    name: Ed25519PublicKey,
+    name: PublicKey,
     committee: SharedCommittee,
     parameters: Parameters,
     store_path: PathBuf,
@@ -348,7 +345,7 @@ pub struct WorkerNodeDetails {
 impl WorkerNodeDetails {
     fn new(
         id: WorkerId,
-        name: Ed25519PublicKey,
+        name: PublicKey,
         parameters: Parameters,
         transactions_address: Multiaddr,
         committee: SharedCommittee,
@@ -423,7 +420,7 @@ impl WorkerNodeDetails {
 #[derive(Clone)]
 pub struct AuthorityDetails {
     pub id: usize,
-    pub name: Ed25519PublicKey,
+    pub name: PublicKey,
     internal: Arc<RwLock<AuthorityDetailsInternal>>,
 }
 
@@ -435,7 +432,7 @@ struct AuthorityDetailsInternal {
 impl AuthorityDetails {
     pub fn new(
         id: usize,
-        key_pair: Ed25519KeyPair,
+        key_pair: KeyPair,
         parameters: Parameters,
         committee: SharedCommittee,
         internal_consensus_enabled: bool,

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -18,6 +18,7 @@ proptest-derive = "0.3.0"
 prost = "0.10.4"
 rand = "0.7.3"
 serde = { version = "1.0.140", features = ["derive"] }
+signature = "1.5.0"
 store = { git = "https://github.com/mystenlabs/mysten-infra.git", package = "typed-store", rev = "123c9e40b529315e1c1d91a54fb717111c3e349c" }
 thiserror = "1.0.31"
 tokio = { version = "1.20.1", features = ["sync", "rt", "macros"] }

--- a/types/benches/batch_digest.rs
+++ b/types/benches/batch_digest.rs
@@ -3,7 +3,7 @@
 use criterion::{
     criterion_group, criterion_main, BenchmarkId, Criterion, SamplingMode, Throughput,
 };
-use crypto::{ed25519::Ed25519PublicKey, Hash};
+use crypto::Hash;
 use rand::Rng;
 use types::{serialized_batch_digest, Batch, WorkerMessage};
 
@@ -20,7 +20,7 @@ pub fn batch_digest(c: &mut Criterion) {
                 .collect::<Vec<u8>>()
         };
         let batch = Batch((0..size).map(|_| tx_gen()).collect::<Vec<_>>());
-        let message = WorkerMessage::<Ed25519PublicKey>::Batch(batch.clone());
+        let message = WorkerMessage::Batch(batch.clone());
         let serialized_batch = bincode::serialize(&message).unwrap();
 
         digest_group.throughput(Throughput::Bytes(512 * size as u64));

--- a/types/src/consensus.rs
+++ b/types/src/consensus.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use crate::{CertificateDigest, Round};
-use crypto::traits::VerifyingKey;
+use crypto::PublicKey;
 use std::{collections::HashMap, ops::RangeInclusive};
 use store::{
     rocks::{DBMap, TypedStoreError},
@@ -19,14 +19,14 @@ pub type ShutdownToken = mpsc::Sender<()>;
 pub type StoreResult<T> = Result<T, TypedStoreError>;
 
 /// The persistent storage of the sequencer.
-pub struct ConsensusStore<PublicKey: VerifyingKey> {
+pub struct ConsensusStore {
     /// The latest committed round of each validator.
     last_committed: DBMap<PublicKey, Round>,
     /// The global consensus sequence.
     sequence: DBMap<SequenceNumber, CertificateDigest>,
 }
 
-impl<PublicKey: VerifyingKey> ConsensusStore<PublicKey> {
+impl ConsensusStore {
     /// Create a new consensus store structure by using already loaded maps.
     pub fn new(
         last_committed: DBMap<PublicKey, Round>,

--- a/types/src/error.rs
+++ b/types/src/error.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use crate::{HeaderDigest, Round};
 use config::Epoch;
-use crypto::{CryptoError, Digest};
+use crypto::Digest;
 use store::StoreError;
 use thiserror::Error;
 
@@ -28,7 +28,7 @@ pub type DagResult<T> = Result<T, DagError>;
 #[derive(Debug, Error)]
 pub enum DagError {
     #[error("Invalid signature")]
-    InvalidSignature(#[from] CryptoError),
+    InvalidSignature(#[from] signature::Error),
 
     #[error("Storage failure: {0}")]
     StoreError(#[from] StoreError),

--- a/types/src/primary.rs
+++ b/types/src/primary.rs
@@ -254,7 +254,6 @@ impl PartialEq for Header {
 }
 
 #[derive(Clone, Serialize, Deserialize)]
-#[serde(bound(deserialize = "PublicKey: VerifyingKey"))] // bump the bound to VerifyingKey as soon as you include a sig
 pub struct Vote {
     pub id: HeaderDigest,
     pub round: Round,
@@ -528,7 +527,6 @@ impl Affiliated for Certificate {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(bound(deserialize = "PublicKey: VerifyingKey"))]
 pub enum PrimaryMessage {
     Header(Header),
     Vote(Vote),
@@ -557,7 +555,6 @@ pub enum PrimaryMessage {
 
 /// Message to reconfigure worker tasks.
 #[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(bound(deserialize = "PublicKey: VerifyingKey"))]
 pub enum ReconfigureNotification {
     /// Indicate the committee has been updated.
     NewCommittee(Committee),
@@ -567,7 +564,6 @@ pub enum ReconfigureNotification {
 
 /// The messages sent by the primary to its workers.
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(bound(deserialize = "PublicKey: VerifyingKey"))]
 pub enum PrimaryWorkerMessage {
     /// The primary indicates that the worker need to sync the target missing batches.
     Synchronize(Vec<BatchDigest>, /* target */ PublicKey),
@@ -639,7 +635,6 @@ impl fmt::Display for BlockErrorKind {
 
 /// The messages sent by the workers to their primary.
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(bound(deserialize = "PublicKey: VerifyingKey"))]
 pub enum WorkerPrimaryMessage {
     /// The worker indicates it sealed a new batch.
     OurBatch(BatchDigest, WorkerId),

--- a/types/src/proto.rs
+++ b/types/src/proto.rs
@@ -12,7 +12,7 @@ use crate::{
     Batch, BatchDigest, BatchMessage, BlockError, BlockErrorKind, CertificateDigest, Transaction,
 };
 use bytes::{Buf, Bytes};
-use crypto::traits::VerifyingKey;
+use crypto::PublicKey;
 
 pub use narwhal::{
     collection_retrieval_result::RetrievalResult,
@@ -41,7 +41,7 @@ pub use narwhal::{
     RoundsRequest, RoundsResponse, Transaction as TransactionProto, ValidatorData,
 };
 
-impl<PublicKey: VerifyingKey> From<PublicKey> for PublicKeyProto {
+impl From<PublicKey> for PublicKeyProto {
     fn from(pub_key: PublicKey) -> Self {
         PublicKeyProto {
             bytes: Bytes::from(pub_key.as_ref().to_vec()),

--- a/types/src/worker.rs
+++ b/types/src/worker.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use blake2::digest::Update;
-use crypto::traits::VerifyingKey;
+use crypto::PublicKey;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -10,8 +10,7 @@ use crate::{Batch, BatchDigest};
 
 /// The message exchanged between workers.
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(bound(deserialize = "PublicKey: VerifyingKey"))]
-pub enum WorkerMessage<PublicKey: VerifyingKey> {
+pub enum WorkerMessage {
     /// Used by workers to send a new batch or to reply to a batch request.
     Batch(Batch),
     /// Used by workers to request batches.

--- a/types/tests/batch_serde.rs
+++ b/types/tests/batch_serde.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use crypto::{ed25519::Ed25519PublicKey, Hash};
+use crypto::Hash;
 use proptest::arbitrary::Arbitrary;
 use serde_test::{assert_tokens, Token};
 use types::{serialized_batch_digest, Batch, WorkerMessage};
@@ -64,8 +64,7 @@ fn test_bincode_serde_batch() {
 fn test_bincode_serde_batch_message() {
     let tx = || vec![1; 5];
 
-    let txes: WorkerMessage<Ed25519PublicKey> =
-        WorkerMessage::Batch(Batch((0..2).map(|_| tx()).collect()));
+    let txes: WorkerMessage = WorkerMessage::Batch(Batch((0..2).map(|_| tx()).collect()));
 
     let txes_bytes = bincode::serialize(&txes).unwrap();
 
@@ -92,7 +91,7 @@ proptest::proptest! {
         batch in Batch::arbitrary()
     ) {
         let digest = batch.digest();
-        let message = WorkerMessage::<Ed25519PublicKey>::Batch(batch);
+        let message = WorkerMessage::Batch(batch);
         let serialized = bincode::serialize(&message).expect("Failed to serialize our own batch");
         let digest_from_serialized = serialized_batch_digest(&serialized).expect("Failed to hash serialized batch");
         assert_eq!(digest, digest_from_serialized);

--- a/worker/src/batch_maker.rs
+++ b/worker/src/batch_maker.rs
@@ -2,7 +2,6 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use config::Committee;
-use crypto::traits::VerifyingKey;
 #[cfg(feature = "benchmark")]
 use std::convert::TryInto;
 use tokio::{
@@ -20,15 +19,15 @@ use types::{error::DagError, Batch, ReconfigureNotification, Transaction};
 pub mod batch_maker_tests;
 
 /// Assemble clients transactions into batches.
-pub struct BatchMaker<PublicKey: VerifyingKey> {
+pub struct BatchMaker {
     /// The committee information.
-    committee: Committee<PublicKey>,
+    committee: Committee,
     /// The preferred batch size (in bytes).
     batch_size: usize,
     /// The maximum delay after which to seal the batch.
     max_batch_delay: Duration,
     /// Receive reconfiguration updates.
-    rx_reconfigure: watch::Receiver<ReconfigureNotification<PublicKey>>,
+    rx_reconfigure: watch::Receiver<ReconfigureNotification>,
     /// Channel to receive transactions from the network.
     rx_transaction: Receiver<Transaction>,
     /// Output channel to deliver sealed batches to the `QuorumWaiter`.
@@ -39,12 +38,12 @@ pub struct BatchMaker<PublicKey: VerifyingKey> {
     current_batch_size: usize,
 }
 
-impl<PublicKey: VerifyingKey> BatchMaker<PublicKey> {
+impl BatchMaker {
     pub fn spawn(
-        committee: Committee<PublicKey>,
+        committee: Committee,
         batch_size: usize,
         max_batch_delay: Duration,
-        rx_reconfigure: watch::Receiver<ReconfigureNotification<PublicKey>>,
+        rx_reconfigure: watch::Receiver<ReconfigureNotification>,
         rx_transaction: Receiver<Transaction>,
         tx_message: Sender<Batch>,
     ) -> JoinHandle<()> {
@@ -129,7 +128,7 @@ impl<PublicKey: VerifyingKey> BatchMaker<PublicKey> {
 
         #[cfg(feature = "benchmark")]
         {
-            let message = types::WorkerMessage::<PublicKey>::Batch(batch.clone());
+            let message = types::WorkerMessage::Batch(batch.clone());
             let serialized =
                 bincode::serialize(&message).expect("Failed to serialize our own batch");
 

--- a/worker/src/helper.rs
+++ b/worker/src/helper.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use bytes::Bytes;
 use config::{Committee, WorkerId};
-use crypto::traits::VerifyingKey;
+use crypto::PublicKey;
 use network::WorkerNetwork;
 use store::Store;
 use tokio::{
@@ -21,15 +21,15 @@ use types::{BatchDigest, ReconfigureNotification, SerializedBatchMessage};
 pub mod helper_tests;
 
 /// A task dedicated to help other authorities by replying to their batch requests.
-pub struct Helper<PublicKey: VerifyingKey> {
+pub struct Helper {
     /// The id of this worker.
     id: WorkerId,
     /// The committee information.
-    committee: Committee<PublicKey>,
+    committee: Committee,
     /// The persistent storage.
     store: Store<BatchDigest, SerializedBatchMessage>,
     /// Receive reconfiguration updates.
-    rx_reconfigure: watch::Receiver<ReconfigureNotification<PublicKey>>,
+    rx_reconfigure: watch::Receiver<ReconfigureNotification>,
     /// Input channel to receive batch requests from workers.
     rx_worker_request: Receiver<(Vec<BatchDigest>, PublicKey)>,
     /// Input channel to receive batch requests from workers.
@@ -38,12 +38,12 @@ pub struct Helper<PublicKey: VerifyingKey> {
     network: WorkerNetwork,
 }
 
-impl<PublicKey: VerifyingKey> Helper<PublicKey> {
+impl Helper {
     pub fn spawn(
         id: WorkerId,
-        committee: Committee<PublicKey>,
+        committee: Committee,
         store: Store<BatchDigest, SerializedBatchMessage>,
-        rx_reconfigure: watch::Receiver<ReconfigureNotification<PublicKey>>,
+        rx_reconfigure: watch::Receiver<ReconfigureNotification>,
         rx_worker_request: Receiver<(Vec<BatchDigest>, PublicKey)>,
         rx_client_request: Receiver<(Vec<BatchDigest>, Sender<SerializedBatchMessage>)>,
     ) -> JoinHandle<()> {

--- a/worker/src/primary_connector.rs
+++ b/worker/src/primary_connector.rs
@@ -2,7 +2,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use config::Committee;
-use crypto::traits::VerifyingKey;
+use crypto::PublicKey;
 use futures::{stream::FuturesUnordered, StreamExt};
 use network::WorkerToPrimaryNetwork;
 use tokio::{
@@ -15,25 +15,25 @@ use types::{ReconfigureNotification, WorkerPrimaryMessage};
 pub const MAX_PENDING_DIGESTS: usize = 10_000;
 
 // Send batches' digests to the primary.
-pub struct PrimaryConnector<PublicKey: VerifyingKey> {
+pub struct PrimaryConnector {
     /// The public key of this authority.
     name: PublicKey,
     /// The committee information.
-    committee: Committee<PublicKey>,
+    committee: Committee,
     /// Receive reconfiguration updates.
-    rx_reconfigure: watch::Receiver<ReconfigureNotification<PublicKey>>,
+    rx_reconfigure: watch::Receiver<ReconfigureNotification>,
     /// Input channel to receive the messages to send to the primary.
-    rx_digest: Receiver<WorkerPrimaryMessage<PublicKey>>,
+    rx_digest: Receiver<WorkerPrimaryMessage>,
     /// A network sender to send the batches' digests to the primary.
     primary_client: WorkerToPrimaryNetwork,
 }
 
-impl<PublicKey: VerifyingKey> PrimaryConnector<PublicKey> {
+impl PrimaryConnector {
     pub fn spawn(
         name: PublicKey,
-        committee: Committee<PublicKey>,
-        rx_reconfigure: watch::Receiver<ReconfigureNotification<PublicKey>>,
-        rx_digest: Receiver<WorkerPrimaryMessage<PublicKey>>,
+        committee: Committee,
+        rx_reconfigure: watch::Receiver<ReconfigureNotification>,
+        rx_digest: Receiver<WorkerPrimaryMessage>,
     ) -> JoinHandle<()> {
         tokio::spawn(async move {
             Self {

--- a/worker/src/processor.rs
+++ b/worker/src/processor.rs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use config::WorkerId;
-use crypto::traits::VerifyingKey;
 use store::Store;
 use tokio::{
     sync::{
@@ -26,17 +25,17 @@ pub mod processor_tests;
 pub struct Processor;
 
 impl Processor {
-    pub fn spawn<PublicKey: VerifyingKey>(
+    pub fn spawn(
         // Our worker's id.
         id: WorkerId,
         // The persistent storage.
         store: Store<BatchDigest, SerializedBatchMessage>,
         // Receive reconfiguration signals.
-        mut rx_reconfigure: watch::Receiver<ReconfigureNotification<PublicKey>>,
+        mut rx_reconfigure: watch::Receiver<ReconfigureNotification>,
         // Input channel to receive batches.
         mut rx_batch: Receiver<SerializedBatchMessage>,
         // Output channel to send out batches' digests.
-        tx_digest: Sender<WorkerPrimaryMessage<PublicKey>>,
+        tx_digest: Sender<WorkerPrimaryMessage>,
         // Whether we are processing our own batches or the batches of other nodes.
         own_digest: bool,
     ) -> JoinHandle<()> {

--- a/worker/src/tests/processor_tests.rs
+++ b/worker/src/tests/processor_tests.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use super::*;
 use crate::worker::WorkerMessage;
-use crypto::{ed25519::Ed25519PublicKey, Hash};
+use crypto::Hash;
 use store::rocks;
 use test_utils::{batch, committee, temp_dir};
 use tokio::sync::mpsc::channel;
@@ -39,7 +39,7 @@ async fn hash_and_store() {
 
     // Send a batch to the `Processor`.
     let batch = batch();
-    let message = WorkerMessage::<Ed25519PublicKey>::Batch(batch.clone());
+    let message = WorkerMessage::Batch(batch.clone());
     let serialized = bincode::serialize(&message).unwrap();
     tx_batch.send(serialized.clone()).await.unwrap();
 

--- a/worker/src/tests/quorum_waiter_tests.rs
+++ b/worker/src/tests/quorum_waiter_tests.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use super::*;
 use crate::worker::WorkerMessage;
-use crypto::{ed25519::Ed25519PublicKey, traits::KeyPair};
+use crypto::traits::KeyPair;
 use test_utils::{batch, committee, keys, WorkerToWorkerMockServer};
 use tokio::sync::mpsc::channel;
 
@@ -29,7 +29,7 @@ async fn wait_for_quorum() {
 
     // Make a batch.
     let batch = batch();
-    let message = WorkerMessage::<Ed25519PublicKey>::Batch(batch.clone());
+    let message = WorkerMessage::Batch(batch.clone());
     let serialized = bincode::serialize(&message).unwrap();
 
     // Spawn enough listeners to acknowledge our batches.

--- a/worker/src/tests/synchronizer_tests.rs
+++ b/worker/src/tests/synchronizer_tests.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use super::*;
 use arc_swap::ArcSwap;
-use crypto::{ed25519::Ed25519PublicKey, traits::KeyPair};
+use crypto::traits::KeyPair;
 use prometheus::Registry;
 use test_utils::{
     batch, batch_digest, batches, committee, keys, open_batch_store, serialize_batch_message,
@@ -103,7 +103,7 @@ async fn test_successful_request_batch() {
     store.write(expected_digest, batch_serialised.clone()).await;
 
     // WHEN we send a message to retrieve the batch
-    let message = PrimaryWorkerMessage::<Ed25519PublicKey>::RequestBatch(expected_digest);
+    let message = PrimaryWorkerMessage::RequestBatch(expected_digest);
 
     tx_message
         .send(message)
@@ -162,7 +162,7 @@ async fn test_request_batch_not_found() {
     let expected_batch_id = BatchDigest::default();
 
     // WHEN we send a message to retrieve the batch that doesn't exist
-    let message = PrimaryWorkerMessage::<Ed25519PublicKey>::RequestBatch(expected_batch_id);
+    let message = PrimaryWorkerMessage::RequestBatch(expected_batch_id);
 
     tx_message
         .send(message)
@@ -233,7 +233,7 @@ async fn test_successful_batch_delete() {
     }
 
     // WHEN we send a message to delete batches
-    let message = PrimaryWorkerMessage::<Ed25519PublicKey>::DeleteBatches(batch_digests.clone());
+    let message = PrimaryWorkerMessage::DeleteBatches(batch_digests.clone());
 
     tx_message
         .send(message)

--- a/worker/src/tests/worker_tests.rs
+++ b/worker/src/tests/worker_tests.rs
@@ -4,7 +4,7 @@
 use super::*;
 
 use arc_swap::ArcSwap;
-use crypto::{ed25519::Ed25519PublicKey, traits::KeyPair};
+use crypto::traits::KeyPair;
 use futures::StreamExt;
 use prometheus::Registry;
 use std::time::Duration;
@@ -55,11 +55,7 @@ async fn handle_clients_transactions() {
     let batch_digest = serialized_batch_digest(&serialized_batch).unwrap();
 
     let primary_address = committee.primary(&name).unwrap().worker_to_primary;
-    let expected = bincode::serialize(&WorkerPrimaryMessage::<Ed25519PublicKey>::OurBatch(
-        batch_digest,
-        id,
-    ))
-    .unwrap();
+    let expected = bincode::serialize(&WorkerPrimaryMessage::OurBatch(batch_digest, id)).unwrap();
     let mut handle = WorkerToPrimaryMockServer::spawn(primary_address);
 
     // Spawn enough workers' listeners to acknowledge our batches.


### PR DESCRIPTION
## Context 
MystenLabs/narwhal#35 introduced generic traits for public keys (`VerifyingKey`), private keys (`SigningKey`), signatures (`Authenticator`) and key pairs (`KeyPair`). We then added support for more schemes implementing this, notably BLS12-381 (#37), BLS12-377 (#36) and secp256k1 (#484). 

## The issue

However, the code base was left in a state where most structures are defined generically, which is unwieldy (see e.g. the definitions of `ExecutionState` and `ConsensusProtocol` in resp. MystenLabs/narwhal#489 and MystenLabs/narwhal#385) and limits us in using genericity elsewhere (e.g. MystenLabs/narwhal#171 could have conveyed the same functionality in ~ 1/2 the SLoC). It also led to some repair PRs (#583 MystenLabs/narwhal#602).

## The solution

We notice, following the discipline in Sui (https://github.com/MystenLabs/sui/pull/2994) and Diem before it, that we do not have to keep the code base generic since we expect at most one signing scheme to be used for authority signing at any given time. We expect to always be able to pick that single scheme at compile time (this is only used for validator signing, not user signing). We therefore confine the genericity to the crypto crate, and use aliases to pick one specific scheme at the top of that crate (`crypto::{PublicKey, Signature, PrivateKey, KeyPair}`). Those aliases are then what is used in the rest of the code base. 

Provided we do not add nasty introspection in the specifics of one scheme between now and then, we will only have to switch the definition of the aliases in order to switch the signing scheme we use throughout the code base (including tests).

This should pave the way for further refactorings, among which MystenLabs/sui#5292.
