### PR TITLE
Avoid blocking `tokio::select` branches on a potent. full channel

### DIFF
--- a/executor/src/errors.rs
+++ b/executor/src/errors.rs
@@ -21,10 +21,31 @@ macro_rules! ensure {
     };
 }
 
+#[macro_export]
+macro_rules! try_fut_and_permit {
+    ($fut:expr, $sender:expr) => {
+        futures::future::TryFutureExt::unwrap_or_else(
+            futures::future::try_join(
+                $fut,
+                futures::TryFutureExt::map_err($sender.reserve(), |_e| {
+                    SubscriberError::ClosedChannel(stringify!(sender).to_owned())
+                }),
+            ),
+            |e| {
+                tracing::error!("{e}");
+                panic!("I/O failure, killing the node.");
+            },
+        )
+    };
+}
+
 pub type SubscriberResult<T> = Result<T, SubscriberError>;
 
 #[derive(Debug, Error, Clone)]
 pub enum SubscriberError {
+    #[error("channel {0} closed unexpectedly")]
+    ClosedChannel(String),
+
     #[error("Storage failure: {0}")]
     StoreError(#[from] StoreError),
 


### PR DESCRIPTION
Checkpointing some (incomplete) backpressure work on top of #691.
This PR is an incremental improvement.

## Context

We often have branches of a `tokio::select` that fire, and then send a message on a channel as part of their immediate processing. This message is sent with `sender.send(message).await`, which does not return immediately. 

## The issue

This will yield to the executor, but not let the rest of the `select` resume.

## The solution

We introduce a macro that helps provide semantics by which a `select` branch fires if it has received an input for its condition (typically a `waiting.next()` or `receiver.recv()`) *and* can acquire a permit to send a message for a downstream channel (typically a `sender.send(result)`). This gives the other branches in the `select` a chance to fire in case the downstream channel is full, as the macro-using branch will then not fire. The macro meshes better than an async function with [the unusual borrowing behavior of the `select` macro](https://tokio.rs/tokio/tutorial/select#borrowing).