### PR TITLE
Input registry to restarter

### DIFF
--- a/node/src/restarter.rs
+++ b/node/src/restarter.rs
@@ -57,7 +57,7 @@ impl NodeRestarter {
                 /* consensus */ true,
                 execution_state.clone(),
                 tx_output.clone(),
-                &registry,
+                registry,
             )
             .await
             .unwrap();
@@ -68,7 +68,7 @@ impl NodeRestarter {
                 Arc::new(ArcSwap::new(Arc::new(committee.clone()))),
                 &store,
                 parameters.clone(),
-                &registry,
+                registry,
             );
 
             handles.extend(primary_handles);

--- a/node/src/restarter.rs
+++ b/node/src/restarter.rs
@@ -25,6 +25,7 @@ impl NodeRestarter {
         parameters: Parameters,
         mut rx_reconfigure: Receiver<(KeyPair, Committee)>,
         tx_output: Sender<ExecutorOutput<State>>,
+        registry: &Registry,
     ) where
         State: ExecutionState + Send + Sync + 'static,
         State::Outcome: Send + 'static,
@@ -56,7 +57,7 @@ impl NodeRestarter {
                 /* consensus */ true,
                 execution_state.clone(),
                 tx_output.clone(),
-                &Registry::new(),
+                &registry,
             )
             .await
             .unwrap();
@@ -67,7 +68,7 @@ impl NodeRestarter {
                 Arc::new(ArcSwap::new(Arc::new(committee.clone()))),
                 &store,
                 parameters.clone(),
-                &Registry::new(),
+                &registry,
             );
 
             handles.extend(primary_handles);

--- a/node/tests/reconfigure.rs
+++ b/node/tests/reconfigure.rs
@@ -189,6 +189,7 @@ async fn restart() {
                 parameters,
                 rx_node_reconfigure,
                 tx_output,
+                &Registry::new(),
             )
             .await;
         });


### PR DESCRIPTION
The restarter should take the registry as input rather than re-creating a new one every time.