### PR TITLE
refactor: make functions returning join handles `#[must_use]`

### DIFF
--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -210,6 +210,7 @@ impl<Protocol> Consensus<Protocol>
 where
     Protocol: ConsensusProtocol + Send + 'static,
 {
+    #[must_use]
     pub fn spawn(
         committee: Committee,
         store: Arc<ConsensusStore>,

--- a/consensus/src/subscriber.rs
+++ b/consensus/src/subscriber.rs
@@ -37,6 +37,7 @@ pub struct SubscriberHandler {
 
 impl SubscriberHandler {
     /// Spawn a new subscriber handler in a dedicated tokio task.
+    #[must_use]
     pub fn spawn(
         consensus_store: Arc<ConsensusStore>,
         certificate_store: CertificateStore,

--- a/consensus/src/tests/bullshark_tests.rs
+++ b/consensus/src/tests/bullshark_tests.rs
@@ -83,7 +83,7 @@ async fn commit_one() {
     let gc_depth = 50;
     let bullshark = Bullshark::new(committee.clone(), store.clone(), gc_depth);
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
-    Consensus::spawn(
+    let _consensus_handle = Consensus::spawn(
         committee,
         store,
         cert_store,
@@ -147,7 +147,7 @@ async fn dead_node() {
     let bullshark = Bullshark::new(committee.clone(), store.clone(), gc_depth);
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
 
-    Consensus::spawn(
+    let _consensus_handle = Consensus::spawn(
         committee,
         store,
         cert_store,
@@ -257,7 +257,7 @@ async fn not_enough_support() {
     let bullshark = Bullshark::new(committee.clone(), store.clone(), gc_depth);
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
 
-    Consensus::spawn(
+    let _consensus_handle = Consensus::spawn(
         committee,
         store,
         cert_store,
@@ -341,7 +341,7 @@ async fn missing_leader() {
     let bullshark = Bullshark::new(committee.clone(), store.clone(), gc_depth);
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
 
-    Consensus::spawn(
+    let _consensus_handle = Consensus::spawn(
         committee,
         store,
         cert_store,
@@ -401,7 +401,7 @@ async fn epoch_change() {
     let gc_depth = 50;
     let bullshark = Bullshark::new(committee.clone(), store.clone(), gc_depth);
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
-    Consensus::spawn(
+    let _consensus_handle = Consensus::spawn(
         committee.clone(),
         store,
         cert_store,

--- a/consensus/src/tests/tusk_tests.rs
+++ b/consensus/src/tests/tusk_tests.rs
@@ -82,7 +82,7 @@ async fn commit_one() {
     let tusk = Tusk::new(committee.clone(), store.clone(), gc_depth);
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
 
-    Consensus::spawn(
+    let _consensus_handle = Consensus::spawn(
         committee,
         store,
         cert_store,
@@ -146,7 +146,7 @@ async fn dead_node() {
     let tusk = Tusk::new(committee.clone(), store.clone(), gc_depth);
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
 
-    Consensus::spawn(
+    let _consensus_handle = Consensus::spawn(
         committee,
         store,
         cert_store,
@@ -254,7 +254,7 @@ async fn not_enough_support() {
     let tusk = Tusk::new(committee.clone(), store.clone(), gc_depth);
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
 
-    Consensus::spawn(
+    let _consensus_handle = Consensus::spawn(
         committee,
         store,
         cert_store,
@@ -335,7 +335,7 @@ async fn missing_leader() {
     let gc_depth = 50;
     let tusk = Tusk::new(committee.clone(), store.clone(), gc_depth);
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
-    Consensus::spawn(
+    let _consensus_handle = Consensus::spawn(
         committee,
         store,
         cert_store,
@@ -395,7 +395,7 @@ async fn epoch_change() {
     let gc_depth = 50;
     let tusk = Tusk::new(committee.clone(), store.clone(), gc_depth);
     let metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
-    Consensus::spawn(
+    let _consensus_handle = Consensus::spawn(
         committee.clone(),
         store,
         cert_store,

--- a/executor/src/batch_loader.rs
+++ b/executor/src/batch_loader.rs
@@ -40,6 +40,7 @@ pub struct BatchLoader {
 
 impl BatchLoader {
     /// Spawn a new batch loaded in a dedicated tokio task.
+    #[must_use]
     pub fn spawn(
         store: Store<BatchDigest, SerializedBatchMessage>,
         rx_reconfigure: watch::Receiver<ReconfigureNotification>,

--- a/executor/src/core.rs
+++ b/executor/src/core.rs
@@ -57,6 +57,7 @@ where
     State::Error: Debug,
 {
     /// Spawn a new executor in a dedicated tokio task.
+    #[must_use]
     pub fn spawn(
         store: Store<BatchDigest, SerializedBatchMessage>,
         execution_state: Arc<State>,

--- a/executor/src/subscriber.rs
+++ b/executor/src/subscriber.rs
@@ -49,6 +49,7 @@ pub struct Subscriber {
 
 impl Subscriber {
     /// Spawn a new subscriber in a new tokio task.
+    #[must_use]
     pub fn spawn(
         store: Store<BatchDigest, SerializedBatchMessage>,
         rx_reconfigure: watch::Receiver<ReconfigureNotification>,

--- a/executor/src/tests/executor_tests.rs
+++ b/executor/src/tests/executor_tests.rs
@@ -23,7 +23,7 @@ async fn execute_transactions() {
     // Spawn the executor.
     let store = test_store();
     let execution_state = Arc::new(TestState::default());
-    Core::<TestState>::spawn(
+    let _core_handle = Core::<TestState>::spawn(
         store.clone(),
         execution_state.clone(),
         rx_reconfigure,
@@ -70,7 +70,7 @@ async fn execute_empty_certificate() {
     // Spawn the executor.
     let store = test_store();
     let execution_state = Arc::new(TestState::default());
-    Core::<TestState>::spawn(
+    let _core_handle = Core::<TestState>::spawn(
         store.clone(),
         execution_state.clone(),
         rx_reconfigure,
@@ -126,7 +126,7 @@ async fn execute_malformed_transactions() {
     // Spawn the executor.
     let store = test_store();
     let execution_state = Arc::new(TestState::default());
-    Core::<TestState>::spawn(
+    let _core_handle = Core::<TestState>::spawn(
         store.clone(),
         execution_state.clone(),
         rx_reconfigure,
@@ -188,7 +188,7 @@ async fn internal_error_execution() {
     // Spawn the executor.
     let store = test_store();
     let execution_state = Arc::new(TestState::default());
-    Core::<TestState>::spawn(
+    let _core_hanlde = Core::<TestState>::spawn(
         store.clone(),
         execution_state.clone(),
         rx_reconfigure,
@@ -240,7 +240,7 @@ async fn crash_recovery() {
     // Spawn the executor.
     let store = test_store();
     let execution_state = Arc::new(TestState::default());
-    Core::<TestState>::spawn(
+    let _core_handle = Core::<TestState>::spawn(
         store.clone(),
         execution_state.clone(),
         rx_reconfigure,
@@ -295,7 +295,7 @@ async fn crash_recovery() {
     let (tx_output, mut rx_output) = channel(10);
     let (_tx_reconfigure, rx_reconfigure) = watch::channel(reconfigure_notification);
 
-    Core::<TestState>::spawn(
+    let _core_handle = Core::<TestState>::spawn(
         store.clone(),
         execution_state.clone(),
         rx_reconfigure,

--- a/executor/src/tests/subscriber_tests.rs
+++ b/executor/src/tests/subscriber_tests.rs
@@ -31,7 +31,7 @@ async fn spawn_consensus_and_subscriber(
     // Spawn a test subscriber.
     let store = test_store();
     let next_consensus_index = SequenceNumber::default();
-    Subscriber::spawn(
+    let _subsscriber_handle = Subscriber::spawn(
         store.clone(),
         rx_reconfigure,
         rx_consensus_to_client,
@@ -126,7 +126,7 @@ async fn synchronize() {
     // Spawn a subscriber.
     let store = test_store();
     let next_consensus_index = SequenceNumber::default();
-    Subscriber::spawn(
+    let _subscriber_handle = Subscriber::spawn(
         store.clone(),
         rx_reconfigure,
         rx_consensus_to_client,

--- a/network/src/bounded_executor.rs
+++ b/network/src/bounded_executor.rs
@@ -107,6 +107,7 @@ impl BoundedExecutor {
         }
     }
 
+    #[must_use]
     fn spawn_with_permit<F>(
         &self,
         f: F,
@@ -148,6 +149,7 @@ impl BoundedExecutor {
     /// TODO: this still spawns one task, unconditionally, per call.
     /// We would instead like to have one central task that drives all retries
     /// for the whole executor.
+    #[must_use]
     pub(crate) fn spawn_with_retries<F, Fut, T, E>(
         &self,
         retry_config: crate::RetryConfig,

--- a/node/src/metrics.rs
+++ b/node/src/metrics.rs
@@ -28,6 +28,7 @@ pub fn worker_metrics_registry(worker_id: WorkerId, name: PublicKey) -> Registry
     Registry::new_custom(Some(WORKER_METRICS_PREFIX.to_string()), Some(labels)).unwrap()
 }
 
+#[must_use]
 pub fn start_prometheus_server(addr: Multiaddr, registry: &Registry) -> JoinHandle<()> {
     let app = Router::new()
         .route(METRICS_ROUTE, get(metrics))

--- a/primary/src/block_remover.rs
+++ b/primary/src/block_remover.rs
@@ -225,6 +225,7 @@ pub struct BlockRemover {
 }
 
 impl BlockRemover {
+    #[must_use]
     pub fn spawn(
         name: PublicKey,
         committee: Committee,

--- a/primary/src/block_synchronizer/mod.rs
+++ b/primary/src/block_synchronizer/mod.rs
@@ -199,6 +199,7 @@ pub struct BlockSynchronizer {
 }
 
 impl BlockSynchronizer {
+    #[must_use]
     pub fn spawn(
         name: PublicKey,
         committee: Committee,

--- a/primary/src/block_synchronizer/tests/block_synchronizer_tests.rs
+++ b/primary/src/block_synchronizer/tests/block_synchronizer_tests.rs
@@ -72,7 +72,7 @@ async fn test_successful_headers_synchronization() {
     }
 
     // AND create the synchronizer
-    BlockSynchronizer::spawn(
+    let _synchronizer_handle = BlockSynchronizer::spawn(
         name.clone(),
         committee.clone(),
         rx_reconfigure,
@@ -228,7 +228,7 @@ async fn test_successful_payload_synchronization() {
     }
 
     // AND create the synchronizer
-    BlockSynchronizer::spawn(
+    let _synchronizer_handle = BlockSynchronizer::spawn(
         name.clone(),
         committee.clone(),
         rx_reconfigure,
@@ -527,7 +527,7 @@ async fn test_timeout_while_waiting_for_certificates() {
         .collect();
 
     // AND create the synchronizer
-    BlockSynchronizer::spawn(
+    let _synchronizer_handle = BlockSynchronizer::spawn(
         name.clone(),
         committee.clone(),
         rx_reconfigure,
@@ -882,6 +882,7 @@ async fn test_reply_with_payload_already_in_storage_for_own_certificates() {
     }
 }
 
+#[must_use]
 pub fn primary_listener<T>(
     num_of_expected_responses: i32,
     address: multiaddr::Multiaddr,

--- a/primary/src/block_waiter.rs
+++ b/primary/src/block_waiter.rs
@@ -249,6 +249,7 @@ pub struct BlockWaiter<SynchronizerHandler: Handler + Send + Sync + 'static> {
 impl<SynchronizerHandler: Handler + Send + Sync + 'static> BlockWaiter<SynchronizerHandler> {
     // Create a new waiter and start listening on incoming
     // commands to fetch a block
+    #[must_use]
     pub fn spawn(
         name: PublicKey,
         committee: Committee,

--- a/primary/src/certificate_waiter.rs
+++ b/primary/src/certificate_waiter.rs
@@ -63,6 +63,7 @@ pub struct CertificateWaiter {
 }
 
 impl CertificateWaiter {
+    #[must_use]
     pub fn spawn(
         committee: Committee,
         store: Store<CertificateDigest, Certificate>,

--- a/primary/src/core.rs
+++ b/primary/src/core.rs
@@ -93,6 +93,7 @@ pub struct Core {
 
 impl Core {
     #[allow(clippy::too_many_arguments)]
+    #[must_use]
     pub fn spawn(
         name: PublicKey,
         committee: Committee,

--- a/primary/src/grpc_server/mod.rs
+++ b/primary/src/grpc_server/mod.rs
@@ -37,6 +37,7 @@ pub struct ConsensusAPIGrpc<SynchronizerHandler: Handler + Send + Sync + 'static
 }
 
 impl<SynchronizerHandler: Handler + Send + Sync + 'static> ConsensusAPIGrpc<SynchronizerHandler> {
+    #[must_use]
     pub fn spawn(
         name: PublicKey,
         socket_address: Multiaddr,

--- a/primary/src/header_waiter.rs
+++ b/primary/src/header_waiter.rs
@@ -95,6 +95,7 @@ pub struct HeaderWaiter {
 }
 
 impl HeaderWaiter {
+    #[must_use]
     pub fn spawn(
         name: PublicKey,
         committee: Committee,

--- a/primary/src/helper.rs
+++ b/primary/src/helper.rs
@@ -50,6 +50,7 @@ pub struct Helper {
 }
 
 impl Helper {
+    #[must_use]
     pub fn spawn(
         name: PublicKey,
         committee: Committee,

--- a/primary/src/payload_receiver.rs
+++ b/primary/src/payload_receiver.rs
@@ -17,6 +17,7 @@ pub struct PayloadReceiver {
 }
 
 impl PayloadReceiver {
+    #[must_use]
     pub fn spawn(
         store: Store<(BatchDigest, WorkerId), PayloadToken>,
         rx_workers: Receiver<(BatchDigest, WorkerId)>,

--- a/primary/src/primary.rs
+++ b/primary/src/primary.rs
@@ -433,6 +433,7 @@ impl PrimaryReceiverHandler {
         }
     }
 
+    #[must_use]
     fn spawn(
         self,
         address: Multiaddr,
@@ -539,6 +540,7 @@ impl WorkerReceiverHandler {
         }
     }
 
+    #[must_use]
     fn spawn(
         self,
         address: Multiaddr,

--- a/primary/src/proposer.rs
+++ b/primary/src/proposer.rs
@@ -63,6 +63,7 @@ pub struct Proposer {
 
 impl Proposer {
     #[allow(clippy::too_many_arguments)]
+    #[must_use]
     pub fn spawn(
         name: PublicKey,
         committee: Committee,

--- a/primary/src/state_handler.rs
+++ b/primary/src/state_handler.rs
@@ -36,6 +36,7 @@ pub struct StateHandler {
 }
 
 impl StateHandler {
+    #[must_use]
     pub fn spawn(
         name: PublicKey,
         committee: SharedCommittee,

--- a/primary/src/tests/block_remover_tests.rs
+++ b/primary/src/tests/block_remover_tests.rs
@@ -52,7 +52,7 @@ async fn test_successful_blocks_delete() {
     let dag = Arc::new(Dag::new(&committee, rx_consensus, consensus_metrics).1);
     populate_genesis(&dag, &committee).await;
 
-    BlockRemover::spawn(
+    let _remover_handler = BlockRemover::spawn(
         name.clone(),
         committee.clone(),
         certificate_store.clone(),
@@ -216,7 +216,7 @@ async fn test_timeout() {
     let dag = Arc::new(Dag::new(&committee, rx_consensus, consensus_metrics).1);
     populate_genesis(&dag, &committee).await;
 
-    BlockRemover::spawn(
+    let _remover_handler = BlockRemover::spawn(
         name.clone(),
         committee.clone(),
         certificate_store.clone(),
@@ -452,6 +452,7 @@ async fn test_unlocking_pending_requests() {
     assert!(remover.map_tx_removal_results.is_empty());
 }
 
+#[must_use]
 pub fn worker_listener(
     address: multiaddr::Multiaddr,
     expected_batch_ids: Vec<BatchDigest>,

--- a/primary/src/tests/block_waiter_tests.rs
+++ b/primary/src/tests/block_waiter_tests.rs
@@ -84,7 +84,7 @@ async fn test_successfully_retrieve_block() {
         .times(1)
         .return_const(vec![Ok(certificate)]);
 
-    BlockWaiter::spawn(
+    let _waiter_handler = BlockWaiter::spawn(
         name.clone(),
         committee.clone(),
         rx_reconfigure,
@@ -250,7 +250,7 @@ async fn test_successfully_retrieve_multiple_blocks() {
         .times(1)
         .return_const(expected_result);
 
-    BlockWaiter::spawn(
+    let _waiter_handler = BlockWaiter::spawn(
         name.clone(),
         committee.clone(),
         rx_reconfigure,
@@ -469,7 +469,7 @@ async fn test_batch_timeout() {
         .times(1)
         .return_const(vec![Ok(certificate)]);
 
-    BlockWaiter::spawn(
+    let _waiter_handle = BlockWaiter::spawn(
         name.clone(),
         committee.clone(),
         rx_reconfigure,
@@ -531,7 +531,7 @@ async fn test_return_error_when_certificate_is_missing() {
         .times(1)
         .return_const(vec![Err(handler::Error::BlockDeliveryTimeout { block_id })]);
 
-    BlockWaiter::spawn(
+    let _waiter_handle = BlockWaiter::spawn(
         name.clone(),
         committee.clone(),
         rx_reconfigure,
@@ -601,7 +601,7 @@ async fn test_return_error_when_certificate_is_missing_when_get_blocks() {
         .times(1)
         .return_const(vec![]);
 
-    BlockWaiter::spawn(
+    let _waiter_handle = BlockWaiter::spawn(
         name.clone(),
         committee.clone(),
         rx_reconfigure,
@@ -641,6 +641,7 @@ async fn test_return_error_when_certificate_is_missing_when_get_blocks() {
 
 // worker_listener listens to TCP requests. The worker responds to the
 // RequestBatch requests for the provided expected_batches.
+#[must_use]
 pub fn worker_listener(
     address: multiaddr::Multiaddr,
     expected_batches: HashMap<BatchDigest, BatchMessage>,

--- a/primary/src/tests/certificate_waiter_tests.rs
+++ b/primary/src/tests/certificate_waiter_tests.rs
@@ -66,7 +66,7 @@ async fn process_certificate_missing_parents_in_reverse() {
     let gc_depth: Round = 50;
 
     // Make a headerWaiter
-    HeaderWaiter::spawn(
+    let _header_waiter_handle = HeaderWaiter::spawn(
         name.clone(),
         committee(None),
         certificates_store.clone(),
@@ -84,7 +84,7 @@ async fn process_certificate_missing_parents_in_reverse() {
     );
 
     // Make a certificate waiter
-    CertificateWaiter::spawn(
+    let _certificate_waiter_handle = CertificateWaiter::spawn(
         committee(None),
         certificates_store.clone(),
         consensus_round.clone(),
@@ -96,7 +96,7 @@ async fn process_certificate_missing_parents_in_reverse() {
     );
 
     // Spawn the core.
-    Core::spawn(
+    let _core_handle = Core::spawn(
         name.clone(),
         committee(None),
         header_store.clone(),
@@ -207,7 +207,7 @@ async fn process_certificate_check_gc_fires() {
     let gc_depth: Round = 50;
 
     // Make a headerWaiter
-    HeaderWaiter::spawn(
+    let _header_waiter_handle = HeaderWaiter::spawn(
         name.clone(),
         committee(None),
         certificates_store.clone(),
@@ -225,7 +225,7 @@ async fn process_certificate_check_gc_fires() {
     );
 
     // Make a certificate waiter
-    CertificateWaiter::spawn(
+    let _certficate_waiter_handle = CertificateWaiter::spawn(
         committee(None),
         certificates_store.clone(),
         consensus_round.clone(),
@@ -237,7 +237,7 @@ async fn process_certificate_check_gc_fires() {
     );
 
     // Spawn the core.
-    Core::spawn(
+    let _core_handle = Core::spawn(
         name.clone(),
         committee(None),
         header_store.clone(),

--- a/primary/src/tests/common.rs
+++ b/primary/src/tests/common.rs
@@ -33,6 +33,7 @@ pub fn create_db_stores() -> (
     )
 }
 
+#[must_use]
 pub fn worker_listener<T>(
     num_of_expected_responses: i32,
     address: multiaddr::Multiaddr,

--- a/primary/src/tests/core_tests.rs
+++ b/primary/src/tests/core_tests.rs
@@ -60,7 +60,7 @@ async fn process_header() {
     let metrics = Arc::new(PrimaryMetrics::new(&Registry::new()));
 
     // Spawn the core.
-    Core::spawn(
+    let _core_handle = Core::spawn(
         name,
         committee.clone(),
         header_store.clone(),
@@ -140,7 +140,7 @@ async fn process_header_missing_parent() {
     let metrics = Arc::new(PrimaryMetrics::new(&Registry::new()));
 
     // Spawn the core.
-    Core::spawn(
+    let _core_handle = Core::spawn(
         name.clone(),
         committee(None),
         header_store.clone(),
@@ -216,7 +216,7 @@ async fn process_header_missing_payload() {
     let metrics = Arc::new(PrimaryMetrics::new(&Registry::new()));
 
     // Spawn the core.
-    Core::spawn(
+    let _core_handle = Core::spawn(
         name.clone(),
         committee(None),
         header_store.clone(),
@@ -304,7 +304,7 @@ async fn process_votes() {
     let metrics = Arc::new(PrimaryMetrics::new(&Registry::new()));
 
     // Spawn the core.
-    Core::spawn(
+    let _core_handle = Core::spawn(
         name.clone(),
         committee.clone(),
         header_store.clone(),
@@ -397,7 +397,7 @@ async fn process_certificates() {
     let metrics = Arc::new(PrimaryMetrics::new(&Registry::new()));
 
     // Spawn the core.
-    Core::spawn(
+    let _core_handle = Core::spawn(
         name,
         committee(None),
         header_store.clone(),
@@ -576,7 +576,7 @@ async fn reconfigure_core() {
     );
 
     // Spawn the core.
-    Core::spawn(
+    let _core_handle = Core::spawn(
         name,
         committee.clone(),
         header_store.clone(),

--- a/primary/src/tests/header_waiter_tests.rs
+++ b/primary/src/tests/header_waiter_tests.rs
@@ -31,7 +31,7 @@ async fn successfully_synchronize_batches() {
     let (tx_core, mut rx_core) = channel(10);
     let metrics = Arc::new(PrimaryMetrics::new(&Registry::new()));
 
-    HeaderWaiter::spawn(
+    let _header_waiter_handle = HeaderWaiter::spawn(
         name.clone(),
         committee.clone(),
         certificate_store,

--- a/primary/src/tests/helper_tests.rs
+++ b/primary/src/tests/helper_tests.rs
@@ -35,7 +35,7 @@ async fn test_process_certificates_stream_mode() {
     let (tx_primaries, rx_primaries) = channel(10);
 
     // AND a helper
-    Helper::spawn(
+    let _helper_handle = Helper::spawn(
         name.clone(),
         committee.clone(),
         certificate_store.clone(),
@@ -111,7 +111,7 @@ async fn test_process_certificates_batch_mode() {
     let (tx_primaries, rx_primaries) = channel(10);
 
     // AND a helper
-    Helper::spawn(
+    let _helper_handle = Helper::spawn(
         name.clone(),
         committee.clone(),
         certificate_store.clone(),
@@ -208,7 +208,7 @@ async fn test_process_payload_availability_success() {
     let (tx_primaries, rx_primaries) = channel(10);
 
     // AND a helper
-    Helper::spawn(
+    let _helper_handle = Helper::spawn(
         name.clone(),
         committee.clone(),
         certificate_store.clone(),
@@ -324,7 +324,7 @@ async fn test_process_payload_availability_when_failures() {
     let (tx_primaries, rx_primaries) = channel(10);
 
     // AND a helper
-    Helper::spawn(
+    let _helper_handle = Helper::spawn(
         name.clone(),
         committee.clone(),
         certificate_store.clone(),

--- a/primary/src/tests/proposer_tests.rs
+++ b/primary/src/tests/proposer_tests.rs
@@ -22,7 +22,7 @@ async fn propose_empty() {
     let metrics = Arc::new(PrimaryMetrics::new(&Registry::new()));
 
     // Spawn the proposer.
-    Proposer::spawn(
+    let _proposer_handle = Proposer::spawn(
         name,
         committee(None),
         signature_service,
@@ -58,7 +58,7 @@ async fn propose_payload() {
     let metrics = Arc::new(PrimaryMetrics::new(&Registry::new()));
 
     // Spawn the proposer.
-    Proposer::spawn(
+    let _proposer_handle = Proposer::spawn(
         name.clone(),
         committee(None),
         signature_service,

--- a/worker/src/batch_maker.rs
+++ b/worker/src/batch_maker.rs
@@ -39,6 +39,7 @@ pub struct BatchMaker {
 }
 
 impl BatchMaker {
+    #[must_use]
     pub fn spawn(
         committee: Committee,
         batch_size: usize,

--- a/worker/src/helper.rs
+++ b/worker/src/helper.rs
@@ -39,6 +39,7 @@ pub struct Helper {
 }
 
 impl Helper {
+    #[must_use]
     pub fn spawn(
         id: WorkerId,
         committee: Committee,

--- a/worker/src/primary_connector.rs
+++ b/worker/src/primary_connector.rs
@@ -29,6 +29,7 @@ pub struct PrimaryConnector {
 }
 
 impl PrimaryConnector {
+    #[must_use]
     pub fn spawn(
         name: PublicKey,
         committee: Committee,

--- a/worker/src/processor.rs
+++ b/worker/src/processor.rs
@@ -25,6 +25,7 @@ pub mod processor_tests;
 pub struct Processor;
 
 impl Processor {
+    #[must_use]
     pub fn spawn(
         // Our worker's id.
         id: WorkerId,

--- a/worker/src/quorum_waiter.rs
+++ b/worker/src/quorum_waiter.rs
@@ -40,6 +40,7 @@ pub struct QuorumWaiter {
 
 impl QuorumWaiter {
     /// Spawn a new QuorumWaiter.
+    #[must_use]
     pub fn spawn(
         name: PublicKey,
         id: WorkerId,

--- a/worker/src/synchronizer.rs
+++ b/worker/src/synchronizer.rs
@@ -70,6 +70,7 @@ pub struct Synchronizer {
 }
 
 impl Synchronizer {
+    #[must_use]
     pub fn spawn(
         name: PublicKey,
         id: WorkerId,

--- a/worker/src/tests/batch_maker_tests.rs
+++ b/worker/src/tests/batch_maker_tests.rs
@@ -14,7 +14,7 @@ async fn make_batch() {
     let (tx_message, mut rx_message) = channel(1);
 
     // Spawn a `BatchMaker` instance.
-    BatchMaker::spawn(
+    let _batch_maker_handle = BatchMaker::spawn(
         committee,
         /* max_batch_size */ 200,
         /* max_batch_delay */
@@ -44,7 +44,7 @@ async fn batch_timeout() {
     let (tx_message, mut rx_message) = channel(1);
 
     // Spawn a `BatchMaker` instance.
-    BatchMaker::spawn(
+    let _batch_maker_handle = BatchMaker::spawn(
         committee,
         /* max_batch_size */ 200,
         /* max_batch_delay */

--- a/worker/src/tests/helper_tests.rs
+++ b/worker/src/tests/helper_tests.rs
@@ -37,7 +37,7 @@ async fn worker_batch_reply() {
     store.write(batch_digest, serialized_batch.clone()).await;
 
     // Spawn an `Helper` instance.
-    Helper::spawn(
+    let _helper_handle = Helper::spawn(
         id,
         committee.clone(),
         store,
@@ -85,7 +85,7 @@ async fn client_batch_reply() {
     store.write(batch_digest, serialized_batch.clone()).await;
 
     // Spawn an `Helper` instance.
-    Helper::spawn(
+    let _helper_handler = Helper::spawn(
         id,
         committee.clone(),
         store,

--- a/worker/src/tests/processor_tests.rs
+++ b/worker/src/tests/processor_tests.rs
@@ -28,7 +28,7 @@ async fn hash_and_store() {
 
     // Spawn a new `Processor` instance.
     let id = 0;
-    Processor::spawn(
+    let _processor_handler = Processor::spawn(
         id,
         store.clone(),
         rx_reconfiguration,

--- a/worker/src/tests/quorum_waiter_tests.rs
+++ b/worker/src/tests/quorum_waiter_tests.rs
@@ -18,7 +18,7 @@ async fn wait_for_quorum() {
         watch::channel(ReconfigureNotification::NewCommittee(committee.clone()));
 
     // Spawn a `QuorumWaiter` instance.
-    QuorumWaiter::spawn(
+    let _quorum_waiter_handler = QuorumWaiter::spawn(
         myself.clone(),
         /* worker_id */ 0,
         committee.clone(),

--- a/worker/src/tests/synchronizer_tests.rs
+++ b/worker/src/tests/synchronizer_tests.rs
@@ -31,7 +31,7 @@ async fn synchronize() {
     let metrics = Arc::new(WorkerMetrics::new(&Registry::new()));
 
     // Spawn a `Synchronizer` instance.
-    Synchronizer::spawn(
+    let _synchronizer_handle = Synchronizer::spawn(
         name.clone(),
         id,
         Arc::new(ArcSwap::from_pointee(committee.clone())),
@@ -82,7 +82,7 @@ async fn test_successful_request_batch() {
     let metrics = Arc::new(WorkerMetrics::new(&Registry::new()));
 
     // Spawn a `Synchronizer` instance.
-    Synchronizer::spawn(
+    let _synchronizer_handle = Synchronizer::spawn(
         name.clone(),
         id,
         Arc::new(ArcSwap::from_pointee(committee.clone())),
@@ -145,7 +145,7 @@ async fn test_request_batch_not_found() {
     let metrics = Arc::new(WorkerMetrics::new(&Registry::new()));
 
     // Spawn a `Synchronizer` instance.
-    Synchronizer::spawn(
+    let _synchronizer_handle = Synchronizer::spawn(
         name.clone(),
         id,
         Arc::new(ArcSwap::from_pointee(committee.clone())),
@@ -207,7 +207,7 @@ async fn test_successful_batch_delete() {
     let metrics = Arc::new(WorkerMetrics::new(&Registry::new()));
 
     // Spawn a `Synchronizer` instance.
-    Synchronizer::spawn(
+    let _synchronizer_handle = Synchronizer::spawn(
         name.clone(),
         id,
         Arc::new(ArcSwap::from_pointee(committee.clone())),

--- a/worker/src/worker.rs
+++ b/worker/src/worker.rs
@@ -343,6 +343,7 @@ impl TxReceiverHandler {
         }
     }
 
+    #[must_use]
     fn spawn(
         self,
         address: Multiaddr,
@@ -419,6 +420,7 @@ impl WorkerReceiverHandler {
         }
     }
 
+    #[must_use]
     fn spawn(
         self,
         address: Multiaddr,
@@ -525,6 +527,7 @@ impl PrimaryReceiverHandler {
         }
     }
 
+    #[must_use]
     fn spawn(
         self,
         address: Multiaddr,


### PR DESCRIPTION
This should make the scoping and termination of tasks (which will be key to MystenLabs/sui#5313) clearer to analyze.

(Along with MystenLabs/narwhal#427 and MystenLabs/narwhal#428, ) Closes MystenLabs/narwhal#77.