### PR TITLE
Log the start of primary components

### DIFF
--- a/primary/src/block_remover.rs
+++ b/primary/src/block_remover.rs
@@ -21,7 +21,7 @@ use tokio::{
     task::JoinHandle,
     time::timeout,
 };
-use tracing::{debug, error, instrument, warn};
+use tracing::{debug, error, info, instrument, warn};
 use types::{
     BatchDigest, BlockRemoverError, BlockRemoverErrorKind, BlockRemoverResult, Certificate,
     CertificateDigest, Header, HeaderDigest, PrimaryWorkerMessage, ReconfigureNotification,
@@ -264,7 +264,10 @@ impl BlockRemover {
     async fn run(&mut self) {
         let mut waiting = FuturesUnordered::new();
 
-        debug!("BlockRemover on {} is starting.", self.name);
+        info!(
+            "BlockRemover on node {} has started successfully.",
+            self.name
+        );
         loop {
             tokio::select! {
                 Some(command) = self.rx_commands.recv() => {

--- a/primary/src/block_remover.rs
+++ b/primary/src/block_remover.rs
@@ -264,6 +264,7 @@ impl BlockRemover {
     async fn run(&mut self) {
         let mut waiting = FuturesUnordered::new();
 
+        debug!("BlockRemover on {} is starting.", self.name);
         loop {
             tokio::select! {
                 Some(command) = self.rx_commands.recv() => {

--- a/primary/src/block_synchronizer/mod.rs
+++ b/primary/src/block_synchronizer/mod.rs
@@ -246,6 +246,7 @@ impl BlockSynchronizer {
         // processing.
         let mut waiting = FuturesUnordered::new();
 
+        debug!("BlockSynchronizer on {} is starting.", self.name);
         loop {
             tokio::select! {
                 Some(command) = self.rx_commands.recv() => {

--- a/primary/src/block_synchronizer/mod.rs
+++ b/primary/src/block_synchronizer/mod.rs
@@ -32,7 +32,7 @@ use tokio::{
     task::JoinHandle,
     time::{sleep, timeout},
 };
-use tracing::{debug, error, instrument, trace, warn};
+use tracing::{debug, error, info, instrument, trace, warn};
 use types::{
     BatchDigest, Certificate, CertificateDigest, PrimaryWorkerMessage, ReconfigureNotification,
 };
@@ -246,7 +246,10 @@ impl BlockSynchronizer {
         // processing.
         let mut waiting = FuturesUnordered::new();
 
-        debug!("BlockSynchronizer on {} is starting.", self.name);
+        info!(
+            "BlockSynchronizer on node {} has started successfully.",
+            self.name
+        );
         loop {
             tokio::select! {
                 Some(command) = self.rx_commands.recv() => {

--- a/primary/src/block_waiter.rs
+++ b/primary/src/block_waiter.rs
@@ -21,7 +21,7 @@ use tokio::{
     task::JoinHandle,
     time::timeout,
 };
-use tracing::{debug, error, instrument, warn};
+use tracing::{debug, error, info, instrument, warn};
 use types::{
     BatchDigest, BatchMessage, BlockError, BlockErrorKind, BlockResult, Certificate,
     CertificateDigest, Header, PrimaryWorkerMessage, ReconfigureNotification,
@@ -282,7 +282,10 @@ impl<SynchronizerHandler: Handler + Send + Sync + 'static> BlockWaiter<Synchroni
         let mut waiting_get_block = FuturesUnordered::new();
         let mut waiting_get_blocks = FuturesUnordered::new();
 
-        debug!("BlockWaiter on {} is starting.", self.name);
+        info!(
+            "BlockWaiter on node {} has started successfully.",
+            self.name
+        );
         loop {
             tokio::select! {
                 Some(command) = self.rx_commands.recv() => {

--- a/primary/src/block_waiter.rs
+++ b/primary/src/block_waiter.rs
@@ -282,6 +282,7 @@ impl<SynchronizerHandler: Handler + Send + Sync + 'static> BlockWaiter<Synchroni
         let mut waiting_get_block = FuturesUnordered::new();
         let mut waiting_get_blocks = FuturesUnordered::new();
 
+        debug!("BlockWaiter on {} is starting.", self.name);
         loop {
             tokio::select! {
                 Some(command) = self.rx_commands.recv() => {

--- a/primary/src/certificate_waiter.rs
+++ b/primary/src/certificate_waiter.rs
@@ -19,7 +19,7 @@ use tokio::{
     task::JoinHandle,
     time::{sleep, Duration, Instant},
 };
-use tracing::{debug, error};
+use tracing::{error, info};
 use types::{
     error::{DagError, DagResult},
     Certificate, CertificateDigest, HeaderDigest, ReconfigureNotification, Round,
@@ -113,7 +113,7 @@ impl CertificateWaiter {
         tokio::pin!(timer);
         let mut attempt_garbage_collection;
 
-        debug!("CertificateWaiter is starting.");
+        info!("CertificateWaiter has started successfully.");
         loop {
             // Initially set to not garbage collect
             attempt_garbage_collection = false;

--- a/primary/src/certificate_waiter.rs
+++ b/primary/src/certificate_waiter.rs
@@ -19,7 +19,7 @@ use tokio::{
     task::JoinHandle,
     time::{sleep, Duration, Instant},
 };
-use tracing::error;
+use tracing::{debug, error};
 use types::{
     error::{DagError, DagResult},
     Certificate, CertificateDigest, HeaderDigest, ReconfigureNotification, Round,
@@ -109,11 +109,11 @@ impl CertificateWaiter {
 
     async fn run(&mut self) {
         let mut waiting = FuturesUnordered::new();
-
         let timer = sleep(Duration::from_millis(GC_RESOLUTION));
         tokio::pin!(timer);
         let mut attempt_garbage_collection;
 
+        debug!("CertificateWaiter is starting.");
         loop {
             // Initially set to not garbage collect
             attempt_garbage_collection = false;

--- a/primary/src/core.rs
+++ b/primary/src/core.rs
@@ -24,7 +24,7 @@ use tokio::{
     },
     task::JoinHandle,
 };
-use tracing::{debug, error, instrument, warn};
+use tracing::{debug, error, info, instrument, warn};
 use types::{
     ensure,
     error::{DagError, DagResult},
@@ -546,7 +546,7 @@ impl Core {
 
     // Main loop listening to incoming messages.
     pub async fn run(&mut self) {
-        debug!("Core on {} is starting.", self.name);
+        info!("Core on node {} has started successfully.", self.name);
         loop {
             let result = tokio::select! {
                 // We receive here messages from other primaries.

--- a/primary/src/core.rs
+++ b/primary/src/core.rs
@@ -546,6 +546,7 @@ impl Core {
 
     // Main loop listening to incoming messages.
     pub async fn run(&mut self) {
+        debug!("Core on {} is starting.", self.name);
         loop {
             let result = tokio::select! {
                 // We receive here messages from other primaries.

--- a/primary/src/header_waiter.rs
+++ b/primary/src/header_waiter.rs
@@ -171,6 +171,7 @@ impl HeaderWaiter {
         let timer = sleep(Duration::from_millis(TIMER_RESOLUTION));
         tokio::pin!(timer);
 
+        debug!("HeaderWaiter on {} is starting.", self.name);
         loop {
             let mut attempt_garbage_collection = false;
 

--- a/primary/src/header_waiter.rs
+++ b/primary/src/header_waiter.rs
@@ -27,7 +27,7 @@ use tokio::{
     task::JoinHandle,
     time::{sleep, Duration, Instant},
 };
-use tracing::{debug, error};
+use tracing::{debug, error, info};
 use types::{
     error::{DagError, DagResult},
     BatchDigest, Certificate, CertificateDigest, Header, HeaderDigest, ReconfigureNotification,
@@ -171,7 +171,10 @@ impl HeaderWaiter {
         let timer = sleep(Duration::from_millis(TIMER_RESOLUTION));
         tokio::pin!(timer);
 
-        debug!("HeaderWaiter on {} is starting.", self.name);
+        info!(
+            "HeaderWaiter on node {} has started successfully.",
+            self.name
+        );
         loop {
             let mut attempt_garbage_collection = false;
 

--- a/primary/src/helper.rs
+++ b/primary/src/helper.rs
@@ -11,7 +11,7 @@ use tokio::{
     sync::{mpsc::Receiver, watch},
     task::JoinHandle,
 };
-use tracing::{debug, error, instrument};
+use tracing::{error, info, instrument};
 use types::{BatchDigest, Certificate, CertificateDigest, ReconfigureNotification};
 
 #[cfg(test)]
@@ -76,8 +76,8 @@ impl Helper {
     }
 
     async fn run(&mut self) {
-        debug!(
-            "Helper for availability requests on {} is starting.",
+        info!(
+            "Helper for availability requests on node {} has started successfully.",
             self.name
         );
         loop {

--- a/primary/src/helper.rs
+++ b/primary/src/helper.rs
@@ -11,7 +11,7 @@ use tokio::{
     sync::{mpsc::Receiver, watch},
     task::JoinHandle,
 };
-use tracing::{error, instrument};
+use tracing::{debug, error, instrument};
 use types::{BatchDigest, Certificate, CertificateDigest, ReconfigureNotification};
 
 #[cfg(test)]
@@ -76,6 +76,10 @@ impl Helper {
     }
 
     async fn run(&mut self) {
+        debug!(
+            "Helper for availability requests on {} is starting.",
+            self.name
+        );
         loop {
             tokio::select! {
                 Some(request) = self.rx_primaries.recv() => match request {

--- a/primary/src/payload_receiver.rs
+++ b/primary/src/payload_receiver.rs
@@ -5,6 +5,7 @@ use crate::primary::PayloadToken;
 use config::WorkerId;
 use store::Store;
 use tokio::{sync::mpsc::Receiver, task::JoinHandle};
+use tracing::debug;
 use types::BatchDigest;
 
 /// Receives batches' digests of other authorities. These are only needed to verify incoming
@@ -28,6 +29,7 @@ impl PayloadReceiver {
     }
 
     async fn run(&mut self) {
+        debug!("PayloadReceiver is starting.");
         while let Some((digest, worker_id)) = self.rx_workers.recv().await {
             self.store.write((digest, worker_id), 0u8).await;
         }

--- a/primary/src/payload_receiver.rs
+++ b/primary/src/payload_receiver.rs
@@ -5,7 +5,7 @@ use crate::primary::PayloadToken;
 use config::WorkerId;
 use store::Store;
 use tokio::{sync::mpsc::Receiver, task::JoinHandle};
-use tracing::debug;
+use tracing::info;
 use types::BatchDigest;
 
 /// Receives batches' digests of other authorities. These are only needed to verify incoming
@@ -29,7 +29,7 @@ impl PayloadReceiver {
     }
 
     async fn run(&mut self) {
-        debug!("PayloadReceiver is starting.");
+        info!("PayloadReceiver has started successfully.");
         while let Some((digest, worker_id)) = self.rx_workers.recv().await {
             self.store.write((digest, worker_id), 0u8).await;
         }

--- a/primary/src/primary.rs
+++ b/primary/src/primary.rs
@@ -37,7 +37,7 @@ use tokio::{
     task::JoinHandle,
 };
 use tonic::{Request, Response, Status};
-use tracing::{debug, info, log::error};
+use tracing::{info, log::error};
 use types::{
     error::DagError, BatchDigest, BatchMessage, BincodeEncodedPayload, Certificate,
     CertificateDigest, Empty, Header, HeaderDigest, PrimaryToPrimary, PrimaryToPrimaryServer,
@@ -517,7 +517,7 @@ impl PrimaryReceiverHandler {
         tokio::spawn(async move {
             let mut config = mysten_network::config::Config::new();
             config.concurrency_limit_per_connection = Some(max_concurrent_requests);
-            debug!("PrimaryReceiverHandler is starting.");
+            info!("PrimaryReceiverHandler has started successfully.");
             tokio::select! {
                 _result = config
                     .server_builder_with_metrics(primary_endpoint_metrics)
@@ -622,7 +622,7 @@ impl WorkerReceiverHandler {
         rx_reconfigure: watch::Receiver<ReconfigureNotification>,
     ) -> JoinHandle<()> {
         tokio::spawn(async move {
-            debug!("WorkerReceiverHandler is starting.");
+            info!("WorkerReceiverHandler has started successfully.");
             tokio::select! {
                 _result = mysten_network::config::Config::default()
                     .server_builder()

--- a/primary/src/primary.rs
+++ b/primary/src/primary.rs
@@ -37,7 +37,7 @@ use tokio::{
     task::JoinHandle,
 };
 use tonic::{Request, Response, Status};
-use tracing::{info, log::error};
+use tracing::{debug, info, log::error};
 use types::{
     error::DagError, BatchDigest, BatchMessage, BincodeEncodedPayload, Certificate,
     CertificateDigest, Empty, Header, HeaderDigest, PrimaryToPrimary, PrimaryToPrimaryServer,
@@ -158,7 +158,7 @@ impl Primary {
                             }
                         },
 
-                        // Check whether the committee changed.
+                    // Check whether the committee changed.
                     result = mon_rx_reconfigure.changed() => {
                         result.expect("Committee channel dropped");
                         let message = mon_rx_reconfigure.borrow().clone();
@@ -517,6 +517,7 @@ impl PrimaryReceiverHandler {
         tokio::spawn(async move {
             let mut config = mysten_network::config::Config::new();
             config.concurrency_limit_per_connection = Some(max_concurrent_requests);
+            debug!("PrimaryReceiverHandler is starting.");
             tokio::select! {
                 _result = config
                     .server_builder_with_metrics(primary_endpoint_metrics)
@@ -621,6 +622,7 @@ impl WorkerReceiverHandler {
         rx_reconfigure: watch::Receiver<ReconfigureNotification>,
     ) -> JoinHandle<()> {
         tokio::spawn(async move {
+            debug!("WorkerReceiverHandler is starting.");
             tokio::select! {
                 _result = mysten_network::config::Config::default()
                     .server_builder()

--- a/primary/src/proposer.rs
+++ b/primary/src/proposer.rs
@@ -209,6 +209,7 @@ impl Proposer {
         let timer = sleep(self.max_header_delay);
         tokio::pin!(timer);
 
+        debug!("Proposer on {} is starting.", self.name);
         loop {
             // Check if we can propose a new header. We propose a new header when we have a quorum of parents
             // and one of the following conditions is met:

--- a/primary/src/proposer.rs
+++ b/primary/src/proposer.rs
@@ -13,7 +13,7 @@ use tokio::{
     task::JoinHandle,
     time::{sleep, Duration, Instant},
 };
-use tracing::debug;
+use tracing::{debug, info};
 use types::{
     error::{DagError, DagResult},
     BatchDigest, Certificate, Header, ReconfigureNotification, Round,
@@ -209,7 +209,7 @@ impl Proposer {
         let timer = sleep(self.max_header_delay);
         tokio::pin!(timer);
 
-        debug!("Proposer on {} is starting.", self.name);
+        info!("Proposer on node {} has started successfully.", self.name);
         loop {
             // Check if we can propose a new header. We propose a new header when we have a quorum of parents
             // and one of the following conditions is met:

--- a/primary/src/state_handler.rs
+++ b/primary/src/state_handler.rs
@@ -10,6 +10,7 @@ use tokio::{
     sync::{mpsc::Receiver, watch},
     task::JoinHandle,
 };
+use tracing::debug;
 use types::{Certificate, ReconfigureNotification, Round};
 
 /// Receives the highest round reached by consensus and update it for all tasks.
@@ -85,6 +86,7 @@ impl StateHandler {
     }
 
     async fn run(&mut self) {
+        debug!("StateHandler on {} is starting.", self.name);
         loop {
             tokio::select! {
                 Some(certificate) = self.rx_consensus.recv() => {

--- a/primary/src/state_handler.rs
+++ b/primary/src/state_handler.rs
@@ -10,7 +10,7 @@ use tokio::{
     sync::{mpsc::Receiver, watch},
     task::JoinHandle,
 };
-use tracing::debug;
+use tracing::info;
 use types::{Certificate, ReconfigureNotification, Round};
 
 /// Receives the highest round reached by consensus and update it for all tasks.
@@ -86,7 +86,10 @@ impl StateHandler {
     }
 
     async fn run(&mut self) {
-        debug!("StateHandler on {} is starting.", self.name);
+        info!(
+            "StateHandler on node {} has started successfully.",
+            self.name
+        );
         loop {
             tokio::select! {
                 Some(certificate) = self.rx_consensus.recv() => {


### PR DESCRIPTION
Sample log lines:
```
2022-08-03T04:24:07.192145Z DEBUG primary::primary: PrimaryReceiverHandler is starting.
2022-08-03T04:24:07.193491Z DEBUG primary::primary: WorkerReceiverHandler is starting.
2022-08-03T04:24:07.193744Z DEBUG primary::core: Core on IP26ybELdYe7p7W8FjvOaeeW1x5O1EwQ/LRIhon3oUQ= is starting.
2022-08-03T04:24:07.193840Z DEBUG primary::payload_receiver: PayloadReceiver is starting.
2022-08-03T04:24:07.193894Z DEBUG primary::block_waiter: BlockWaiter on IP26ybELdYe7p7W8FjvOaeeW1x5O1EwQ/LRIhon3oUQ= is starting.
2022-08-03T04:24:07.193979Z DEBUG primary::block_remover: BlockRemover on IP26ybELdYe7p7W8FjvOaeeW1x5O1EwQ/LRIhon3oUQ= is starting.
2022-08-03T04:24:07.194043Z DEBUG primary::block_synchronizer: BlockSynchronizer on IP26ybELdYe7p7W8FjvOaeeW1x5O1EwQ/LRIhon3oUQ= is starting.
2022-08-03T04:24:07.194075Z DEBUG primary::header_waiter: HeaderWaiter on IP26ybELdYe7p7W8FjvOaeeW1x5O1EwQ/LRIhon3oUQ= is starting.
2022-08-03T04:24:07.194194Z DEBUG primary::certificate_waiter: CertificateWaiter is starting.
2022-08-03T04:24:07.194227Z DEBUG primary::proposer: Dag starting at round 0
2022-08-03T04:24:07.194235Z DEBUG primary::proposer: Proposer on IP26ybELdYe7p7W8FjvOaeeW1x5O1EwQ/LRIhon3oUQ= is starting.
2022-08-03T04:24:07.194261Z DEBUG primary::helper: Helper for availability requests on IP26ybELdYe7p7W8FjvOaeeW1x5O1EwQ/LRIhon3oUQ= is starting.
2022-08-03T04:24:07.194284Z DEBUG primary::state_handler: StateHandler on IP26ybELdYe7p7W8FjvOaeeW1x5O1EwQ/LRIhon3oUQ= is starting.
```

Adding logging to shutdown will be in another change.