### PR TITLE
fix: redirect apt output to /dev/null

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -21,7 +21,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -qq update \
     libssl-dev \
     pkg-config \
     clang \
-    cmake  2> /dev/null > /dev/null \
+    cmake > /dev/null 2>&1 \
     && rm -rf /var/lib/apt/lists/*
 # Install the fmt
 RUN rustup component add rustfmt

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -61,7 +61,7 @@ ARG FEATURES="celo,benchmark"
 COPY --from=planner /narwhal/Cargo.toml Cargo.toml
 COPY --from=planner /narwhal/Cargo.lock Cargo.lock
 COPY --from=planner /narwhal/workspace-hack workspace-hack
-RUN cargo build --${BUILD_MODE} --features ${FEATURES}
+RUN cargo build --${BUILD_MODE} --all-features
 
 #################################################################
 # Stage 2.5 : Building

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR "$WORKDIR/narwhal"
 ARG BUILD_MODE
 
 # Install basic dependencies
-RUN apt-get -qq update \
+RUN DEBIAN_FRONTEND=noninteractive apt-get -qq update \
     && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -qq install -y --no-install-recommends \
     tzdata \
     git \
@@ -21,7 +21,7 @@ RUN apt-get -qq update \
     libssl-dev \
     pkg-config \
     clang \
-    cmake \
+    cmake  2> /dev/null > /dev/null \
     && rm -rf /var/lib/apt/lists/*
 # Install the fmt
 RUN rustup component add rustfmt


### PR DESCRIPTION
So the `-qq` option doesn't work, so adding redirect to /dev/null
