### PR TITLE
[network] Refactor boilerplate in Primary & Worker networks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2237,6 +2237,7 @@ dependencies = [
  "multiaddr",
  "mysten-network 0.1.0 (git+https://github.com/mystenlabs/mysten-infra.git?rev=123c9e40b529315e1c1d91a54fb717111c3e349c)",
  "rand 0.7.3",
+ "serde",
  "test_utils",
  "thiserror",
  "tokio",

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -24,6 +24,7 @@ anyhow = "1.0.58"
 
 mysten-network = { git = "https://github.com/mystenlabs/mysten-infra.git", rev = "123c9e40b529315e1c1d91a54fb717111c3e349c" }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
+serde = "1.0.140"
 
 [dev-dependencies]
 bincode = "1.3.3"

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -7,16 +7,19 @@
     rust_2018_idioms,
     rust_2021_compatibility
 )]
+#![allow(clippy::async_yields_async)]
 
 mod bounded_executor;
 mod primary;
 mod retry;
+mod traits;
 mod worker;
 
 pub use crate::{
     bounded_executor::BoundedExecutor,
     primary::{PrimaryNetwork, PrimaryToWorkerNetwork},
     retry::RetryConfig,
+    traits::{LuckyNetwork, ReliableNetwork, UnreliableNetwork},
     worker::{WorkerNetwork, WorkerToPrimaryNetwork},
 };
 

--- a/network/src/traits.rs
+++ b/network/src/traits.rs
@@ -1,0 +1,106 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use async_trait::async_trait;
+use multiaddr::Multiaddr;
+use rand::prelude::{SliceRandom, SmallRng};
+use serde::Serialize;
+use tokio::task::JoinHandle;
+use types::BincodeEncodedPayload;
+
+use crate::{CancelOnDropHandler, MessageResult};
+
+pub trait BaseNetwork {
+    type Client;
+    type Message: Serialize + Sync;
+
+    fn client(&mut self, address: Multiaddr) -> Self::Client;
+    fn create_client(config: &mysten_network::config::Config, address: Multiaddr) -> Self::Client;
+}
+
+#[async_trait]
+pub trait UnreliableNetwork: BaseNetwork {
+    async fn unreliable_send_message(
+        &mut self,
+        address: Multiaddr,
+        message: BincodeEncodedPayload,
+    ) -> JoinHandle<()>;
+
+    async fn unreliable_send(
+        &mut self,
+        address: Multiaddr,
+        message: &Self::Message,
+    ) -> JoinHandle<()> {
+        let message =
+            BincodeEncodedPayload::try_from(message).expect("Failed to serialize payload");
+        self.unreliable_send_message(address, message).await
+    }
+
+    /// Broadcasts a message to all `addresses` passed as an argument.
+    /// The attempts to send individual messages are best effort and will not be retried.
+    async fn unreliable_broadcast(
+        &mut self,
+        addresses: Vec<Multiaddr>,
+        message: &Self::Message,
+    ) -> Vec<JoinHandle<()>> {
+        let message =
+            BincodeEncodedPayload::try_from(message).expect("Failed to serialize payload");
+        let mut handlers = Vec::new();
+        for address in addresses {
+            let handle = { self.unreliable_send_message(address, message.clone()).await };
+            handlers.push(handle);
+        }
+        handlers
+    }
+}
+
+#[async_trait]
+pub trait LuckyNetwork: UnreliableNetwork {
+    fn rng(&mut self) -> &mut SmallRng;
+
+    /// Pick a few addresses at random (specified by `nodes`) and try (best-effort) to send the
+    /// message only to them. This is useful to pick nodes with whom to sync.
+    async fn lucky_broadcast(
+        &mut self,
+        mut addresses: Vec<Multiaddr>,
+        message: &Self::Message,
+        nodes: usize,
+    ) -> Vec<JoinHandle<()>> {
+        addresses.shuffle(self.rng());
+        addresses.truncate(nodes);
+        self.unreliable_broadcast(addresses, message).await
+    }
+}
+
+#[async_trait]
+pub trait ReliableNetwork: BaseNetwork {
+    async fn send(
+        &mut self,
+        address: Multiaddr,
+        message: &Self::Message,
+    ) -> CancelOnDropHandler<MessageResult> {
+        let message =
+            BincodeEncodedPayload::try_from(message).expect("Failed to serialize payload");
+        self.send_message(address, message).await
+    }
+
+    async fn send_message(
+        &mut self,
+        address: Multiaddr,
+        message: BincodeEncodedPayload,
+    ) -> CancelOnDropHandler<MessageResult>;
+
+    async fn broadcast(
+        &mut self,
+        addresses: Vec<Multiaddr>,
+        message: &Self::Message,
+    ) -> Vec<CancelOnDropHandler<MessageResult>> {
+        let message =
+            BincodeEncodedPayload::try_from(message).expect("Failed to serialize payload");
+        let mut handlers = Vec::new();
+        for address in addresses {
+            let handle = self.send_message(address, message.clone()).await;
+            handlers.push(handle);
+        }
+        handlers
+    }
+}

