### PR TITLE
Consensus log message improvements

### DIFF
--- a/primary/src/core.rs
+++ b/primary/src/core.rs
@@ -452,7 +452,7 @@ impl Core {
         );
         ensure!(
             self.gc_round < header.round,
-            DagError::TooOld(header.id.into(), header.round)
+            DagError::TooOld(header.id.into(), header.round, self.gc_round)
         );
 
         // Verify the header's signature.
@@ -476,7 +476,7 @@ impl Core {
         );
         ensure!(
             self.current_header.round <= vote.round,
-            DagError::TooOld(vote.digest().into(), vote.round)
+            DagError::VoteTooOld(vote.digest().into(), vote.round, self.current_header.round)
         );
 
         // Ensure we receive a vote on the expected header.
@@ -504,7 +504,11 @@ impl Core {
         );
         ensure!(
             self.gc_round < certificate.round(),
-            DagError::TooOld(certificate.digest().into(), certificate.round())
+            DagError::TooOld(
+                certificate.digest().into(),
+                certificate.round(),
+                self.gc_round
+            )
         );
 
         // Verify the certificate (and the embedded header).

--- a/types/src/error.rs
+++ b/types/src/error.rs
@@ -57,8 +57,11 @@ pub enum DagError {
     #[error("Parents of header {0} are not a quorum")]
     HeaderRequiresQuorum(HeaderDigest),
 
-    #[error("Message {0} (round {1}) too old")]
-    TooOld(Digest, Round),
+    #[error("Message {0} (round {1}) too old for GC round {2}")]
+    TooOld(Digest, Round, Round),
+
+    #[error("Vote {0} (round {1}) too old for round {2}")]
+    VoteTooOld(Digest, Round, Round),
 
     #[error("Invalid epoch (expected {expected}, received {received})")]
     InvalidEpoch { expected: Epoch, received: Epoch },


### PR DESCRIPTION
Improves ~two~ a log messages:
- "TooOld"
- ~"Leader has/hasn't got enough support"~ this one actually doesn't need editing: you can figure it out from the certificate display