### PR TITLE
[primary] Aggressive pruning of old message cancel handles 

### DIFF
--- a/benchmark/benchmark/logs.py
+++ b/benchmark/benchmark/logs.py
@@ -158,7 +158,7 @@ class LogParser:
         return sizes, samples, ip
 
     def _to_posix(self, string):
-        x = parser.isoparse(string)
+        x = parser.isoparse(string[:24])
         return datetime.timestamp(x)
 
     def _consensus_throughput(self):

--- a/primary/src/core.rs
+++ b/primary/src/core.rs
@@ -424,10 +424,11 @@ impl Core {
                 .await
                 .map_err(|_| DagError::ShuttingDown)?;
             
-            debug!("Cancel Handlers len: {}", self.cancel_handlers.len());
-            if certificate.round() > 0 {
-                self.cancel_handlers.retain(|k, _| *k > certificate.round()-1);
-            }
+                let before = self.cancel_handlers.len();
+                if certificate.round() > 0 {
+                    self.cancel_handlers.retain(|k, _| *k >= certificate.round());
+                }
+                debug!("Pruned {} messages from obsolete rounds.", self.cancel_handlers.len() - before);
         }
 
         // Send it to the consensus layer.

--- a/primary/src/core.rs
+++ b/primary/src/core.rs
@@ -427,7 +427,7 @@ impl Core {
             let before = self.cancel_handlers.len();
             if certificate.round() > 0 {
                 self.cancel_handlers
-                    .retain(|k, _| *k >= certificate.round());
+                    .retain(|k, _| *k >= certificate.round()-1);
             }
             debug!(
                 "Pruned {} messages from obsolete rounds.",

--- a/primary/src/core.rs
+++ b/primary/src/core.rs
@@ -423,12 +423,16 @@ impl Core {
                 .send((parents, certificate.round(), certificate.epoch()))
                 .await
                 .map_err(|_| DagError::ShuttingDown)?;
-            
-                let before = self.cancel_handlers.len();
-                if certificate.round() > 0 {
-                    self.cancel_handlers.retain(|k, _| *k >= certificate.round());
-                }
-                debug!("Pruned {} messages from obsolete rounds.", self.cancel_handlers.len() - before);
+
+            let before = self.cancel_handlers.len();
+            if certificate.round() > 0 {
+                self.cancel_handlers
+                    .retain(|k, _| *k >= certificate.round());
+            }
+            debug!(
+                "Pruned {} messages from obsolete rounds.",
+                self.cancel_handlers.len() - before
+            );
         }
 
         // Send it to the consensus layer.

--- a/primary/src/core.rs
+++ b/primary/src/core.rs
@@ -423,6 +423,11 @@ impl Core {
                 .send((parents, certificate.round(), certificate.epoch()))
                 .await
                 .map_err(|_| DagError::ShuttingDown)?;
+            
+            debug!("Cancel Handlers len: {}", self.cancel_handlers.len());
+            if certificate.round() > 0 {
+                self.cancel_handlers.retain(|k, _| *k > certificate.round()-1);
+            }
         }
 
         // Send it to the consensus layer.

--- a/primary/src/core.rs
+++ b/primary/src/core.rs
@@ -427,7 +427,7 @@ impl Core {
             let before = self.cancel_handlers.len();
             if certificate.round() > 0 {
                 self.cancel_handlers
-                    .retain(|k, _| *k >= certificate.round()-1);
+                    .retain(|k, _| *k >= certificate.round() - 1);
             }
             debug!(
                 "Pruned {} messages from obsolete rounds.",


### PR DESCRIPTION
Once the primary receives a valid certificate for round X, there is no more point to wait for messages that were received in rounds lower than X to advance rounds and the DAG. Any missing information ging forward might be re-requested under a higher round number, or by other subsystems like synchronizer that only gets messages GCed after a commit.