--- a/node/src/restarter.rs
+++ b/node/src/restarter.rs
@@ -6,7 +6,7 @@ use config::{Committee, Parameters};
 use crypto::{traits::KeyPair as _, KeyPair};
 use executor::{ExecutionState, ExecutorOutput};
 use futures::future::join_all;
-use network::{PrimaryToWorkerNetwork, WorkerToPrimaryNetwork};
+use network::{PrimaryToWorkerNetwork, ReliableNetwork, UnreliableNetwork, WorkerToPrimaryNetwork};
 use prometheus::Registry;
 use std::{fmt::Debug, path::PathBuf, sync::Arc};
 use tokio::sync::mpsc::{Receiver, Sender};

--- a/node/tests/reconfigure.rs
+++ b/node/tests/reconfigure.rs
@@ -7,7 +7,7 @@ use consensus::ConsensusOutput;
 use crypto::{traits::KeyPair as _, KeyPair, PublicKey};
 use executor::{ExecutionIndices, ExecutionState, ExecutionStateError};
 use futures::future::join_all;
-use network::{PrimaryToWorkerNetwork, WorkerToPrimaryNetwork};
+use network::{PrimaryToWorkerNetwork, ReliableNetwork, UnreliableNetwork, WorkerToPrimaryNetwork};
 use node::{restarter::NodeRestarter, Node, NodeStorage};
 use primary::PrimaryWorkerMessage;
 use prometheus::Registry;

--- a/primary/src/block_synchronizer/mod.rs
+++ b/primary/src/block_synchronizer/mod.rs
@@ -16,7 +16,7 @@ use futures::{
     stream::FuturesUnordered,
     FutureExt, StreamExt,
 };
