### PR TITLE
Revert "Laura/eliminate recursion (#376)"

### DIFF
--- a/dag/Cargo.toml
+++ b/dag/Cargo.toml
@@ -16,6 +16,7 @@ thiserror = "1.0.31"
 arc-swap = "1.5.0"
 once_cell = "1.13.0"
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
+rayon = "1.5.3"
 
 [dev-dependencies]
 hex = "0.4.3"


### PR DESCRIPTION
This reverts commit b93014c8a4f516d94adddbd285079fbcbe97a89c.

MystenLabs/narwhal#376 changed the path compression algorithm from a recursive depth-first traversal that modified *all* the nodes with compressible children along the traversal, to a stack-based breadth first search that modifies the single node passed as an initial argument.

As a consequence, the cost of each call to `parents()` on a distinct receiver is linear, whereas before, the call to parents would be linear, amortized over all calls.

Reverting to the original until we find a better solution to MystenLabs/sui#5259. Fixes MystenLabs/narwhal#611 