### PR TITLE
crypto: ensure same length of the aggregated sigs and pubkeys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,9 +48,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.60"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c794e162a5eff65c72ef524dfe393eb923c354e350bb78b9c7383df13f3bc142"
+checksum = "c91f1f46651137be86f3a2b9a8359f9ab421d04d941c62b5982e1ca21113adf9"
 
 [[package]]
 name = "arc-swap"

--- a/crypto/src/ed25519.rs
+++ b/crypto/src/ed25519.rs
@@ -341,6 +341,9 @@ impl AggregateAuthenticator for Ed25519AggregateSignature {
         let mut batch = batch::Verifier::new();
 
         for i in 0..pks.len() {
+            if pks[i].len() != sigs[i].0.len() {
+                return Err(signature::Error::new());
+            }
             for j in 0..pks[i].len() {
                 let vk_bytes = VerificationKeyBytes::from(pks[i][j].0);
                 batch.queue((vk_bytes, sigs[i].0[j], messages[i]));

--- a/crypto/src/tests/ed25519_tests.rs
+++ b/crypto/src/tests/ed25519_tests.rs
@@ -320,6 +320,29 @@ fn verify_batch_aggregate_signature_length_mismatch() {
     )
     .is_err());
 
+    // add an extra signature to both aggregated_signature that batch_verify takes in
+    let mut signatures1_with_extra = aggregated_signature1.clone();
+    let kp = &keys()[0];
+    let sig = kp.sign(&digest1.0);
+    let res = signatures1_with_extra.add_signature(sig);
+    assert!(res.is_ok());
+
+    let mut signatures2_with_extra = aggregated_signature2.clone();
+    let kp = &keys()[0];
+    let sig2 = kp.sign(&digest1.0);
+    let res = signatures2_with_extra.add_signature(sig2);
+    assert!(res.is_ok());
+
+    assert!(Ed25519AggregateSignature::batch_verify(
+        &[
+            signatures1_with_extra.clone(),
+            signatures2_with_extra.clone()
+        ],
+        &[&pubkeys1[..]],
+        &[&digest1.0[..], &digest2.0[..]]
+    )
+    .is_err());
+
     assert!(Ed25519AggregateSignature::batch_verify(
         &[aggregated_signature1.clone(), aggregated_signature2.clone()],
         &[&pubkeys1[..], &pubkeys2[1..]],


### PR DESCRIPTION
previously, ed25519-dalek's batch_verify takes in two arrays of signatures and pubkeys to verify. but for ed25519-consensus library, the user of the library needs to feed in each paired sig and pubkey. 

there is a bug introduced by https://github.com/MystenLabs/narwhal/pull/624 that the number of sigs is more than the number of pubkey provided, the for loop will only verify the first numbers of the sig and pubkey pairs, and terminate as OK and ignores the extra sig. 

example: 

```
Ed25519AggregateSignature::batch_verify(
        &[vec(sig1, sig2, sig3, sig4, bad_sig), vec(sig5, sig6, sig7, sig8, bad_sig)],
        &[vec(pk1, pk2, pk3, pk4), vec(pk5, pk6, pk7, pk8)],
        &[msg1, msg2]
    )
```

this is caught by a test case `test_handle_reject_malicious_signature` in sui that a malicious sig is added to the array to cause one extra sig provided, but not verified. 