-use network::{PrimaryNetwork, PrimaryToWorkerNetwork};
+use network::{PrimaryNetwork, PrimaryToWorkerNetwork, UnreliableNetwork};
 use rand::{rngs::SmallRng, SeedableRng};
 use std::{
     collections::{HashMap, HashSet},

--- a/primary/src/block_waiter.rs
+++ b/primary/src/block_waiter.rs
@@ -8,7 +8,7 @@ use futures::{
     stream::{futures_unordered::FuturesUnordered, StreamExt as _},
     FutureExt,
 };
-use network::PrimaryToWorkerNetwork;
+use network::{PrimaryToWorkerNetwork, UnreliableNetwork};
 use std::{
     collections::{HashMap, HashSet},
     fmt,

--- a/primary/src/core.rs
+++ b/primary/src/core.rs
@@ -10,7 +10,7 @@ use crate::{
 use async_recursion::async_recursion;
 use config::{Committee, Epoch};
 use crypto::{Hash as _, PublicKey, Signature, SignatureService};
-use network::{CancelOnDropHandler, MessageResult, PrimaryNetwork};
+use network::{CancelOnDropHandler, MessageResult, PrimaryNetwork, ReliableNetwork};
 use std::{
     collections::{HashMap, HashSet},
     sync::{

--- a/primary/src/header_waiter.rs
+++ b/primary/src/header_waiter.rs
@@ -11,7 +11,7 @@ use futures::{
     future::{try_join_all, BoxFuture},
     stream::{futures_unordered::FuturesUnordered, StreamExt as _},
 };
-use network::{PrimaryNetwork, PrimaryToWorkerNetwork};
+use network::{LuckyNetwork, PrimaryNetwork, PrimaryToWorkerNetwork, UnreliableNetwork};
 use serde::{de::DeserializeOwned, Serialize};
 use std::{
     collections::HashMap,

--- a/primary/src/helper.rs
+++ b/primary/src/helper.rs
@@ -4,7 +4,7 @@
 use crate::{primary::PrimaryMessage, PayloadToken};
 use config::{Committee, WorkerId};
 use crypto::{traits::EncodeDecodeBase64, PublicKey};
-use network::PrimaryNetwork;
+use network::{PrimaryNetwork, UnreliableNetwork};
 use store::{Store, StoreError};
 use thiserror::Error;
 use tokio::{

--- a/primary/src/state_handler.rs
+++ b/primary/src/state_handler.rs
@@ -4,7 +4,7 @@
 use crate::primary::PrimaryWorkerMessage;
 use config::SharedCommittee;
 use crypto::PublicKey;
-use network::PrimaryToWorkerNetwork;
+use network::{PrimaryToWorkerNetwork, UnreliableNetwork};
 use std::sync::{
     atomic::{AtomicU64, Ordering},
     Arc,

--- a/primary/src/tests/block_remover_tests.rs
+++ b/primary/src/tests/block_remover_tests.rs
@@ -78,7 +78,7 @@ async fn test_successful_blocks_delete() {
     let worker_id_1 = 1;
 
     // AND generate headers with distributed batches between 2 workers (0 and 1)
-    for headers in 0..5 {
+    for _headers in 0..5 {
         let batch_1 = fixture_batch_with_transactions(10);
         let batch_2 = fixture_batch_with_transactions(10);
 
@@ -204,7 +204,7 @@ async fn test_timeout() {
     let (tx_commands, rx_commands) = channel(10);
     let (tx_remove_block, mut rx_remove_block) = channel(1);
     let (_tx_consensus, rx_consensus) = channel(1);
-    let (tx_delete_batches, rx_delete_batches) = channel(10);
+    let (_tx_delete_batches, rx_delete_batches) = channel(10);
     let (tx_removed_certificates, _rx_removed_certificates) = channel(10);
 
     // AND the necessary keys
@@ -241,7 +241,7 @@ async fn test_timeout() {
     let worker_id_3 = 3;
 
     // AND generate headers with distributed batches between 2 workers (2 and 3)
-    for headers in 0..5 {
+    for _headers in 0..5 {
         let batch_1 = fixture_batch_with_transactions(10);
         let batch_2 = fixture_batch_with_transactions(10);
 
@@ -339,9 +339,9 @@ async fn test_timeout() {
 async fn test_unlocking_pending_requests() {
     // GIVEN
     let (header_store, certificate_store, payload_store) = create_db_stores();
-    let (tx_commands, rx_commands) = channel(10);
+    let (_tx_commands, rx_commands) = channel(10);
     let (_tx_consensus, rx_consensus) = channel(1);
-    let (tx_delete_batches, rx_delete_batches) = channel(10);
+    let (_tx_delete_batches, rx_delete_batches) = channel(10);
     let (tx_removed_certificates, _rx_removed_certificates) = channel(10);
 
     // AND the necessary keys

--- a/primary/tests/epoch_change.rs
+++ b/primary/tests/epoch_change.rs
@@ -4,7 +4,7 @@ use arc_swap::ArcSwap;
 use config::{Committee, Epoch, Parameters};
 use crypto::traits::KeyPair;
 use futures::future::join_all;
-use network::{CancelOnDropHandler, WorkerToPrimaryNetwork};
+use network::{CancelOnDropHandler, ReliableNetwork, WorkerToPrimaryNetwork};
 use node::NodeStorage;
 use primary::{NetworkModel, Primary, CHANNEL_CAPACITY};
 use prometheus::Registry;

--- a/worker/src/helper.rs
+++ b/worker/src/helper.rs
@@ -4,7 +4,7 @@
 use bytes::Bytes;
 use config::{Committee, WorkerId};
 use crypto::PublicKey;
-use network::WorkerNetwork;
+use network::{UnreliableNetwork, WorkerNetwork};
 use store::Store;
 use tokio::{
     sync::{
@@ -81,7 +81,7 @@ impl Helper {
                     for digest in digests {
                         match self.store.read(digest).await {
                             Ok(Some(data)) => {
-                                let _ = self.network.unreliable_send_message(address.clone(), Bytes::from(data)).await;
+                                let _ = self.network.unreliable_send_message(address.clone(), Bytes::from(data).into()).await;
                             }
                             Ok(None) => {
                                 trace!("No Batches found for requested digests {:?}", digest);

--- a/worker/src/primary_connector.rs
+++ b/worker/src/primary_connector.rs
@@ -4,7 +4,7 @@
 use config::Committee;
 use crypto::PublicKey;
 use futures::{stream::FuturesUnordered, StreamExt};
-use network::WorkerToPrimaryNetwork;
+use network::{ReliableNetwork, WorkerToPrimaryNetwork};
 use tokio::{
     sync::{mpsc::Receiver, watch},
     task::JoinHandle,

--- a/worker/src/quorum_waiter.rs
+++ b/worker/src/quorum_waiter.rs
@@ -4,7 +4,7 @@
 use config::{Committee, Stake, WorkerId};
 use crypto::PublicKey;
 use futures::stream::{futures_unordered::FuturesUnordered, StreamExt as _};
-use network::{CancelOnDropHandler, MessageResult, WorkerNetwork};
+use network::{CancelOnDropHandler, MessageResult, ReliableNetwork, WorkerNetwork};
 use tokio::{
     sync::{
         mpsc::{Receiver, Sender},

--- a/worker/src/synchronizer.rs
+++ b/worker/src/synchronizer.rs
@@ -5,7 +5,7 @@ use crate::metrics::WorkerMetrics;
 use config::{SharedCommittee, WorkerId};
 use crypto::PublicKey;
 use futures::stream::{futures_unordered::FuturesUnordered, StreamExt as _};
-use network::WorkerNetwork;
+use network::{LuckyNetwork, UnreliableNetwork, WorkerNetwork};
 use primary::PrimaryWorkerMessage;
 use std::{
     collections::HashMap,


### PR DESCRIPTION
Puts Primary and Worker Network under the natural trait hierarchy unlocked by #614 (and #612 to a minor degree).

To @arun-koshy 's possible interest, it's now much easier to define / extend a `Network`.