### PR TITLE
ci: move rust build/test to ghcloud

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,9 +53,8 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-latest
-          # TODO: reactivate when we have self-hosted runners
-          # - windows-latest
+          - ubuntu-ghcloud
+          - windows-ghcloud
       fail-fast: false
     env:
       RUSTFLAGS: -D warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,6 +53,7 @@ jobs:
     strategy:
       matrix:
         os:
+          - ubuntu-latest
           - ubuntu-ghcloud
           - windows-ghcloud
       fail-fast: false


### PR DESCRIPTION
This also re-enables the windows build.