### PR TITLE
Update Ed25519Signature ser/de logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -958,6 +958,7 @@ dependencies = [
  "secp256k1",
  "serde",
  "serde-reflection",
+ "serde_bytes",
  "serde_json",
  "serde_with",
  "sha3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -957,6 +957,7 @@ dependencies = [
  "readonly",
  "secp256k1",
  "serde",
+ "serde-reflection",
  "serde_json",
  "serde_with",
  "sha3",

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -16,6 +16,7 @@ hkdf = { version = "0.12.3", features = ["std"] }
 rand = { version = "0.8.5", features = ["std"] }
 rust_secp256k1 = { version = "0.24.0", package = "secp256k1", features = ["recovery", "rand-std", "bitcoin_hashes", "global-context"] }
 serde = { version = "1.0.142", features = ["derive"] }
+serde_bytes = "0.11.7"
 serde_with = "2.0.0"
 signature = "1.5.0"
 tokio = { version = "1.20.1", features = ["sync", "rt", "macros"] }

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -21,7 +21,7 @@ signature = "1.5.0"
 tokio = { version = "1.20.1", features = ["sync", "rt", "macros"] }
 zeroize = "1.5.7"
 
-# TODO: switch to https://github.com/celo-org/celo-bls-snark-rs 
+# TODO: switch to https://github.com/celo-org/celo-bls-snark-rs
 # when https://github.com/celo-org/celo-bls-snark-rs/issues/228 is solved
 celo-bls = { git = "https://github.com/huitseeker/celo-bls-snark-rs", branch = "updates-2", package = "bls-crypto", optional = true }
 
@@ -55,3 +55,4 @@ proptest = "1.0.0"
 proptest-derive = "0.3.0"
 serde_json = "1.0.83"
 sha3 = "0.10.2"
+serde-reflection = "0.3.6"

--- a/crypto/src/tests/ed25519_tests.rs
+++ b/crypto/src/tests/ed25519_tests.rs
@@ -12,6 +12,7 @@ use crate::{
     traits::{AggregateAuthenticator, EncodeDecodeBase64, KeyPair, ToFromBytes, VerifyingKey},
 };
 use blake2::digest::Update;
+use ed25519_consensus::VerificationKey;
 use rand::{rngs::StdRng, SeedableRng as _};
 use serde_reflection::{Samples, Tracer, TracerConfig};
 use sha3::Sha3_256;
@@ -52,7 +53,7 @@ fn serialize_deserialize() {
 }
 
 #[test]
-fn serde_reflection() {
+fn custom_serde_reflection() {
     let config = TracerConfig::default()
         .record_samples_for_newtype_structs(true)
         .record_samples_for_structs(true)
@@ -66,6 +67,9 @@ fn serde_reflection() {
         .trace_value(&mut samples, &sig)
         .expect("trace value Ed25519Signature");
     assert!(samples.value("Ed25519Signature").is_some());
+    tracer
+        .trace_type::<Ed25519Signature>(&samples)
+        .expect("trace type Ed25519PublicKey");
 
     let kpref = keys().pop().unwrap();
     let public_key = kpref.public();
@@ -73,14 +77,11 @@ fn serde_reflection() {
         .trace_value(&mut samples, public_key)
         .expect("trace value Ed25519PublicKey");
     assert!(samples.value("Ed25519PublicKey").is_some());
-
-    // TODO: make the logic below work. Related to node/src/generate_format.rs#L137
-    // tracer
-    //     .trace_type::<Ed25519Signature>(&samples)
-    //     .expect("trace type Ed25519PublicKey");
-    // tracer
-    //     .trace_type::<Ed25519PublicKey>(&samples)
-    //     .expect("trace type Ed25519PublicKey");
+    // The Ed25519PublicKey struct and its ser/de implementation treats itself as a "newtype struct".
+    // But `trace_type()` only supports the base type.
+    tracer
+        .trace_type::<VerificationKey>(&samples)
+        .expect("trace type VerificationKey");
 }
 
 #[test]
@@ -100,10 +101,9 @@ fn test_serde_signatures_human_readable() {
     let signature = kp.sign(message);
 
     let serialized = serde_json::to_string(&signature).unwrap();
-    println!("{:?}", serialized);
     assert_eq!(
         format!(
-            "\"{}\"",
+            r#"{{"base64":"{}"}}"#,
             base64ct::Base64::encode_string(&signature.sig.to_bytes())
         ),
         serialized

--- a/crypto/src/tests/ed25519_tests.rs
+++ b/crypto/src/tests/ed25519_tests.rs
@@ -11,9 +11,9 @@ use crate::{
     hkdf::hkdf_generate_from_ikm,
     traits::{AggregateAuthenticator, EncodeDecodeBase64, KeyPair, ToFromBytes, VerifyingKey},
 };
-
 use blake2::digest::Update;
 use rand::{rngs::StdRng, SeedableRng as _};
+use serde_reflection::{Samples, Tracer, TracerConfig};
 use sha3::Sha3_256;
 use signature::{Signer, Verifier};
 
@@ -49,6 +49,38 @@ fn serialize_deserialize() {
 
     // serialize with Ed25519PublicKey fails
     assert!(bincode::deserialize::<Ed25519PublicKey>(&bytes).is_err());
+}
+
+#[test]
+fn serde_reflection() {
+    let config = TracerConfig::default()
+        .record_samples_for_newtype_structs(true)
+        .record_samples_for_structs(true)
+        .record_samples_for_tuple_structs(true);
+    let mut tracer = Tracer::new(config);
+    let mut samples = Samples::new();
+
+    let message = b"hello, narwhal";
+    let sig = keys().pop().unwrap().sign(message);
+    tracer
+        .trace_value(&mut samples, &sig)
+        .expect("trace value Ed25519Signature");
+    assert!(samples.value("Ed25519Signature").is_some());
+
+    let kpref = keys().pop().unwrap();
+    let public_key = kpref.public();
+    tracer
+        .trace_value(&mut samples, public_key)
+        .expect("trace value Ed25519PublicKey");
+    assert!(samples.value("Ed25519PublicKey").is_some());
+
+    // TODO: make the logic below work. Related to node/src/generate_format.rs#L137
+    // tracer
+    //     .trace_type::<Ed25519Signature>(&samples)
+    //     .expect("trace type Ed25519PublicKey");
+    // tracer
+    //     .trace_type::<Ed25519PublicKey>(&samples)
+    //     .expect("trace type Ed25519PublicKey");
 }
 
 #[test]

--- a/node/src/generate_format.rs
+++ b/node/src/generate_format.rs
@@ -126,18 +126,6 @@ fn get_registry() -> Result<Registry> {
     tracer.trace_type::<HeaderDigest>(&samples)?;
     tracer.trace_type::<CertificateDigest>(&samples)?;
 
-    // Caveat: the following (trace_type) won't work, but not because of generics.
-    //
-    // Generic types instantiated multiple times in the same tracing session requires a work around.
-    // https://docs.rs/serde-reflection/latest/serde_reflection/#features-and-limitations
-    // but here we should be fine.
-    //
-    // This doesn't work because of the custom ser/de in PublicKey, which carries through to most top-level messages
-    //
-    // tracer.trace_type::<Header<Ed25519PublicKey>>(&samples)?;
-    // tracer.trace_type::<Certificate<Ed25519PublicKey>>(&samples)?;
-    // tracer.trace_type::<PrimaryWorkerMessage<Ed25519PublicKey>>(&samples)?;
-
     // The final entry points that we must document
     tracer.trace_type::<WorkerPrimaryMessage>(&samples)?;
     tracer.trace_type::<WorkerPrimaryError>(&samples)?;

--- a/node/tests/staged/narwhal.yaml
+++ b/node/tests/staged/narwhal.yaml
@@ -26,7 +26,7 @@ Certificate:
         SEQ:
           TUPLE:
             - TYPENAME: Ed25519PublicKey
-            - SEQ: U8
+            - TYPENAME: Ed25519Signature
 CertificateDigest:
   NEWTYPESTRUCT:
     TUPLEARRAY:
@@ -42,6 +42,8 @@ Committee:
             TYPENAME: Authority
     - epoch: U64
 Ed25519PublicKey:
+  NEWTYPESTRUCT: STR
+Ed25519Signature:
   NEWTYPESTRUCT: STR
 Header:
   STRUCT:
@@ -60,7 +62,7 @@ Header:
     - id:
         TYPENAME: HeaderDigest
     - signature:
-        SEQ: U8
+        TYPENAME: Ed25519Signature
 HeaderDigest:
   NEWTYPESTRUCT:
     TUPLEARRAY:
@@ -152,4 +154,3 @@ WorkerPrimaryMessage:
       Reconfigure:
         NEWTYPE:
           TYPENAME: ReconfigureNotification
-

--- a/node/tests/staged/narwhal.yaml
+++ b/node/tests/staged/narwhal.yaml
@@ -44,7 +44,8 @@ Committee:
 Ed25519PublicKey:
   NEWTYPESTRUCT: STR
 Ed25519Signature:
-  NEWTYPESTRUCT: STR
+  STRUCT:
+    - raw: BYTES
 Header:
   STRUCT:
     - author:


### PR DESCRIPTION
Implement struct ser/de logic for `Ed25519Signature`. The current ser/de logic of `Ed25519Signature` just returns a `&[u8]`, making it being treated as `[u8]` by `serde_reflection` and causing ser/de failures.

I investigated if we can rely on `serde` annotations and avoid manual implementation of struct ser/de. But it seems there is no straightforward way unless we want to compromise on
- Using cached `bytes` for ser/de.
- And / or using base64 for readable serialization.