### PR TITLE
chore: change end to end test run setup

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,8 +27,8 @@ env:
   RUST_BACKTRACE: short
 
 jobs:
-  ignored:
-    name: Run long-running tests
+  end-to-end-tests:
+    name: Run long-running end-to-end tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -39,9 +39,11 @@ jobs:
       - uses: bmwill/rust-cache@v1 # Fork of 'Swatinem/rust-cache' which allows caching additional paths
         with:
           path: ~/.cargo/registry/src/**/librocksdb-sys-*
-      - name: cargo test
+      # We run only the integration tests that are ignored under the primary package.
+      # These are considered the end-to-end "slow" tests for us
+      - name: cargo nextest
         run: |
-          cargo nextest run --profile ci --run-ignored ignored-only
+          cargo nextest run -E 'kind(test) + package(primary)' --run-ignored ignored-only
 
   beta:
     name: Run test on the beta channel


### PR DESCRIPTION
Currently we considered an `ignored` test a "long running" one. Thus an engineer who marks a test as `ignored` will force it to run under the long running test suite - and not getting actually ignored as it would be expected (there are circumstances where we might want to have a test temporarily ignored). Ex the [ignored test in the certificate_waiter](https://github.com/MystenLabs/narwhal/pull/742) which was meant to be ignored (because was failing) but ended up running in the long running tests causing them to break.

In order to avoid breaking the long running tests suite I propose via this PR to run only:
* the `integration tests` 
* under the `primary` package
* which are `ignored`

We can start loosing the semantics as we see the tests becoming more stable.