### PR TITLE
[crypto] accept references in batch verification

### DIFF
--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -397,7 +397,7 @@ impl Committee {
         self.authorities
             .iter()
             .filter(|(name, _)| *name != myself)
-            .map(|(name, authority)| (name.deref().clone(), authority.primary.clone()))
+            .map(|(name, authority)| (name.clone(), authority.primary.clone()))
             .collect()
     }
 
@@ -446,7 +446,7 @@ impl Committee {
                     .workers
                     .iter()
                     .find(|(worker_id, _)| worker_id == &id)
-                    .map(|(_, addresses)| (name.deref().clone(), addresses.clone()))
+                    .map(|(_, addresses)| (name.clone(), addresses.clone()))
             })
             .collect()
     }

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -7,6 +7,7 @@
     rust_2018_idioms,
     rust_2021_compatibility
 )]
+#![allow(clippy::mutable_key_type)]
 
 use arc_swap::ArcSwap;
 use crypto::{traits::EncodeDecodeBase64, PublicKey};
@@ -320,6 +321,7 @@ pub struct Authority {
 
 pub type SharedCommittee = Arc<ArcSwap<Committee>>;
 
+#[allow(clippy::mutable_key_type)]
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct Committee {
     /// The authorities of epoch.
@@ -491,6 +493,7 @@ impl Committee {
     /// Update the networking information of some of the primaries. The arguments are a full vector of
     /// authorities which Public key and Stake must match the one stored in the current Committee. Any discrepancy
     /// will generate no update and return a vector of errors.
+    #[allow(clippy::mutable_key_type)]
     pub fn update_primary_network_info(
         &mut self,
         mut new_info: BTreeMap<PublicKey, (Stake, PrimaryAddresses)>,
@@ -511,6 +514,7 @@ impl Committee {
         let res = table
             .iter()
             .fold(Ok(BTreeMap::new()), |acc, (pk, authority)| {
+                #[allow(mutable-key-type)]
                 if let Some((stake, addresses)) = new_info.remove(pk) {
                     if stake == authority.stake {
                         match acc {

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -16,7 +16,6 @@ use std::{
     collections::{BTreeMap, HashMap, HashSet},
     fs::{self, OpenOptions},
     io::{BufWriter, Write as _},
-    ops::Deref,
     sync::Arc,
     time::Duration,
 };

--- a/crypto/src/bls12377/mod.rs
+++ b/crypto/src/bls12377/mod.rs
@@ -546,18 +546,25 @@ impl AggregateAuthenticator for BLS12377AggregateSignature {
         Ok(())
     }
 
-    fn batch_verify(
-        signatures: &[Self],
-        pks: &[&[Self::PubKey]],
+    fn batch_verify<'a>(
+        signatures: &[&Self],
+        pks: Vec<impl Iterator<Item = &'a Self::PubKey>>,
         messages: &[&[u8]],
     ) -> Result<(), signature::Error> {
         if pks.len() != messages.len() || messages.len() != signatures.len() {
             return Err(signature::Error::new());
         }
+        let mut pk_iter = pks.into_iter();
         for i in 0..signatures.len() {
             let sig = signatures[i].sig.clone();
             let mut cache = celo_bls::PublicKeyCache::new();
-            let apk = cache.aggregate(pks[i].iter().map(|pk| pk.pubkey.clone()).collect());
+            let apk = cache.aggregate(
+                pk_iter
+                    .next()
+                    .unwrap()
+                    .map(|pk| pk.pubkey.clone())
+                    .collect(),
+            );
             apk.verify(
                 messages[i],
                 &[],

--- a/crypto/src/ed25519.rs
+++ b/crypto/src/ed25519.rs
@@ -438,13 +438,15 @@ impl AggregateAuthenticator for Ed25519AggregateSignature {
         }
         let mut batch = batch::Verifier::new();
 
-        for i in 0..pks.len() {
-            if pks[i].len() != sigs[i].0.len() {
+        let mut pk_iter = pks.into_iter();
+        for i in 0..sigs.len() {
+            let pk_list = &pk_iter.next().unwrap().map(|x| &x.0).collect::<Vec<_>>()[..];
+            if pk_list.len() != sigs[i].0.len() {
                 return Err(signature::Error::new());
             }
-            for j in 0..pks[i].len() {
-                let vk_bytes = VerificationKeyBytes::from(pks[i][j].0);
-                batch.queue((vk_bytes, sigs[i].0[j], messages[i]));
+            for (&pk, sig) in pk_list.iter().zip(&sigs[i].0) {
+                let vk_bytes = VerificationKeyBytes::from(*pk);
+                batch.queue((vk_bytes, *sig, messages[i]));
             }
         }
         batch.verify(OsRng).map_err(|_| signature::Error::new())

--- a/crypto/src/ed25519.rs
+++ b/crypto/src/ed25519.rs
@@ -428,9 +428,9 @@ impl AggregateAuthenticator for Ed25519AggregateSignature {
         batch.verify(OsRng).map_err(|_| signature::Error::new())
     }
 
-    fn batch_verify(
-        sigs: &[Self],
-        pks: &[&[Self::PubKey]],
+    fn batch_verify<'a>(
+        sigs: &[&Self],
+        pks: Vec<impl ExactSizeIterator<Item = &'a Self::PubKey>>,
         messages: &[&[u8]],
     ) -> Result<(), signature::Error> {
         if pks.len() != messages.len() || messages.len() != sigs.len() {

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -73,10 +73,15 @@ pub mod serde_helpers;
 // Beware: if you change those aliases to point to another scheme implementation, you will have
 // to change all four aliases to point to concrete types that work with each other. Failure to do
 // so will result in a ton of compilation errors, and worse: it will not make sense!
-pub type PublicKey = ed25519::Ed25519PublicKey;
-pub type Signature = ed25519::Ed25519Signature;
-pub type PrivateKey = ed25519::Ed25519PrivateKey;
-pub type KeyPair = ed25519::Ed25519KeyPair;
+// pub type PublicKey = ed25519::Ed25519PublicKey;
+// pub type Signature = ed25519::Ed25519Signature;
+// pub type PrivateKey = ed25519::Ed25519PrivateKey;
+// pub type KeyPair = ed25519::Ed25519KeyPair;
+
+pub type PublicKey = bls12381::BLS12381PublicKey;
+pub type Signature = bls12381::BLS12381Signature;
+pub type PrivateKey = bls12381::BLS12381PrivateKey;
+pub type KeyPair = bls12381::BLS12381KeyPair;
 ////////////////////////////////////////////////////////////////////////
 
 pub const DIGEST_LEN: usize = 32;

--- a/crypto/src/tests/bls12377_tests.rs
+++ b/crypto/src/tests/bls12377_tests.rs
@@ -218,8 +218,8 @@ fn verify_batch_aggregate_signature() {
         verify_batch_aggregate_signature_inputs();
 
     assert!(BLS12377AggregateSignature::batch_verify(
-        &[aggregated_signature1, aggregated_signature2],
-        &[&pubkeys1[..], &pubkeys2[..]],
+        &[&aggregated_signature1, &aggregated_signature2],
+        vec![pubkeys1.iter(), pubkeys2.iter()],
         &[&digest1[..], &digest2[..]]
     )
     .is_ok());
@@ -232,28 +232,28 @@ fn verify_batch_missing_parameters_length_mismatch() {
 
     // Fewer pubkeys than signatures
     assert!(BLS12377AggregateSignature::batch_verify(
-        &[aggregated_signature1.clone(), aggregated_signature2.clone()],
-        &[&pubkeys1[..]],
+        &[&aggregated_signature1, &aggregated_signature2],
+        vec![pubkeys1.iter()],
         &[&digest1[..], &digest2[..]]
     )
     .is_err());
     assert!(BLS12377AggregateSignature::batch_verify(
-        &[aggregated_signature1.clone(), aggregated_signature2.clone()],
-        &[&pubkeys1[..]],
+        &[&aggregated_signature1, &aggregated_signature2],
+        vec![pubkeys1.iter()],
         &[&digest1[..]]
     )
     .is_err());
 
     // Fewer messages than signatures
     assert!(BLS12377AggregateSignature::batch_verify(
-        &[aggregated_signature1.clone(), aggregated_signature2.clone()],
-        &[&pubkeys1[..], &pubkeys2[..]],
+        &[&aggregated_signature1, &aggregated_signature2],
+        vec![pubkeys1.iter(), pubkeys2.iter()],
         &[&digest1[..]]
     )
     .is_err());
     assert!(BLS12377AggregateSignature::batch_verify(
-        &[aggregated_signature1, aggregated_signature2],
-        &[&pubkeys1[..]],
+        &[&aggregated_signature1, &aggregated_signature2],
+        vec![pubkeys1.iter()],
         &[&digest1[..]]
     )
     .is_err());
@@ -266,16 +266,36 @@ fn verify_batch_missing_keys_in_batch() {
 
     // Pubkeys missing at the end
     assert!(BLS12377AggregateSignature::batch_verify(
-        &[aggregated_signature1.clone(), aggregated_signature2.clone()],
-        &[&pubkeys1[..], &pubkeys2[1..]],
+        &[&aggregated_signature1, &aggregated_signature2],
+        vec![pubkeys1.iter(), pubkeys2[1..].iter()],
         &[&digest1[..], &digest2[..]]
     )
     .is_err());
 
     // Pubkeys missing at the start
     assert!(BLS12377AggregateSignature::batch_verify(
-        &[aggregated_signature1, aggregated_signature2],
-        &[&pubkeys1[..], &pubkeys2[..pubkeys2.len() - 1]],
+        &[&aggregated_signature1, &aggregated_signature2],
+        vec![pubkeys1.iter(), pubkeys2[..pubkeys2.len() - 1].iter()],
+        &[&digest1[..], &digest2[..]]
+    )
+    .is_err());
+
+    // add an extra signature to both aggregated_signature that batch_verify takes in
+    let mut signatures1_with_extra = aggregated_signature1;
+    let kp = &keys()[0];
+    let sig = kp.sign(&digest1);
+    let res = signatures1_with_extra.add_signature(sig);
+    assert!(res.is_ok());
+
+    let mut signatures2_with_extra = aggregated_signature2;
+    let kp = &keys()[0];
+    let sig2 = kp.sign(&digest1);
+    let res = signatures2_with_extra.add_signature(sig2);
+    assert!(res.is_ok());
+
+    assert!(BLS12377AggregateSignature::batch_verify(
+        &[&signatures1_with_extra, &signatures2_with_extra],
+        vec![pubkeys1.iter()],
         &[&digest1[..], &digest2[..]]
     )
     .is_err());

--- a/crypto/src/tests/bls12381_tests.rs
+++ b/crypto/src/tests/bls12381_tests.rs
@@ -193,11 +193,9 @@ fn verify_batch_aggregate_signature() {
         verify_batch_aggregate_signature_inputs();
 
     assert!(BLS12381AggregateSignature::batch_verify(
-=======
         &[&aggregated_signature1, &aggregated_signature2],
         vec![pubkeys1.iter(), pubkeys2.iter()],
-        &[&digest1.0[..], &digest2.0[..]]
->>>>>>> 3bb91846 ([crypto] change to references on batch_verify)
+        &[&digest1[..], &digest2[..]]
     )
     .is_ok());
 }
@@ -209,28 +207,28 @@ fn verify_batch_missing_parameters_length_mismatch() {
 
     // Fewer pubkeys than signatures
     assert!(BLS12381AggregateSignature::batch_verify(
-        &[aggregated_signature1.clone(), aggregated_signature2.clone()],
-        &[&pubkeys1[..]],
+        &[&aggregated_signature1, &aggregated_signature2],
+        vec![pubkeys1.iter()],
         &[&digest1[..], &digest2[..]]
     )
     .is_err());
     assert!(BLS12381AggregateSignature::batch_verify(
-        &[aggregated_signature1.clone(), aggregated_signature2.clone()],
-        &[&pubkeys1[..]],
+        &[&aggregated_signature1, &aggregated_signature2],
+        vec![pubkeys1.iter()],
         &[&digest1[..]]
     )
     .is_err());
 
     // Fewer messages than signatures
     assert!(BLS12381AggregateSignature::batch_verify(
-        &[aggregated_signature1.clone(), aggregated_signature2.clone()],
-        &[&pubkeys1[..], &pubkeys2[..]],
+        &[&aggregated_signature1, &aggregated_signature2],
+        vec![pubkeys1.iter(), pubkeys2.iter()],
         &[&digest1[..]]
     )
     .is_err());
     assert!(BLS12381AggregateSignature::batch_verify(
-        &[aggregated_signature1, aggregated_signature2],
-        &[&pubkeys1[..]],
+        &[&aggregated_signature1, &aggregated_signature2],
+        vec![pubkeys1.iter()],
         &[&digest1[..]]
     )
     .is_err());
@@ -243,16 +241,36 @@ fn verify_batch_missing_keys_in_batch() {
 
     // Pubkeys missing at the end
     assert!(BLS12381AggregateSignature::batch_verify(
-        &[aggregated_signature1.clone(), aggregated_signature2.clone()],
-        &[&pubkeys1[..], &pubkeys2[1..]],
+        &[&aggregated_signature1, &aggregated_signature2],
+        vec![pubkeys1.iter(), pubkeys2[1..].iter()],
         &[&digest1[..], &digest2[..]]
     )
     .is_err());
 
     // Pubkeys missing at the start
     assert!(BLS12381AggregateSignature::batch_verify(
-        &[aggregated_signature1, aggregated_signature2],
-        &[&pubkeys1[..], &pubkeys2[..pubkeys2.len() - 1]],
+        &[&aggregated_signature1, &aggregated_signature2],
+        vec![pubkeys1.iter(), pubkeys2[..pubkeys2.len() - 1].iter()],
+        &[&digest1[..], &digest2[..]]
+    )
+    .is_err());
+
+    // add an extra signature to both aggregated_signature that batch_verify takes in
+    let mut signatures1_with_extra = aggregated_signature1;
+    let kp = &keys()[0];
+    let sig = kp.sign(&digest1);
+    let res = signatures1_with_extra.add_signature(sig);
+    assert!(res.is_ok());
+
+    let mut signatures2_with_extra = aggregated_signature2;
+    let kp = &keys()[0];
+    let sig2 = kp.sign(&digest1);
+    let res = signatures2_with_extra.add_signature(sig2);
+    assert!(res.is_ok());
+
+    assert!(BLS12381AggregateSignature::batch_verify(
+        &[&signatures1_with_extra, &signatures2_with_extra],
+        vec![pubkeys1.iter()],
         &[&digest1[..], &digest2[..]]
     )
     .is_err());

--- a/crypto/src/tests/bls12381_tests.rs
+++ b/crypto/src/tests/bls12381_tests.rs
@@ -193,9 +193,11 @@ fn verify_batch_aggregate_signature() {
         verify_batch_aggregate_signature_inputs();
 
     assert!(BLS12381AggregateSignature::batch_verify(
-        &[aggregated_signature1, aggregated_signature2],
-        &[&pubkeys1[..], &pubkeys2[..]],
-        &[&digest1[..], &digest2[..]]
+=======
+        &[&aggregated_signature1, &aggregated_signature2],
+        vec![pubkeys1.iter(), pubkeys2.iter()],
+        &[&digest1.0[..], &digest2.0[..]]
+>>>>>>> 3bb91846 ([crypto] change to references on batch_verify)
     )
     .is_ok());
 }

--- a/crypto/src/tests/ed25519_tests.rs
+++ b/crypto/src/tests/ed25519_tests.rs
@@ -311,8 +311,8 @@ fn verify_batch_aggregate_signature() {
         verify_batch_aggregate_signature_inputs();
 
     assert!(Ed25519AggregateSignature::batch_verify(
-        &[aggregated_signature1, aggregated_signature2],
-        &[&pubkeys1[..], &pubkeys2[..]],
+        &[&aggregated_signature1, &aggregated_signature2],
+        vec![pubkeys1.iter(), pubkeys2.iter()],
         &[&digest1[..], &digest2[..]]
     )
     .is_ok());
@@ -325,28 +325,28 @@ fn verify_batch_missing_parameters_length_mismatch() {
 
     // Fewer pubkeys than signatures
     assert!(Ed25519AggregateSignature::batch_verify(
-        &[aggregated_signature1.clone(), aggregated_signature2.clone()],
-        &[&pubkeys1[..]],
+        &[&aggregated_signature1, &aggregated_signature2],
+        vec![pubkeys1.iter()],
         &[&digest1[..], &digest2[..]]
     )
     .is_err());
     assert!(Ed25519AggregateSignature::batch_verify(
-        &[aggregated_signature1.clone(), aggregated_signature2.clone()],
-        &[&pubkeys1[..]],
+        &[&aggregated_signature1, &aggregated_signature2],
+        vec![pubkeys1.iter()],
         &[&digest1[..]]
     )
     .is_err());
 
     // Fewer messages than signatures
     assert!(Ed25519AggregateSignature::batch_verify(
-        &[aggregated_signature1.clone(), aggregated_signature2.clone()],
-        &[&pubkeys1[..], &pubkeys2[..]],
+        &[&aggregated_signature1, &aggregated_signature2],
+        vec![pubkeys1.iter(), pubkeys2.iter()],
         &[&digest1[..]]
     )
     .is_err());
     assert!(Ed25519AggregateSignature::batch_verify(
-        &[aggregated_signature1, aggregated_signature2],
-        &[&pubkeys1[..]],
+        &[&aggregated_signature1, &aggregated_signature2],
+        vec![pubkeys1.iter()],
         &[&digest1[..]]
     )
     .is_err());
@@ -359,16 +359,16 @@ fn verify_batch_missing_keys_in_batch() {
 
     // Pubkeys missing at the end
     assert!(Ed25519AggregateSignature::batch_verify(
-        &[aggregated_signature1.clone(), aggregated_signature2.clone()],
-        &[&pubkeys1[..], &pubkeys2[1..]],
+        &[&aggregated_signature1, &aggregated_signature2],
+        vec![pubkeys1.iter(), pubkeys2[1..].iter()],
         &[&digest1[..], &digest2[..]]
     )
     .is_err());
 
     // Pubkeys missing at the start
     assert!(Ed25519AggregateSignature::batch_verify(
-        &[aggregated_signature1.clone(), aggregated_signature2.clone()],
-        &[&pubkeys1[..], &pubkeys2[..pubkeys2.len() - 1]],
+        &[&aggregated_signature1, &aggregated_signature2],
+        vec![pubkeys1.iter(), pubkeys2[..pubkeys2.len() - 1].iter()],
         &[&digest1[..], &digest2[..]]
     )
     .is_err());
@@ -387,11 +387,8 @@ fn verify_batch_missing_keys_in_batch() {
     assert!(res.is_ok());
 
     assert!(Ed25519AggregateSignature::batch_verify(
-        &[
-            signatures1_with_extra.clone(),
-            signatures2_with_extra.clone()
-        ],
-        &[&pubkeys1[..]],
+        &[&signatures1_with_extra, &signatures2_with_extra],
+        vec![pubkeys1.iter()],
         &[&digest1[..], &digest2[..]]
     )
     .is_err());

--- a/crypto/src/traits.rs
+++ b/crypto/src/traits.rs
@@ -187,9 +187,9 @@ pub trait AggregateAuthenticator:
         message: &[u8],
     ) -> Result<(), Error>;
 
-    fn batch_verify(
-        sigs: &[Self],
-        pks: &[&[Self::PubKey]],
+    fn batch_verify<'a>(
+        sigs: &[&Self],
+        pks: Vec<impl ExactSizeIterator<Item = &'a Self::PubKey>>,
         messages: &[&[u8]],
     ) -> Result<(), Error>;
 }


### PR DESCRIPTION
**Problem:** In Narwhal crypto, we used to:
Copy a Public Key every time we want to verify a signature (once from copying out of the 'committee' struct, the second time copying into the narwhal references function, which does not take in references)

This was probably fine with ed25519, where the public keys were already serialized bytes,  but BLS12381 stores public keys in some other form - which adds extra cost very time we deep-copy the public keys. Note that this happened 30 times for each certificate.
