### PR TITLE
fix: make apt update quiet

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -11,8 +11,8 @@ WORKDIR "$WORKDIR/narwhal"
 ARG BUILD_MODE
 
 # Install basic dependencies
-RUN apt-get update \
-    && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y --no-install-recommends \
+RUN apt-get -q update \
+    && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -q install -y --no-install-recommends \
     tzdata \
     git \
     ca-certificates \

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -11,8 +11,8 @@ WORKDIR "$WORKDIR/narwhal"
 ARG BUILD_MODE
 
 # Install basic dependencies
-RUN apt-get -q update \
-    && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -q install -y --no-install-recommends \
+RUN apt-get -qq update \
+    && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -qq install -y --no-install-recommends \
     tzdata \
     git \
     ca-certificates \


### PR DESCRIPTION
Adding `-q` to the apt commands to make them quiet.  No need to see that output.