### PR TITLE
[metrics] add metrics for the worker transaction endpoint

### DIFF
--- a/primary/tests/integration_tests_validator_api.rs
+++ b/primary/tests/integration_tests_validator_api.rs
@@ -27,7 +27,7 @@ use types::{
     SerializedBatchMessage, ValidatorClient,
 };
 use worker::{
-    metrics::{Metrics, WorkerMetrics},
+    metrics::{Metrics, WorkerEndpointMetrics, WorkerMetrics},
     Worker, WorkerMessage,
 };
 
@@ -124,8 +124,10 @@ async fn test_get_collections() {
         &Registry::new(),
     );
 
+    let registry = Registry::new();
     let metrics = Metrics {
-        worker_metrics: Some(WorkerMetrics::new(&Registry::new())),
+        worker_metrics: Some(WorkerMetrics::new(&registry)),
+        endpoint_metrics: Some(WorkerEndpointMetrics::new(&registry)),
     };
 
     // Spawn a `Worker` instance.
@@ -328,8 +330,10 @@ async fn test_remove_collections() {
         "Certificate should still exist"
     );
 
+    let registry = Registry::new();
     let metrics = Metrics {
-        worker_metrics: Some(WorkerMetrics::new(&Registry::new())),
+        worker_metrics: Some(WorkerMetrics::new(&registry)),
+        endpoint_metrics: Some(WorkerEndpointMetrics::new(&registry)),
     };
 
     // Spawn a `Worker` instance.
@@ -874,8 +878,10 @@ async fn test_get_collections_with_missing_certificates() {
         &Registry::new(),
     );
 
+    let registry = Registry::new();
     let metrics_1 = Metrics {
-        worker_metrics: Some(WorkerMetrics::new(&Registry::new())),
+        worker_metrics: Some(WorkerMetrics::new(&registry)),
+        endpoint_metrics: Some(WorkerEndpointMetrics::new(&registry)),
     };
 
     // Spawn a `Worker` instance for primary 1.
@@ -912,8 +918,10 @@ async fn test_get_collections_with_missing_certificates() {
         &Registry::new(),
     );
 
+    let registry = Registry::new();
     let metrics_2 = Metrics {
-        worker_metrics: Some(WorkerMetrics::new(&Registry::new())),
+        worker_metrics: Some(WorkerMetrics::new(&registry)),
+        endpoint_metrics: Some(WorkerEndpointMetrics::new(&registry)),
     };
 
     // Spawn a `Worker` instance for primary 2.

--- a/worker/src/metrics.rs
+++ b/worker/src/metrics.rs
@@ -1,10 +1,17 @@
+use mysten_network::metrics::MetricsCallbackProvider;
+use std::time::Duration;
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use prometheus::{default_registry, register_int_gauge_vec_with_registry, IntGaugeVec, Registry};
+use prometheus::{
+    default_registry, register_histogram_vec_with_registry, register_int_counter_vec_with_registry,
+    register_int_gauge_vec_with_registry, HistogramVec, IntCounterVec, IntGaugeVec, Registry,
+};
+use tonic::Code;
 
 #[derive(Clone)]
 pub struct Metrics {
     pub worker_metrics: Option<WorkerMetrics>,
+    pub endpoint_metrics: Option<WorkerEndpointMetrics>,
 }
 
 /// Initialises the metrics. Should be called only once when the worker
@@ -14,14 +21,18 @@ pub fn initialise_metrics(metrics_registry: &Registry) -> Metrics {
     // Essential/core metrics across the worker node
     let node_metrics = WorkerMetrics::new(metrics_registry);
 
+    // Endpoint metrics
+    let endpoint_metrics = WorkerEndpointMetrics::new(metrics_registry);
+
     Metrics {
         worker_metrics: Some(node_metrics),
+        endpoint_metrics: Some(endpoint_metrics),
     }
 }
 
 #[derive(Clone)]
 pub struct WorkerMetrics {
-    /// Number of elements in pending list of header_waiter
+    /// Number of elements pending elements in the worker synchronizer
     pub pending_elements_worker_synchronizer: IntGaugeVec,
 }
 
