### PR TITLE
[fix] move & rename the dag size metric

### DIFF
--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -153,11 +153,6 @@ impl ConsensusState {
                 !authorities.is_empty()
             });
         }
-
-        self.metrics
-            .consensus_dag_size
-            .with_label_values(&[])
-            .set(self.dag.len() as i64);
     }
 }
 
@@ -327,6 +322,11 @@ where
                             tracing::warn!("Failed to output certificate: {e}");
                         }
                     }
+
+                    self.metrics
+                        .consensus_dag_size
+                        .with_label_values(&[])
+                        .set(state.dag.len() as i64);
                 },
 
                 // Check whether the committee changed.

--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -324,7 +324,7 @@ where
                     }
 
                     self.metrics
-                        .consensus_dag_size
+                        .consensus_dag_rounds
                         .with_label_values(&[])
                         .set(state.dag.len() as i64);
                 },

--- a/consensus/src/metrics.rs
+++ b/consensus/src/metrics.rs
@@ -8,7 +8,7 @@ use prometheus::{
 #[derive(Clone, Debug)]
 pub struct ConsensusMetrics {
     /// The number of rounds for which the Dag holds certificates (for Tusk or Bullshark)
-    pub consensus_dag_size: IntGaugeVec,
+    pub consensus_dag_rounds: IntGaugeVec,
     /// The last committed round from consensus
     pub last_committed_round: IntGaugeVec,
     /// The number of elements from the vertices secondary index (external consensus)
@@ -23,8 +23,8 @@ pub struct ConsensusMetrics {
 impl ConsensusMetrics {
     pub fn new(registry: &Registry) -> Self {
         Self {
-            consensus_dag_size: register_int_gauge_vec_with_registry!(
-                "consensus_dag_size",
+            consensus_dag_rounds: register_int_gauge_vec_with_registry!(
+                "consensus_dag_rounds",
                 "The number of rounds for which the consensus Dag holds certificates",
                 &[],
                 registry

--- a/consensus/src/metrics.rs
+++ b/consensus/src/metrics.rs
@@ -7,7 +7,7 @@ use prometheus::{
 
 #[derive(Clone, Debug)]
 pub struct ConsensusMetrics {
-    /// The number of elements in the Dag (for Tusk or Bullshark)
+    /// The number of rounds for which the Dag holds certificates (for Tusk or Bullshark)
     pub consensus_dag_size: IntGaugeVec,
     /// The last committed round from consensus
     pub last_committed_round: IntGaugeVec,
@@ -25,7 +25,7 @@ impl ConsensusMetrics {
         Self {
             consensus_dag_size: register_int_gauge_vec_with_registry!(
                 "consensus_dag_size",
-                "The number of elements (certificates) in consensus dag",
+                "The number of rounds for which the consensus Dag holds certificates",
                 &[],
                 registry
             ).unwrap(),


### PR DESCRIPTION
In our dashboard the `number of elements in DAG` metric was always staying the same (between 3-4) even in period where provenly the consensus was not producing any commit thus we would expect certificates to get accumulated in the DAG and cleaned up only when the next commit happened. That made me realise the metric was getting updated only when a leader was finally elected and elements were cleaned up from the dag anyways.

<img width="1208" alt="Screenshot 2022-08-10 at 12 04 08" src="https://user-images.githubusercontent.com/17335598/183886399-9c764b78-78e3-4250-a3a4-0014b92f17ee.png">

**In this PR:**
* Moved the metric so we can get the updated dag size even when a certificate gets processed from consensus - irrespective of whether a commit happens or not
* Changed the semantics of the metric. We now report the number of `rounds` the DAG holds. I didn't want to go as deep and start summing certificates from the DAG as this could be a bit expensive in cases of long asynchrony where many certificates get accumulated. A DAG with an increasing amount of rounds hold in it will give us pretty good signal that things aren't going as expected.
