### PR TITLE
network: migrate the primary-to-primary interface to a quic p2p networking stack (anemo)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "anemo"
+version = "0.0.0"
+source = "git+https://github.com/mystenlabs/anemo.git?rev=6278d0fa78147a49ff2cb9dd2e45e763886be0a0#6278d0fa78147a49ff2cb9dd2e45e763886be0a0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bincode",
+ "bytes",
+ "ed25519",
+ "futures",
+ "http",
+ "matchit",
+ "pkcs8",
+ "quinn",
+ "rand 0.8.5",
+ "rcgen",
+ "rustls",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower",
+ "tracing",
+ "webpki",
+ "x509-parser",
+]
+
+[[package]]
+name = "anemo-build"
+version = "0.0.0"
+source = "git+https://github.com/mystenlabs/anemo.git?rev=6278d0fa78147a49ff2cb9dd2e45e763886be0a0#6278d0fa78147a49ff2cb9dd2e45e763886be0a0"
+dependencies = [
+ "prettyplease",
+ "proc-macro2 1.0.40",
+ "quote 1.0.20",
+ "syn 1.0.98",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,6 +283,45 @@ name = "arrayvec"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+
+[[package]]
+name = "asn1-rs"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf6690c370453db30743b373a60ba498fc0d6d83b11f4abfd87a84a075db5dd4"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "726535892e8eae7e70657b4c8ea93d26b8553afb1ce617caee529ef96d7dee6c"
+dependencies = [
+ "proc-macro2 1.0.40",
+ "quote 1.0.20",
+ "syn 1.0.98",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2777730b2039ac0f95f093556e61b6d26cebed5393ca6f152717777cec3a42ed"
+dependencies = [
+ "proc-macro2 1.0.40",
+ "quote 1.0.20",
+ "syn 1.0.98",
+]
 
 [[package]]
 name = "async-recursion"
@@ -598,6 +677,9 @@ name = "bytes"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bzip2-sys"
@@ -1196,6 +1278,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "der-parser"
+version = "8.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d4bc9b0db0a0df9ae64634ac5bdefb7afcb534e182275ca0beadbe486701c1"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1285,6 +1381,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf95dc3f046b9da4f2d51833c0d3547d8564ef6910f5c1ed130306a75b92886"
+dependencies = [
+ "proc-macro2 1.0.40",
+ "quote 1.0.20",
+ "syn 1.0.98",
+]
+
+[[package]]
 name = "downcast"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1300,6 +1407,17 @@ dependencies = [
  "elliptic-curve",
  "rfc6979",
  "signature",
+]
+
+[[package]]
+name = "ed25519"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9c280362032ea4203659fc489832d0204ef09f247a0506f170dafcac08c369"
+dependencies = [
+ "pkcs8",
+ "signature",
+ "zeroize",
 ]
 
 [[package]]
@@ -1600,6 +1718,15 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -2277,10 +2404,13 @@ dependencies = [
 name = "network"
 version = "0.1.0"
 dependencies = [
+ "anemo",
+ "anyhow",
  "async-trait",
  "backoff",
  "bincode",
  "bytes",
+ "crypto",
  "eyre",
  "fastcrypto",
  "futures",
@@ -2449,6 +2579,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid-registry"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d4bda43fd1b844cbc6e6e54b5444e2b1bc7838bce59ad205902cccbb26d6761"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2594,6 +2733,15 @@ name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
+name = "pem"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c64931a1a212348ec4f3b4362585eca7159d0d09cbdf4a7f74f02173596fd4"
+dependencies = [
+ "base64",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -2808,6 +2956,8 @@ dependencies = [
 name = "primary"
 version = "0.1.0"
 dependencies = [
+ "anemo",
+ "anyhow",
  "arc-swap",
  "async-recursion",
  "async-trait",
@@ -3044,6 +3194,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b435e71d9bfa0d8889927231970c51fb89c58fa63bffcab117c9c7a41e5ef8f"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "fxhash",
+ "quinn-proto",
+ "quinn-udp",
+ "rustls",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "webpki",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fce546b9688f767a57530652488420d419a8b1f44a478b451c3d1ab6d992a55"
+dependencies = [
+ "bytes",
+ "fxhash",
+ "rand 0.8.5",
+ "ring",
+ "rustls",
+ "rustls-pemfile 0.2.1",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "webpki",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f832d8958db3e84d2ec93b5eb2272b45aa23cf7f8fe6e79f578896f4e6c231b"
+dependencies = [
+ "futures-util",
+ "libc",
+ "quinn-proto",
+ "socket2",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "quote"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3163,6 +3365,18 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
  "num_cpus",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6413f3de1edee53342e6138e75b56d32e7bc6e332b3bd62d497b1929d4cfbcdd"
+dependencies = [
+ "pem",
+ "ring",
+ "time",
+ "yasna",
 ]
 
 [[package]]
@@ -3296,6 +3510,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustls"
 version = "0.20.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3305,6 +3528,15 @@ dependencies = [
  "ring",
  "sct",
  "webpki",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eebeaeb360c87bfb72e84abdb3447159c0eaececf1bef2aecd65a8be949d1c9"
+dependencies = [
+ "base64",
 ]
 
 [[package]]
@@ -3917,6 +4149,7 @@ checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
 name = "test_utils"
 version = "0.1.0"
 dependencies = [
+ "anemo",
  "arc-swap",
  "base64",
  "bincode",
@@ -3932,6 +4165,7 @@ dependencies = [
  "itertools",
  "multiaddr",
  "mysten-network",
+ "network",
  "node",
  "primary",
  "prometheus",
@@ -3942,6 +4176,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tonic",
+ "tower",
  "tracing",
  "typed-store",
  "types",
@@ -4031,7 +4266,14 @@ dependencies = [
  "libc",
  "num_threads",
  "serde",
+ "time-macros",
 ]
+
+[[package]]
+name = "time-macros"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
 
 [[package]]
 name = "tinytemplate"
@@ -4167,7 +4409,7 @@ dependencies = [
  "pin-project",
  "prost",
  "prost-derive",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.1",
  "tokio",
  "tokio-rustls",
  "tokio-stream",
@@ -4454,6 +4696,8 @@ checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 name = "types"
 version = "0.1.0"
 dependencies = [
+ "anemo",
+ "anemo-build",
  "base64",
  "bincode",
  "blake2",
@@ -4838,6 +5082,8 @@ dependencies = [
  "adler",
  "ahash",
  "aho-corasick",
+ "anemo",
+ "anemo-build",
  "ansi_term",
  "anyhow",
  "arc-swap",
@@ -4856,6 +5102,9 @@ dependencies = [
  "ark-std",
  "arrayref",
  "arrayvec 0.7.2",
+ "asn1-rs",
+ "asn1-rs-derive",
+ "asn1-rs-impl",
  "async-recursion",
  "async-stream",
  "async-stream-impl",
@@ -4924,6 +5173,7 @@ dependencies = [
  "dashmap",
  "data-encoding",
  "der",
+ "der-parser",
  "derivative",
  "derive_builder",
  "derive_builder_core",
@@ -4933,8 +5183,10 @@ dependencies = [
  "difflib",
  "digest 0.10.3",
  "digest 0.9.0",
+ "displaydoc",
  "downcast",
  "ecdsa",
+ "ed25519",
  "ed25519-consensus",
  "either",
  "elliptic-curve",
@@ -4958,6 +5210,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "futures-util",
+ "fxhash",
  "generic-array",
  "gethostname",
  "getrandom 0.1.16",
@@ -5032,6 +5285,7 @@ dependencies = [
  "num-traits",
  "num_cpus",
  "object",
+ "oid-registry",
  "once_cell",
  "oorandom",
  "opaque-debug",
@@ -5046,6 +5300,7 @@ dependencies = [
  "parking_lot_core 0.9.3",
  "paste",
  "peeking_take_while",
+ "pem",
  "percent-encoding",
  "pest",
  "petgraph",
@@ -5082,6 +5337,9 @@ dependencies = [
  "protobuf",
  "quick-error 1.2.3",
  "quick-error 2.0.1",
+ "quinn",
+ "quinn-proto",
+ "quinn-udp",
  "quote 0.6.13",
  "quote 1.0.20",
  "rand 0.7.3",
@@ -5092,6 +5350,7 @@ dependencies = [
  "rand_xorshift",
  "rayon",
  "rayon-core",
+ "rcgen",
  "readonly",
  "regex",
  "regex-automata",
@@ -5104,8 +5363,10 @@ dependencies = [
  "rustc-hash",
  "rustc_version 0.2.3",
  "rustc_version 0.3.3",
+ "rusticata-macros",
  "rustls",
- "rustls-pemfile",
+ "rustls-pemfile 0.2.1",
+ "rustls-pemfile 1.0.1",
  "rustversion",
  "rusty-fork",
  "ryu",
@@ -5168,6 +5429,7 @@ dependencies = [
  "threadpool",
  "thrift",
  "time",
+ "time-macros",
  "tinytemplate",
  "tinyvec",
  "tinyvec_macros",
@@ -5219,11 +5481,31 @@ dependencies = [
  "want",
  "webpki",
  "which",
+ "x509-parser",
  "yaml-rust",
  "yansi",
+ "yasna",
  "zeroize",
  "zeroize_derive",
  "zstd-sys",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0ecbeb7b67ce215e40e3cc7f2ff902f94a223acf44995934763467e7b1febc8"
+dependencies = [
+ "asn1-rs",
+ "base64",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror",
+ "time",
 ]
 
 [[package]]
@@ -5240,6 +5522,15 @@ name = "yansi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+
+[[package]]
+name = "yasna"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346d34a236c9d3e5f3b9b74563f238f955bbd05fa0b8b4efa53c130c43982f4c"
+dependencies = [
+ "time",
+]
 
 [[package]]
 name = "zeroize"

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -21,11 +21,15 @@ tokio-util = { version = "0.7.3", features = ["codec"] }
 tonic = { version = "0.7.2", features = ["tls"] }
 tracing = "0.1.36"
 types = { path = "../types" }
+crypto = { path = "../crypto" }
 
 serde = "1.0.144"
 mysten-network = { git = "https://github.com/mystenlabs/mysten-infra.git", rev = "9deac015fbf66e24b6da9699630e06750eaa094a" }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 eyre = "0.6.8"
+
+anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "6278d0fa78147a49ff2cb9dd2e45e763886be0a0" }
+anyhow = "1.0.62"
 
 [dev-dependencies]
 bincode = "1.3.3"

--- a/network/src/traits.rs
+++ b/network/src/traits.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use async_trait::async_trait;
+use crypto::PublicKey;
 use multiaddr::Multiaddr;
 use rand::prelude::{SliceRandom, SmallRng};
 use serde::Serialize;
@@ -99,6 +100,83 @@ pub trait ReliableNetwork: BaseNetwork {
         let mut handlers = Vec::new();
         for address in addresses {
             let handle = self.send_message(address, message.clone()).await;
+            handlers.push(handle);
+        }
+        handlers
+    }
+}
+
+#[async_trait]
+pub trait UnreliableNetwork2<Message: Clone + Send + Sync> {
+    async fn unreliable_send(&mut self, peer: PublicKey, message: &Message) -> JoinHandle<()>;
+
+    /// Broadcasts a message to all `peers` passed as an argument.
+    /// The attempts to send individual messages are best effort and will not be retried.
+    async fn unreliable_broadcast(
+        &mut self,
+        peers: Vec<PublicKey>,
+        message: &Message,
+    ) -> Vec<JoinHandle<()>> {
+        let mut handlers = Vec::new();
+        for peer in peers {
+            let handle = { self.unreliable_send(peer, message).await };
+            handlers.push(handle);
+        }
+        handlers
+    }
+}
+
+pub trait Lucky {
+    fn rng(&mut self) -> &mut SmallRng;
+}
+
+#[async_trait]
+pub trait LuckyNetwork2<Message> {
+    /// Pick a few addresses at random (specified by `nodes`) and try (best-effort) to send the
+    /// message only to them. This is useful to pick nodes with whom to sync.
+    async fn lucky_broadcast(
+        &mut self,
+        mut peers: Vec<PublicKey>,
+        message: &Message,
+        num_nodes: usize,
+    ) -> Vec<JoinHandle<()>>;
+}
+
+#[async_trait]
+impl<T, M> LuckyNetwork2<M> for T
+where
+    M: Clone + Send + Sync,
+    T: UnreliableNetwork2<M> + Send,
+    T: Lucky,
+{
+    async fn lucky_broadcast(
+        &mut self,
+        mut peers: Vec<PublicKey>,
+        message: &M,
+        nodes: usize,
+    ) -> Vec<JoinHandle<()>> {
+        peers.shuffle(self.rng());
+        peers.truncate(nodes);
+        self.unreliable_broadcast(peers, message).await
+    }
+}
+
+#[async_trait]
+pub trait ReliableNetwork2<Message: Clone + Send + Sync> {
+    async fn send(
+        &mut self,
+        peer: PublicKey,
+        message: &Message,
+    ) -> CancelOnDropHandler<anyhow::Result<anemo::Response<()>>>;
+
+    async fn broadcast(
+        &mut self,
+        peers: Vec<PublicKey>,
+        message: &Message,
+    ) -> Vec<CancelOnDropHandler<anyhow::Result<anemo::Response<()>>>> {
+        let mut handlers = Vec::new();
+        for peer in peers {
+            let handle = self.send(peer, message).await;
             handlers.push(handle);
         }
         handlers

--- a/primary/Cargo.toml
+++ b/primary/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 edition = "2021"
 
 [dependencies]
+anyhow = "1.0.59"
 async-recursion = "1.0.0"
 async-trait = "0.1.57"
 base64 = "0.13.0"
@@ -29,7 +30,7 @@ thiserror = "1.0.33"
 tokio = { version = "1.20.1", features = ["sync", "rt", "macros"] }
 tokio-util = { version = "0.7.3", features = ["codec"] }
 tonic = "0.7.2"
-tower = "0.4.13"
+tower = { version = "0.4.13", features = ["full"] }
 tracing = "0.1.36"
 tap = "1.0.1"
 
@@ -43,6 +44,8 @@ mysten-network = { git = "https://github.com/mystenlabs/mysten-infra.git", rev =
 
 store = { git = "https://github.com/mystenlabs/mysten-infra.git", package = "typed-store", rev = "9deac015fbf66e24b6da9699630e06750eaa094a" }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
+
+anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "6278d0fa78147a49ff2cb9dd2e45e763886be0a0" }
 
 [dev-dependencies]
 arc-swap = { version = "1.5.1", features = ["serde"] }

--- a/primary/src/block_synchronizer/mod.rs
+++ b/primary/src/block_synchronizer/mod.rs
@@ -17,7 +17,7 @@ use futures::{
     stream::FuturesUnordered,
     FutureExt, StreamExt,
 };
-use network::{PrimaryNetwork, PrimaryToWorkerNetwork, UnreliableNetwork};
+use network::{PrimaryNetwork, PrimaryToWorkerNetwork, UnreliableNetwork, UnreliableNetwork2};
 use rand::{rngs::SmallRng, SeedableRng};
 use std::{
     collections::{HashMap, HashSet},
@@ -631,15 +631,15 @@ impl BlockSynchronizer {
     async fn broadcast_batch_request(&mut self, message: PrimaryMessage) -> Vec<PublicKey> {
         // Naively now just broadcast the request to all the primaries
 
-        let (primaries_names, primaries_addresses) = self
+        let primaries_names: Vec<_> = self
             .committee
             .others_primaries(&self.name)
             .into_iter()
-            .map(|(name, address)| (name, address.primary_to_primary))
-            .unzip();
+            .map(|(name, _address)| name)
+            .collect();
 
         self.primary_network
-            .unreliable_broadcast(primaries_addresses, &message)
+            .unreliable_broadcast(primaries_names.clone(), &message)
             .await;
 
         primaries_names

--- a/primary/src/tests/certificate_waiter_tests.rs
+++ b/primary/src/tests/certificate_waiter_tests.rs
@@ -25,6 +25,7 @@ async fn process_certificate_missing_parents_in_reverse() {
     let committee = pure_committee_from_keys(&k);
     let worker_cache = shared_worker_cache_from_keys(&k);
     let kp = k.pop().unwrap();
+    let network_key = kp.copy().private().0.to_bytes();
     let name = kp.public().clone();
     let signature_service = SignatureService::new(kp);
 
@@ -65,6 +66,12 @@ async fn process_certificate_missing_parents_in_reverse() {
         None,
     );
 
+    let network = anemo::Network::bind("localhost:0")
+        .server_name("narwhal")
+        .private_key(network_key)
+        .start(anemo::Router::new())
+        .unwrap();
+
     let metrics = Arc::new(PrimaryMetrics::new(&Registry::new()));
     let gc_depth: Round = 50;
 
@@ -83,7 +90,7 @@ async fn process_certificate_missing_parents_in_reverse() {
         rx_sync_headers,
         tx_headers_loopback,
         metrics.clone(),
-        PrimaryNetwork::default(),
+        PrimaryNetwork::new(network.clone()),
         PrimaryToWorkerNetwork::default(),
     );
 
@@ -118,7 +125,7 @@ async fn process_certificate_missing_parents_in_reverse() {
         tx_consensus,
         /* tx_proposer */ tx_parents,
         metrics.clone(),
-        PrimaryNetwork::default(),
+        PrimaryNetwork::new(network),
     );
 
     // Generate headers in successive rounds
@@ -172,6 +179,7 @@ async fn process_certificate_check_gc_fires() {
     let committee = pure_committee_from_keys(&k);
     let worker_cache = shared_worker_cache_from_keys(&k);
     let kp = k.pop().unwrap();
+    let network_key = kp.copy().private().0.to_bytes();
     let name = kp.public().clone();
     let signature_service = SignatureService::new(kp);
 
@@ -212,6 +220,12 @@ async fn process_certificate_check_gc_fires() {
         None,
     );
 
+    let network = anemo::Network::bind("localhost:0")
+        .server_name("narwhal")
+        .private_key(network_key)
+        .start(anemo::Router::new())
+        .unwrap();
+
     let metrics = Arc::new(PrimaryMetrics::new(&Registry::new()));
     let gc_depth: Round = 50;
 
@@ -230,7 +244,7 @@ async fn process_certificate_check_gc_fires() {
         rx_sync_headers,
         tx_headers_loopback,
         metrics.clone(),
-        PrimaryNetwork::default(),
+        PrimaryNetwork::new(network.clone()),
         PrimaryToWorkerNetwork::default(),
     );
 
@@ -265,7 +279,7 @@ async fn process_certificate_check_gc_fires() {
         tx_consensus,
         /* tx_proposer */ tx_parents,
         metrics.clone(),
-        PrimaryNetwork::default(),
+        PrimaryNetwork::new(network),
     );
 
     // Generate headers in successive rounds

--- a/primary/tests/epoch_change.rs
+++ b/primary/tests/epoch_change.rs
@@ -8,7 +8,7 @@ use network::{CancelOnDropHandler, ReliableNetwork, WorkerToPrimaryNetwork};
 use node::NodeStorage;
 use primary::{NetworkModel, Primary, CHANNEL_CAPACITY};
 use prometheus::Registry;
-use std::{collections::BTreeMap, sync::Arc};
+use std::{collections::BTreeMap, sync::Arc, time::Duration};
 use test_utils::{
     keys, make_authority, pure_committee_from_keys, shared_worker_cache_from_keys, temp_dir,
 };
@@ -302,6 +302,8 @@ async fn test_partial_committee_change() {
 /// The epoch changes but the stake distribution and network addresses stay the same.
 #[tokio::test]
 async fn test_restart_with_new_committee_change() {
+    telemetry_subscribers::init_for_testing();
+
     let parameters = Parameters {
         header_size: 32, // One batch digest
         ..Parameters::default()
@@ -385,6 +387,8 @@ async fn test_restart_with_new_committee_change() {
 
     // Wait for the committee to shutdown.
     join_all(handles).await;
+    // Provide a small amount of time for any background tasks to shutdown
+    tokio::time::sleep(Duration::from_secs(1)).await;
 
     // Move to the next epochs.
     for epoch in 1..=3 {
@@ -465,6 +469,8 @@ async fn test_restart_with_new_committee_change() {
 
         // Wait for the committee to shutdown.
         join_all(handles).await;
+        // Provide a small amount of time for any background tasks to shutdown
+        tokio::time::sleep(Duration::from_secs(1)).await;
     }
 }
 

--- a/test_utils/Cargo.toml
+++ b/test_utils/Cargo.toml
@@ -33,9 +33,13 @@ crypto = { path = "../crypto" }
 executor = { path = "../executor" }
 node = { path = "../node" }
 primary = { path = "../primary" }
+network = { path = "../network" }
 types = { path = "../types" }
 worker = { path = "../worker" }
 mysten-network = { git = "https://github.com/mystenlabs/mysten-infra.git", rev = "9deac015fbf66e24b6da9699630e06750eaa094a" }
 
 store = { git = "https://github.com/mystenlabs/mysten-infra.git", package = "typed-store", rev = "9deac015fbf66e24b6da9699630e06750eaa094a" }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
+
+anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "6278d0fa78147a49ff2cb9dd2e45e763886be0a0" }
+tower = { version = "0.4.13", features = ["full"] }

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -33,6 +33,7 @@ config = { path = "../config" }
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "c022a2ae23ca7cc2778293fd3b1db42e8cd02d3b" }
 crypto = { path = "../crypto"}
 dag = { path = "../dag" }
+anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "6278d0fa78147a49ff2cb9dd2e45e763886be0a0" }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 [dev-dependencies]
@@ -45,6 +46,7 @@ test_utils = { path = "../test_utils" }
 prost-build = "0.10.4"
 rustversion = "1.0.9"
 tonic-build = { version = "0.7.2", features = [ "prost", "transport" ] }
+anemo-build = { git = "https://github.com/mystenlabs/anemo.git", rev = "6278d0fa78147a49ff2cb9dd2e45e763886be0a0" }
 
 [features]
 default = []

--- a/types/build.rs
+++ b/types/build.rs
@@ -1,7 +1,10 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{env, path::PathBuf};
+use std::{
+    env,
+    path::{Path, PathBuf},
+};
 
 type Result<T> = ::std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
 
@@ -20,8 +23,10 @@ fn main() -> Result<()> {
     config.bytes(&["."]);
 
     tonic_build::configure()
-        .out_dir(out_dir)
+        .out_dir(&out_dir)
         .compile_with_config(config, proto_files, dirs)?;
+
+    build_anemo_services(&out_dir);
 
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=proto");
@@ -32,6 +37,26 @@ fn main() -> Result<()> {
     stable();
 
     Ok(())
+}
+
+fn build_anemo_services(out_dir: &Path) {
+    let primary_to_primary = anemo_build::manual::Service::builder()
+        .name("PrimaryToPrimary")
+        .package("narwhal")
+        .method(
+            anemo_build::manual::Method::builder()
+                .name("send_message")
+                .route_name("SendMessage")
+                .request_type("crate::PrimaryMessage")
+                .response_type("()")
+                .codec_path("anemo::rpc::codec::BincodeCodec")
+                .build(),
+        )
+        .build();
+
+    anemo_build::manual::Builder::new()
+        .out_dir(out_dir)
+        .compile(&[primary_to_primary]);
 }
 
 #[rustversion::nightly]

--- a/types/proto/narwhal.proto
+++ b/types/proto/narwhal.proto
@@ -162,12 +162,6 @@ service Configuration {
     rpc GetPrimaryAddress(Empty) returns (GetPrimaryAddressResponse);
 }
 
-// The primary-to-primary interface
-service PrimaryToPrimary {
-    // Sends a message
-    rpc SendMessage(BincodeEncodedPayload) returns (Empty) {}
-}
-
 // The worker-to-worker interface
 service WorkerToWorker {
     // Sends a worker message

--- a/types/src/primary.rs
+++ b/types/src/primary.rs
@@ -524,7 +524,7 @@ impl Affiliated for Certificate {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum PrimaryMessage {
     Header(Header),
     Vote(Vote),

--- a/types/src/proto.rs
+++ b/types/src/proto.rs
@@ -3,6 +3,8 @@
 mod narwhal {
     #![allow(clippy::derive_partial_eq_without_eq)]
     tonic::include_proto!("narwhal");
+
+    include!(concat!(env!("OUT_DIR"), "/narwhal.PrimaryToPrimary.rs"));
 }
 
 use std::{array::TryFromSliceError, ops::Deref};

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -18,7 +18,9 @@ addr2line = { version = "0.17", default-features = false }
 adler = { version = "1", default-features = false }
 ahash = { version = "0.7", default-features = false }
 aho-corasick = { version = "0.7", features = ["std"] }
+anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "6278d0fa78147a49ff2cb9dd2e45e763886be0a0", default-features = false }
 ansi_term = { version = "0.12", default-features = false }
+anyhow = { version = "1", features = ["std"] }
 arc-swap = { version = "1", default-features = false, features = ["serde"] }
 ark-bls12-377 = { version = "0.3", features = ["base_field", "curve", "scalar_field", "std"] }
 ark-crypto-primitives = { version = "0.3", features = ["parallel", "rayon", "std"] }
@@ -32,6 +34,7 @@ ark-snark = { version = "0.3", default-features = false }
 ark-std = { version = "0.3", features = ["parallel", "rayon", "std"] }
 arrayref = { version = "0.3", default-features = false }
 arrayvec = { version = "0.7", default-features = false }
+asn1-rs = { version = "0.5", features = ["datetime", "std", "time"] }
 async-stream = { version = "0.3", default-features = false }
 atty = { version = "0.2", default-features = false }
 axum = { version = "0.5", features = ["form", "http1", "json", "matched-path", "original-uri", "query", "serde_json", "serde_urlencoded", "tower-log"] }
@@ -57,7 +60,7 @@ bs58 = { version = "0.4", features = ["alloc", "std"] }
 bstr = { version = "0.2", features = ["lazy_static", "regex-automata", "serde", "serde1", "serde1-nostd", "std", "unicode"] }
 bulletproofs = { version = "4", features = ["rand", "std", "thiserror"] }
 byteorder = { version = "1", features = ["i128", "std"] }
-bytes = { version = "1", features = ["std"] }
+bytes = { version = "1", features = ["serde", "std"] }
 cast = { version = "0.3", default-features = false }
 cfg-if-c65f7effa3be6d31 = { package = "cfg-if", version = "0.1", default-features = false }
 cfg-if-dff4ba8e3ae991db = { package = "cfg-if", version = "1", default-features = false }
@@ -87,7 +90,8 @@ csv-core = { version = "0.1" }
 curve25519-dalek-ng = { version = "4", features = ["alloc", "serde", "std", "u64_backend"] }
 dashmap = { version = "5", default-features = false }
 data-encoding = { version = "2", features = ["alloc", "std"] }
-der = { version = "0.6", default-features = false, features = ["alloc", "const-oid", "oid", "zeroize"] }
+der = { version = "0.6", default-features = false, features = ["alloc", "const-oid", "oid", "std", "zeroize"] }
+der-parser = { version = "8", features = ["bigint", "num-bigint", "std"] }
 derive_builder = { version = "0.11", features = ["std"] }
 dhat = { version = "0.3", default-features = false }
 diff = { version = "0.1", default-features = false }
@@ -96,6 +100,7 @@ digest-93f6ce9d446188ac = { package = "digest", version = "0.10", features = ["a
 digest-274715c4dabd11b0 = { package = "digest", version = "0.9", default-features = false, features = ["alloc", "std"] }
 downcast = { version = "0.11", features = ["std"] }
 ecdsa = { version = "0.14", default-features = false, features = ["alloc", "arithmetic", "der", "digest", "hazmat", "pkcs8", "rfc6979", "sign", "std", "verify"] }
+ed25519 = { version = "1", features = ["alloc", "pkcs8", "std", "zeroize"] }
 ed25519-consensus = { version = "2", features = ["serde", "std", "thiserror"] }
 either = { version = "1", features = ["use_std"] }
 elliptic-curve = { version = "0.12", default-features = false, features = ["alloc", "arithmetic", "digest", "ff", "group", "hazmat", "pkcs8", "sec1", "std"] }
@@ -116,7 +121,8 @@ futures-executor = { version = "0.3", features = ["std"] }
 futures-io = { version = "0.3", default-features = false, features = ["std"] }
 futures-sink = { version = "0.3", features = ["alloc", "std"] }
 futures-task = { version = "0.3", default-features = false, features = ["alloc", "std"] }
-futures-util = { version = "0.3", default-features = false, features = ["alloc", "async-await", "async-await-macro", "channel", "futures-channel", "futures-io", "futures-macro", "futures-sink", "io", "memchr", "sink", "slab", "std"] }
+futures-util = { version = "0.3", features = ["alloc", "async-await", "async-await-macro", "channel", "futures-channel", "futures-io", "futures-macro", "futures-sink", "io", "memchr", "sink", "slab", "std"] }
+fxhash = { version = "0.2", default-features = false }
 generic-array = { version = "0.14", default-features = false, features = ["more_lengths"] }
 gethostname = { version = "0.2", default-features = false }
 getrandom-c65f7effa3be6d31 = { package = "getrandom", version = "0.1", default-features = false, features = ["std"] }
@@ -166,18 +172,21 @@ memchr = { version = "2", features = ["std"] }
 memoffset = { version = "0.6" }
 merlin = { version = "3", features = ["std"] }
 mime = { version = "0.3", default-features = false }
+minimal-lexical = { version = "0.2", default-features = false, features = ["std"] }
 miniz_oxide = { version = "0.5", default-features = false }
 mio = { version = "0.8", features = ["net", "os-ext", "os-poll"] }
 mockall = { version = "0.11", default-features = false }
 multiaddr = { version = "0.14", features = ["url"] }
 multihash = { version = "0.16", default-features = false, features = ["alloc", "derive", "identity", "multihash-derive", "multihash-impl", "std"] }
 mysten-network = { git = "https://github.com/mystenlabs/mysten-infra.git", rev = "9deac015fbf66e24b6da9699630e06750eaa094a", default-features = false }
+nom = { version = "7", features = ["alloc", "std"] }
 normalize-line-endings = { version = "0.3", default-features = false }
-num-bigint = { version = "0.4", default-features = false }
-num-integer = { version = "0.1", default-features = false, features = ["i128"] }
+num-bigint = { version = "0.4", features = ["std"] }
+num-integer = { version = "0.1", default-features = false, features = ["i128", "std"] }
 num-traits = { version = "0.2", features = ["i128", "std"] }
 num_cpus = { version = "1", default-features = false }
 object = { version = "0.29", default-features = false, features = ["archive", "coff", "elf", "macho", "pe", "read_core", "unaligned"] }
+oid-registry = { version = "0.6", features = ["crypto", "kdf", "nist_algs", "pkcs1", "pkcs12", "pkcs7", "pkcs9", "registry", "x509", "x962"] }
 once_cell = { version = "1", features = ["alloc", "race", "std"] }
 oorandom = { version = "11", default-features = false }
 opaque-debug = { version = "0.3", default-features = false }
@@ -190,11 +199,12 @@ parking_lot-a6292c17cd707f01 = { package = "parking_lot", version = "0.11" }
 parking_lot-5ef9efb8ec2df382 = { package = "parking_lot", version = "0.12" }
 parking_lot_core-c38e5c1d305a1b54 = { package = "parking_lot_core", version = "0.8", default-features = false }
 parking_lot_core-274715c4dabd11b0 = { package = "parking_lot_core", version = "0.9", default-features = false }
+pem = { version = "1", default-features = false }
 percent-encoding = { version = "2", default-features = false }
 pin-project = { version = "1", default-features = false }
 pin-project-lite = { version = "0.2", default-features = false }
 pin-utils = { version = "0.1", default-features = false }
-pkcs8 = { version = "0.9", default-features = false, features = ["alloc"] }
+pkcs8 = { version = "0.9", default-features = false, features = ["alloc", "std"] }
 plotters = { version = "0.3", default-features = false, features = ["area_series", "line_series", "plotters-svg", "svg_backend"] }
 plotters-backend = { version = "0.3", default-features = false }
 plotters-svg = { version = "0.3", default-features = false }
@@ -210,6 +220,9 @@ prost = { version = "0.10", features = ["prost-derive", "std"] }
 protobuf = { version = "2", default-features = false }
 quick-error-dff4ba8e3ae991db = { package = "quick-error", version = "1", default-features = false }
 quick-error-f595c2ba2a3f28df = { package = "quick-error", version = "2", default-features = false }
+quinn = { version = "0.8", default-features = false, features = ["rustls", "tls-rustls", "webpki"] }
+quinn-proto = { version = "0.8", default-features = false, features = ["ring", "rustls", "rustls-pemfile", "tls-rustls", "webpki"] }
+quinn-udp = { version = "0.1", default-features = false }
 rand-ca01ad9e24f5d932 = { package = "rand", version = "0.7", features = ["alloc", "getrandom", "getrandom_package", "libc", "std"] }
 rand-c38e5c1d305a1b54 = { package = "rand", version = "0.8", features = ["alloc", "getrandom", "libc", "rand_chacha", "small_rng", "std", "std_rng"] }
 rand_chacha = { version = "0.3", features = ["std"] }
@@ -218,6 +231,7 @@ rand_core-3b31131e45eafb45 = { package = "rand_core", version = "0.6", default-f
 rand_xorshift = { version = "0.3", default-features = false }
 rayon = { version = "1", default-features = false }
 rayon-core = { version = "1", default-features = false }
+rcgen = { version = "0.9", features = ["pem"] }
 regex = { version = "1", features = ["aho-corasick", "memchr", "perf", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "std", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
 regex-automata = { version = "0.1", features = ["regex-syntax", "std"] }
 regex-syntax = { version = "0.6", features = ["unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
@@ -227,8 +241,10 @@ ring = { version = "0.16", features = ["alloc", "dev_urandom_fallback", "once_ce
 rocksdb = { version = "0.19", default-features = false, features = ["lz4", "multi-threaded-cf", "snappy", "zlib", "zstd"] }
 rustc-demangle = { version = "0.1", default-features = false }
 rustc-hash = { version = "1", features = ["std"] }
-rustls = { version = "0.20", default-features = false, features = ["log", "logging", "tls12"] }
-rustls-pemfile = { version = "1", default-features = false }
+rusticata-macros = { version = "4", default-features = false }
+rustls = { version = "0.20", features = ["dangerous_configuration", "log", "logging", "quic", "tls12"] }
+rustls-pemfile-6f8ce4dd05d13bba = { package = "rustls-pemfile", version = "0.2", default-features = false }
+rustls-pemfile-dff4ba8e3ae991db = { package = "rustls-pemfile", version = "1", default-features = false }
 rusty-fork = { version = "0.3", default-features = false, features = ["timeout", "wait-timeout"] }
 ryu = { version = "1", default-features = false }
 same-file = { version = "1", default-features = false }
@@ -256,7 +272,7 @@ similar = { version = "2", features = ["inline", "text"] }
 slab = { version = "0.4", features = ["std"] }
 smallvec = { version = "1", default-features = false }
 socket2 = { version = "0.4", default-features = false, features = ["all"] }
-spki = { version = "0.6", default-features = false, features = ["alloc", "base64ct"] }
+spki = { version = "0.6", default-features = false, features = ["alloc", "base64ct", "std"] }
 static_assertions = { version = "1", default-features = false }
 strsim-93f6ce9d446188ac = { package = "strsim", version = "0.10", default-features = false }
 strsim-c38e5c1d305a1b54 = { package = "strsim", version = "0.8", default-features = false }
@@ -277,7 +293,7 @@ thousands = { version = "0.2", default-features = false }
 thread_local = { version = "1", default-features = false }
 threadpool = { version = "1", default-features = false }
 thrift = { version = "0.15", default-features = false }
-time = { version = "0.3", features = ["alloc", "formatting", "itoa", "std"] }
+time = { version = "0.3", features = ["alloc", "formatting", "itoa", "macros", "parsing", "std", "time-macros"] }
 tinytemplate = { version = "1", default-features = false }
 tinyvec = { version = "1", features = ["alloc", "tinyvec_macros"] }
 tinyvec_macros = { version = "0.1", default-features = false }
@@ -317,23 +333,28 @@ wait-timeout = { version = "0.2", default-features = false }
 walkdir = { version = "2", default-features = false }
 want = { version = "0.3", default-features = false }
 webpki = { version = "0.22", default-features = false, features = ["alloc", "std"] }
+x509-parser = { version = "0.14" }
 yaml-rust = { version = "0.4", default-features = false }
 yansi = { version = "0.5", default-features = false }
+yasna = { version = "0.5", features = ["std", "time"] }
 zeroize = { version = "1", features = ["alloc", "zeroize_derive"] }
 zstd-sys = { version = "2", features = ["legacy", "zdict_builder"] }
 
 [build-dependencies]
+anemo-build = { git = "https://github.com/mystenlabs/anemo.git", rev = "6278d0fa78147a49ff2cb9dd2e45e763886be0a0", default-features = false }
 anyhow = { version = "1", features = ["std"] }
 ark-ff-asm = { version = "0.3", default-features = false }
 ark-ff-macros = { version = "0.3", default-features = false }
 ark-serialize-derive = { version = "0.3", default-features = false }
+asn1-rs-derive = { version = "0.4", default-features = false }
+asn1-rs-impl = { version = "0.1", default-features = false }
 async-recursion = { version = "1", default-features = false }
 async-stream-impl = { version = "0.3", default-features = false }
 async-trait = { version = "0.1", default-features = false }
 autocfg = { version = "1", default-features = false }
 bindgen = { version = "0.60", default-features = false, features = ["runtime"] }
 bitflags = { version = "1" }
-bytes = { version = "1", features = ["std"] }
+bytes = { version = "1", features = ["serde", "std"] }
 cc = { version = "1", default-features = false, features = ["jobserver", "parallel"] }
 cexpr = { version = "0.6", default-features = false }
 cfg-if-c65f7effa3be6d31 = { package = "cfg-if", version = "0.1", default-features = false }
@@ -346,6 +367,7 @@ darling_macro = { version = "0.14", default-features = false }
 derivative = { version = "2", default-features = false, features = ["use_core"] }
 derive_builder_core = { version = "0.11", default-features = false }
 derive_builder_macro = { version = "0.11", default-features = false }
+displaydoc = { version = "0.2", features = ["std"] }
 either = { version = "1", features = ["use_std"] }
 fastrand = { version = "1", default-features = false }
 fixedbitset = { version = "0.4", default-features = false }
@@ -370,9 +392,9 @@ minimal-lexical = { version = "0.2", default-features = false, features = ["std"
 mockall_derive = { version = "0.11", default-features = false }
 multihash-derive = { version = "0.8", default-features = false, features = ["std"] }
 multimap = { version = "0.8", default-features = false }
-nom = { version = "7", default-features = false, features = ["alloc", "std"] }
-num-bigint = { version = "0.4", default-features = false }
-num-integer = { version = "0.1", default-features = false, features = ["i128"] }
+nom = { version = "7", features = ["alloc", "std"] }
+num-bigint = { version = "0.4", features = ["std"] }
+num-integer = { version = "0.1", default-features = false, features = ["i128", "std"] }
 num-traits = { version = "0.2", features = ["i128", "std"] }
 paste = { version = "1", default-features = false }
 peeking_take_while = { version = "0.1", default-features = false }
@@ -419,6 +441,7 @@ synstructure = { version = "0.12", features = ["proc-macro"] }
 tempfile = { version = "3", default-features = false }
 thiserror = { version = "1", default-features = false }
 thiserror-impl = { version = "1", default-features = false }
+time-macros = { version = "0.2", default-features = false }
 tokio-macros = { version = "1", default-features = false }
 toml = { version = "0.5" }
 tonic-build = { version = "0.7", features = ["prost", "prost-build", "transport"] }


### PR DESCRIPTION
Brief summary of the motivation for this change:
- Http (and gRPC) are built with one side of a connection being a client and the other being the server. Only clients are able to initial requests. This leads to requiring two nodes to maintain two connections between each other in order to communicate between each other.
- Due to the above, we can run into network reachability issues where a connection can be established from Node A -> B but not B -> A. Due to the way that narwhals communication is designed this leads to buffering up messages that cannot be delivered for some time.
- This new stack enables both sides of a connection to initiate Requests, enabling us to use 1 connection for all communication.
- Today we communicate in the clear with no authentication, QUIC requires TLS and as such we'll now how authentication and encryption by default (this would be possible with grpc but the libs we use make this more difficult since we don't rely on a central CA)
- Anemo is a p2p networking stack and as such has better utilities around answering questions like "how many connections do i have open", "who am i connected with", coupled with the ability to actually drop a connection from a peer (which today is very difficult or impossible with our current stack)
- Better connection pooling, today we actually make lots of connections between two nodes, with the new stack we'll better be able to share connections.
- QUIC has the potential to enable higher throughput and latency due to solving the head-of-line blocking problem that TCP can suffer from when multiplexing multiple streams of requests over the same connection