### PR TITLE
chore(deps): downgrade anyhow to 1.0.59

### DIFF
--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-anyhow = { version = "1.0.60", features = ["backtrace"] }
+anyhow = { version = "1.0.59", features = ["backtrace"] }
 ark-bls12-377 = { version = "0.3.0", features = ["std"], optional = true }
 base64ct = { version = "1.5.1", features = ["alloc"] }
 ed25519-consensus = { version = "2.0.1", features = ["serde"] }

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-anyhow = "1.0.60"
+anyhow = "1.0.59"
 async-trait = "0.1.57"
 backoff = { version = "0.4.0", features = ["tokio"] }
 bytes = "1.2.1"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2021"
 
 [dependencies]
-anyhow = "1.0.60"
+anyhow = "1.0.59"
 arc-swap = { version = "1.5.1", features = ["serde"] }
 async-trait = "0.1.57"
 bincode = "1.3.3"

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Mysten Labs <build@mystenlabs.com>"]
 edition = "2021"
 
 [dependencies]
-anyhow = "1.0.60"
+anyhow = "1.0.59"
 async-trait = "0.1.57"
 bincode = "1.3.3"
 blake2 = "0.9"


### PR DESCRIPTION
See https://github.com/dtolnay/anyhow/issues/250
The `backtrace` feature is unified against the various anyhow versions we use.