### PR TITLE
crypto: expose verify with hashed message as input in library

### DIFF
--- a/crypto/src/secp256k1.rs
+++ b/crypto/src/secp256k1.rs
@@ -98,6 +98,24 @@ impl Verifier<Secp256k1Signature> for Secp256k1PublicKey {
     }
 }
 
+impl Secp256k1PublicKey {
+    pub fn verify_hashed(
+        &self,
+        hased_msg: &[u8],
+        signature: &Secp256k1Signature,
+    ) -> Result<(), signature::Error> {
+        match Message::from_slice(hased_msg) {
+            Ok(message) => match signature.sig.recover(&message) {
+                Ok(recovered_key) if self.as_bytes() == recovered_key.serialize().as_slice() => {
+                    Ok(())
+                }
+                _ => Err(signature::Error::new()),
+            },
+            _ => Err(signature::Error::new()),
+        }
+    }
+}
+
 impl AsRef<[u8]> for Secp256k1PublicKey {
     fn as_ref(&self) -> &[u8] {
         self.bytes

--- a/crypto/src/tests/secp256k1_tests.rs
+++ b/crypto/src/tests/secp256k1_tests.rs
@@ -129,7 +129,7 @@ fn verify_valid_signature() {
     // Get a keypair.
     let kp = keys().pop().unwrap();
 
-    // Make signature.
+    // Sign over raw message, hashed to keccak256.
     let message: &[u8] = b"Hello, world!";
     let digest = message.digest();
 
@@ -137,6 +137,38 @@ fn verify_valid_signature() {
 
     // Verify the signature.
     assert!(kp.public().verify(&digest.0, &signature).is_ok());
+}
+
+#[test]
+fn verify_valid_signature_against_hashed_msg() {
+    // Get a keypair.
+    let kp = keys().pop().unwrap();
+
+    // Sign over raw message (hashed to keccak256 internally).
+    let message: &[u8] = b"Hello, world!";
+    let signature = kp.sign(message);
+
+    // Verify the signature against hashed message.
+    assert!(kp
+        .public()
+        .verify_hashed(
+            <sha3::Keccak256 as sha3::digest::Digest>::digest(message).as_slice(),
+            &signature
+        )
+        .is_ok());
+}
+
+#[test]
+fn verify_hashed_failed_if_message_unhashed() {
+    // Get a keypair.
+    let kp = keys().pop().unwrap();
+
+    // Sign over raw message (hashed to keccak256 internally).
+    let message: &[u8] = &[0u8; 1];
+    let signature = kp.sign(message);
+
+    // Verify the signature against unhashed msg fails.
+    assert!(kp.public().verify_hashed(message, &signature).is_err());
 }
 
 #[test]


### PR DESCRIPTION
https://github.com/MystenLabs/sui/issues/3844

exposing the verify hashed message API, so that Sui Move can use this to implement native function as part of the API