### PR TITLE
[fix] block_waiter serve blocks with batches of similar digest ids

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2794,6 +2794,7 @@ dependencies = [
  "prost",
  "rand 0.8.5",
  "serde",
+ "tap",
  "telemetry-subscribers",
  "tempfile",
  "test_utils",
@@ -3774,6 +3775,12 @@ dependencies = [
  "syn 1.0.98",
  "unicode-xid 0.2.3",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "task-group"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5081,6 +5081,7 @@ dependencies = [
  "syn 1.0.98",
  "sync_wrapper",
  "synstructure",
+ "tap",
  "task-group",
  "telemetry-subscribers",
  "tempfile",

--- a/primary/Cargo.toml
+++ b/primary/Cargo.toml
@@ -31,6 +31,7 @@ tokio-util = { version = "0.7.3", features = ["codec"] }
 tonic = "0.7.2"
 tower = "0.4.13"
 tracing = "0.1.36"
+tap = "1.0.1"
 
 consensus = { path = "../consensus" }
 crypto = { path = "../crypto" }

--- a/primary/src/block_waiter.rs
+++ b/primary/src/block_waiter.rs
@@ -230,7 +230,8 @@ pub struct BlockWaiter<SynchronizerHandler: Handler + Send + Sync + 'static> {
     /// On the key we hold the batch id (we assume it's globally unique).
     /// On the value we hold a tuple of the channel to communicate the result
     /// to and also a timestamp of when the request was sent.
-    tx_pending_batch: HashMap<BatchDigest, HashMap<CertificateDigest, oneshot::Sender<BatchResult>>>,
+    tx_pending_batch:
+        HashMap<BatchDigest, HashMap<CertificateDigest, oneshot::Sender<BatchResult>>>,
 
     /// A map that holds the channels we should notify with the
     /// GetBlock responses.
@@ -595,7 +596,9 @@ impl<SynchronizerHandler: Handler + Send + Sync + 'static> BlockWaiter<Synchroni
         debug!("No pending get block for {}", id);
 
         // Add on a vector the receivers
-        let batch_receivers = self.send_batch_requests(id, certificate.header.clone()).await;
+        let batch_receivers = self
+            .send_batch_requests(id, certificate.header.clone())
+            .await;
 
         let fut = Self::wait_for_all_batches(id, batch_receivers);
 
@@ -727,7 +730,10 @@ impl<SynchronizerHandler: Handler + Send + Sync + 'static> BlockWaiter<Synchroni
 
                 map.insert(block_id, tx);
             } else {
-                self.tx_pending_batch.entry(digest).or_default().insert(block_id, tx);
+                self.tx_pending_batch
+                    .entry(digest)
+                    .or_default()
+                    .insert(block_id, tx);
 
                 debug!(
                     "Sending batch {} request to worker id {}",

--- a/primary/src/block_waiter.rs
+++ b/primary/src/block_waiter.rs
@@ -227,9 +227,11 @@ pub struct BlockWaiter<SynchronizerHandler: Handler + Send + Sync + 'static> {
     rx_batch_receiver: Receiver<BatchResult>,
 
     /// Maps batch ids to channels that "listen" for arrived batch messages.
-    /// On the key we hold the batch id (we assume it's globally unique).
-    /// On the value we hold a tuple of the channel to communicate the result
-    /// to and also a timestamp of when the request was sent.
+    /// On the key we hold the batch id.
+    /// On the value we hold a map of CertificateDigest --> oneshot::Sender
+    /// as we might need to deliver the batch result for requests from multiple
+    /// certificates (although not really probable its still possible for batches of
+    /// same id to be included in multiple headers).
     tx_pending_batch:
         HashMap<BatchDigest, HashMap<CertificateDigest, oneshot::Sender<BatchResult>>>,
 

--- a/primary/src/tests/block_waiter_tests.rs
+++ b/primary/src/tests/block_waiter_tests.rs
@@ -143,20 +143,21 @@ async fn test_successfully_retrieve_multiple_blocks() {
     let mut expected_get_block_responses = Vec::new();
     let mut certificates = Vec::new();
 
-    for _ in 0..2 {
+    // Batches to be used as "commons" between headers
+    // Practically we want to test the case where different headers happen
+    // to refer to batches with same id.
+    let common_batch_1 = fixture_batch_with_transactions(10);
+    let common_batch_2 = fixture_batch_with_transactions(10);
+
+    for i in 0..10 {
+        let mut builder = fixture_header_builder();
+
         let batch_1 = fixture_batch_with_transactions(10);
         let batch_2 = fixture_batch_with_transactions(10);
 
-        let header = fixture_header_builder()
+        builder = builder
             .with_payload_batch(batch_1.clone(), worker_id)
-            .with_payload_batch(batch_2.clone(), worker_id)
-            .build(&key)
-            .unwrap();
-
-        let certificate = certificate(&header);
-        certificates.push(certificate.clone());
-
-        block_ids.push(certificate.digest());
+            .with_payload_batch(batch_2.clone(), worker_id);
 
         expected_batch_messages.insert(
             batch_1.digest(),
@@ -185,8 +186,51 @@ async fn test_successfully_retrieve_multiple_blocks() {
             },
         ];
 
+        // The first 5 headers will have unique payload.
+        // The next 5 will be created with common payload (some similar
+        // batches will be used)
+        if i > 5 {
+            builder = builder
+                .with_payload_batch(common_batch_1.clone(), worker_id)
+                .with_payload_batch(common_batch_2.clone(), worker_id);
+
+            expected_batch_messages.insert(
+                common_batch_1.digest(),
+                BatchMessage {
+                    id: common_batch_1.digest(),
+                    transactions: common_batch_1.clone(),
+                },
+            );
+
+            expected_batch_messages.insert(
+                common_batch_2.digest(),
+                BatchMessage {
+                    id: common_batch_2.digest(),
+                    transactions: common_batch_2.clone(),
+                },
+            );
+
+            batches.push(BatchMessage {
+                id: common_batch_1.digest(),
+                transactions: common_batch_1.clone(),
+            });
+            batches.push(BatchMessage {
+                id: common_batch_2.digest(),
+                transactions: common_batch_2.clone(),
+            });
+        }
+
         // sort the batches to make sure that the response is the expected one.
         batches.sort_by(|a, b| a.id.cmp(&b.id));
+
+        let header = builder
+            .build(&key)
+            .unwrap();
+
+        let certificate = certificate(&header);
+        certificates.push(certificate.clone());
+
+        block_ids.push(certificate.digest());
 
         expected_get_block_responses.push(Ok(GetBlockResponse {
             id: certificate.digest(),

--- a/primary/src/tests/block_waiter_tests.rs
+++ b/primary/src/tests/block_waiter_tests.rs
@@ -223,9 +223,7 @@ async fn test_successfully_retrieve_multiple_blocks() {
         // sort the batches to make sure that the response is the expected one.
         batches.sort_by(|a, b| a.id.cmp(&b.id));
 
-        let header = builder
-            .build(&key)
-            .unwrap();
+        let header = builder.build(&key).unwrap();
 
         let certificate = certificate(&header);
         certificates.push(certificate.clone());

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -263,6 +263,7 @@ structopt = { version = "0.3" }
 subtle = { version = "2", default-features = false, features = ["i128", "std"] }
 subtle-ng = { version = "2", default-features = false }
 sync_wrapper = { version = "0.1", default-features = false }
+tap = { version = "1", default-features = false }
 task-group = { version = "0.2", default-features = false }
 telemetry-subscribers = { git = "https://github.com/mystenlabs/mysten-infra.git", rev = "f4aa523d3029bd6a23bead5f04c182f2cfa04c5e", features = ["chrome", "jaeger", "opentelemetry", "opentelemetry-jaeger", "tracing-chrome", "tracing-opentelemetry"] }
 tempfile = { version = "3", default-features = false }


### PR DESCRIPTION
When created the `block_waiter` the assumption was that each produced batch will resolve to a unique digest id. Given the current design this is not guaranteed. If someone posts the same transactions _we could_ end up producing batches with the same batch id. That became more apparent from the tests on the [reconfigure.rs](https://github.com/MystenLabs/narwhal/blob/84db6c88f9a179ab3e145ecf81a86117cb522348/node/tests/reconfigure.rs#L158) while working on the task to swap the `batch_loader`  and use the `block_waiter` https://github.com/MystenLabs/narwhal/pull/738 . The tests are producing transactions of the exact same payload ending producing batches of same batch ids. Consequently the `block_waiter` was failing to successfully respond to concurrent requests of different certificates with common batch ids leading to receiving error messages like this:
```
Couldn't find pending batch with id ....
```

which is produced when trying to send a batch reply to the aggregator which waits for a certificate's batches to be received. Since `tx_pending_batch` was holding only the latest request's one shot sender, we couldn't basically notify multiple aggregators for the receipt of the batch.

This PR is fixing this. Also a small optimisation is performed to make sure that only `one network request` will be made to fetch a batch from a worker.

Merging this PR is essential in order to unblock the https://github.com/MystenLabs/narwhal/pull/738 as the [reconfigure.rs](https://github.com/MystenLabs/narwhal/blob/84db6c88f9a179ab3e145ecf81a86117cb522348/node/tests/reconfigure.rs#L158) will keep failing.