@@ -40,6 +51,59 @@ impl WorkerMetrics {
 }
 
 impl Default for WorkerMetrics {
+    fn default() -> Self {
+        Self::new(default_registry())
+    }
+}
+
+#[derive(Clone)]
+pub struct WorkerEndpointMetrics {
+    /// Counter of requests, route is a label (ie separate timeseries per route)
+    requests_by_route: IntCounterVec,
+    /// Request latency, route is a label
+    req_latency_by_route: HistogramVec,
+}
+
+impl WorkerEndpointMetrics {
+    pub fn new(registry: &Registry) -> Self {
+        Self {
+            requests_by_route: register_int_counter_vec_with_registry!(
+                "worker_requests_by_route",
+                "Number of requests by route",
+                &["route", "status", "grpc_status_code"],
+                registry
+            )
+            .unwrap(),
+            req_latency_by_route: register_histogram_vec_with_registry!(
+                "worker_req_latency_by_route",
+                "Latency of a request by route",
+                &["route", "status", "grpc_status_code"],
+                registry
+            )
+            .unwrap(),
+        }
+    }
+}
+
+impl MetricsCallbackProvider for WorkerEndpointMetrics {
+    fn on_request(&self, _path: String) {
+        // For now we just do nothing
+    }
+
+    fn on_response(&self, path: String, latency: Duration, status: u16, grpc_status_code: Code) {
+        let code: i32 = grpc_status_code.into();
+        let labels = [path.as_str(), &status.to_string(), &code.to_string()];
+
+        self.requests_by_route.with_label_values(&labels).inc();
+
+        let req_latency_secs = latency.as_secs_f64();
+        self.req_latency_by_route
+            .with_label_values(&labels)
+            .observe(req_latency_secs);
+    }
+}
+
+impl Default for WorkerEndpointMetrics {
     fn default() -> Self {
         Self::new(default_registry())
     }

--- a/worker/src/metrics.rs
+++ b/worker/src/metrics.rs
@@ -1,11 +1,11 @@
-use mysten_network::metrics::MetricsCallbackProvider;
-use std::time::Duration;
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
+use mysten_network::metrics::MetricsCallbackProvider;
 use prometheus::{
     default_registry, register_histogram_vec_with_registry, register_int_counter_vec_with_registry,
     register_int_gauge_vec_with_registry, HistogramVec, IntCounterVec, IntGaugeVec, Registry,
 };
+use std::time::Duration;
 use tonic::Code;
 
 #[derive(Clone)]

--- a/worker/src/tests/worker_tests.rs
+++ b/worker/src/tests/worker_tests.rs
@@ -35,8 +35,10 @@ async fn handle_clients_transactions() {
     )
     .unwrap();
     let store = Store::new(db);
+    let registry = Registry::new();
     let metrics = Metrics {
-        worker_metrics: Some(WorkerMetrics::new(&Registry::new())),
+        worker_metrics: Some(WorkerMetrics::new(&registry)),
+        endpoint_metrics: Some(WorkerEndpointMetrics::new(&registry)),
     };
 
     // Spawn a `Worker` instance.
@@ -111,8 +113,10 @@ async fn handle_client_batch_request() {
         )
         .await;
 
+    let registry = Registry::new();
     let metrics = Metrics {
-        worker_metrics: Some(WorkerMetrics::new(&Registry::new())),
+        worker_metrics: Some(WorkerMetrics::new(&registry)),
+        endpoint_metrics: Some(WorkerEndpointMetrics::new(&registry)),
     };
 
     // Spawn a `Worker` instance.


### PR DESCRIPTION
This PR is introducing metrics for the worker endpoints. It only injects them for now on the `TxReceiverHandler` which handles the receive of transactions. That will give us insights on the number of transactions submitted (successfully or not).