### PR TITLE
[crypto] standardize verify_batch behaviour and systematize tests

### DIFF
--- a/crypto/benches/crypto.rs
+++ b/crypto/benches/crypto.rs
@@ -113,21 +113,21 @@ mod ed25519_benches {
                 BenchmarkId::new("Ed25519 batch verification", *size),
                 &(msg.clone(), ed_public_keys, ed_signatures),
                 |b, i| {
-                    b.iter(|| VerifyingKey::verify_batch(&i.0, &i.1[..], &i.2[..]));
+                    b.iter(|| VerifyingKey::verify_batch_empty_fail(&i.0, &i.1[..], &i.2[..]));
                 },
             );
             c.bench_with_input(
                 BenchmarkId::new("BLS12377 batch verification", *size),
                 &(msg.clone(), bls_public_keys, bls_signatures),
                 |b, i| {
-                    b.iter(|| VerifyingKey::verify_batch(&i.0, &i.1[..], &i.2[..]));
+                    b.iter(|| VerifyingKey::verify_batch_empty_fail(&i.0, &i.1[..], &i.2[..]));
                 },
             );
             c.bench_with_input(
                 BenchmarkId::new("BLS12381 batch verification", *size),
                 &(msg, blst_public_keys, blst_signatures),
                 |b, i| {
-                    b.iter(|| VerifyingKey::verify_batch(&i.0, &i.1[..], &i.2[..]));
+                    b.iter(|| VerifyingKey::verify_batch_empty_fail(&i.0, &i.1[..], &i.2[..]));
                 },
             );
         }

--- a/crypto/src/tests/bls12377_tests.rs
+++ b/crypto/src/tests/bls12377_tests.rs
@@ -80,8 +80,7 @@ fn verify_invalid_signature() {
     assert!(kp.public().verify(&digest.0, &signature).is_err());
 }
 
-#[test]
-fn verify_valid_batch() {
+fn signature_test_inputs() -> (Vec<u8>, Vec<BLS12377PublicKey>, Vec<BLS12377Signature>) {
     // Make signatures.
     let message: &[u8] = b"Hello, world!";
     let digest = message.digest();
@@ -94,95 +93,78 @@ fn verify_valid_batch() {
         })
         .unzip();
 
-    // Verify the batch.
-    let res = BLS12377PublicKey::verify_batch(&digest.0, &pubkeys, &signatures);
+    (digest.to_vec(), pubkeys, signatures)
+}
+
+#[test]
+fn verify_valid_batch() {
+    let (digest, pubkeys, signatures) = signature_test_inputs();
+
+    let res = BLS12377PublicKey::verify_batch_empty_fail(&digest[..], &pubkeys, &signatures);
     assert!(res.is_ok(), "{:?}", res);
 }
 
 #[test]
 fn verify_invalid_batch() {
-    // Make signatures.
-    let message: &[u8] = b"Hello, world!";
-    let digest = message.digest();
-    let (pubkeys, mut signatures): (Vec<BLS12377PublicKey>, Vec<BLS12377Signature>) = keys()
-        .into_iter()
-        .take(3)
-        .map(|kp| {
-            let sig = kp.sign(&digest.0);
-            (kp.public().clone(), sig)
-        })
-        .unzip();
-
+    let (digest, pubkeys, mut signatures) = signature_test_inputs();
     // mangle one signature
     signatures[0] = BLS12377Signature::default();
 
-    // Verify the batch.
-    let res = BLS12377PublicKey::verify_batch(&digest.0, &pubkeys, &signatures);
+    let res = BLS12377PublicKey::verify_batch_empty_fail(&digest[..], &pubkeys, &signatures);
     assert!(res.is_err(), "{:?}", res);
 }
 
 #[test]
-fn verify_valid_aggregate_signature() {
-    // Make signatures.
-    let message: &[u8] = b"Hello, world!";
-    let digest = message.digest();
-    let (pubkeys, signatures): (Vec<BLS12377PublicKey>, Vec<BLS12377Signature>) = keys()
-        .into_iter()
-        .take(3)
-        .map(|kp| {
-            let sig = kp.sign(&digest.0);
-            (kp.public().clone(), sig)
-        })
-        .unzip();
+fn verify_empty_batch() {
+    let (digest, _, _) = signature_test_inputs();
 
+    let res = BLS12377PublicKey::verify_batch_empty_fail(&digest[..], &[], &[]);
+    assert!(res.is_err(), "{:?}", res);
+}
+
+#[test]
+fn verify_batch_missing_public_keys() {
+    let (digest, pubkeys, signatures) = signature_test_inputs();
+
+    // missing leading public keys
+    let res = BLS12377PublicKey::verify_batch_empty_fail(&digest, &pubkeys[1..], &signatures);
+    assert!(res.is_err(), "{:?}", res);
+
+    // missing trailing public keys
+    let res = BLS12377PublicKey::verify_batch_empty_fail(
+        &digest,
+        &pubkeys[..pubkeys.len() - 1],
+        &signatures,
+    );
+    assert!(res.is_err(), "{:?}", res);
+}
+
+#[test]
+fn verify_valid_aggregate_signaature() {
+    let (digest, pubkeys, signatures) = signature_test_inputs();
     let aggregated_signature = BLS12377AggregateSignature::aggregate(signatures).unwrap();
 
-    // // Verify the batch.
-    let res = aggregated_signature.verify(&pubkeys[..], &digest.0);
+    let res = aggregated_signature.verify(&pubkeys[..], &digest);
     assert!(res.is_ok(), "{:?}", res);
 }
 
 #[test]
 fn verify_invalid_aggregate_signature_length_mismatch() {
-    // Make signatures.
-    let message: &[u8] = b"Hello, world!";
-    let digest = message.digest();
-    let (pubkeys, signatures): (Vec<BLS12377PublicKey>, Vec<BLS12377Signature>) = keys()
-        .into_iter()
-        .take(3)
-        .map(|kp| {
-            let sig = kp.sign(&digest.0);
-            (kp.public().clone(), sig)
-        })
-        .unzip();
-
+    let (digest, pubkeys, signatures) = signature_test_inputs();
     let aggregated_signature = BLS12377AggregateSignature::aggregate(signatures).unwrap();
 
-    // // Verify the batch.
-    let res = aggregated_signature.verify(&pubkeys[..2], &digest.0);
+    let res = aggregated_signature.verify(&pubkeys[..2], &digest);
     assert!(res.is_err(), "{:?}", res);
 }
 
 #[test]
 fn verify_invalid_aggregate_signature_public_key_switch() {
-    // Make signatures.
-    let message: &[u8] = b"Hello, world!";
-    let digest = message.digest();
-    let (mut pubkeys, signatures): (Vec<BLS12377PublicKey>, Vec<BLS12377Signature>) = keys()
-        .into_iter()
-        .take(3)
-        .map(|kp| {
-            let sig = kp.sign(&digest.0);
-            (kp.public().clone(), sig)
-        })
-        .unzip();
-
+    let (digest, mut pubkeys, signatures) = signature_test_inputs();
     let aggregated_signature = BLS12377AggregateSignature::aggregate(signatures).unwrap();
 
     pubkeys[0] = keys()[3].public().clone();
 
-    // // Verify the batch.
-    let res = aggregated_signature.verify(&pubkeys[..], &digest.0);
+    let res = aggregated_signature.verify(&pubkeys[..], &digest);
     assert!(res.is_err(), "{:?}", res);
 }
 

--- a/crypto/src/tests/bls12381_tests.rs
+++ b/crypto/src/tests/bls12381_tests.rs
@@ -84,8 +84,7 @@ fn verify_invalid_signature() {
     assert!(kp.public().verify(&digest.0, &signature).is_err());
 }
 
-#[test]
-fn verify_valid_batch() {
+fn signature_test_inputs() -> (Vec<u8>, Vec<BLS12381PublicKey>, Vec<BLS12381Signature>) {
     // Make signatures.
     let message: &[u8] = b"Hello, world!";
     let digest = message.digest();
@@ -98,95 +97,49 @@ fn verify_valid_batch() {
         })
         .unzip();
 
-    // Verify the batch.
-    let res = BLS12381PublicKey::verify_batch(&digest.0, &pubkeys, &signatures);
+    (digest.to_vec(), pubkeys, signatures)
+}
+
+#[test]
+fn verify_valid_batch() {
+    let (digest, pubkeys, signatures) = signature_test_inputs();
+
+    let res = BLS12381PublicKey::verify_batch_empty_fail(&digest[..], &pubkeys, &signatures);
     assert!(res.is_ok(), "{:?}", res);
 }
 
 #[test]
 fn verify_invalid_batch() {
-    // Make signatures.
-    let message: &[u8] = b"Hello, world!";
-    let digest = message.digest();
-    let (pubkeys, mut signatures): (Vec<BLS12381PublicKey>, Vec<BLS12381Signature>) = keys()
-        .into_iter()
-        .take(3)
-        .map(|kp| {
-            let sig = kp.sign(&digest.0);
-            (kp.public().clone(), sig)
-        })
-        .unzip();
-
+    let (digest, pubkeys, mut signatures) = signature_test_inputs();
     // mangle one signature
     signatures[0] = BLS12381Signature::default();
 
-    // Verify the batch.
-    let res = BLS12381PublicKey::verify_batch(&digest.0, &pubkeys, &signatures);
+    let res = BLS12381PublicKey::verify_batch_empty_fail(&digest, &pubkeys, &signatures);
     assert!(res.is_err(), "{:?}", res);
 }
 
 #[test]
-fn verify_valid_aggregate_signature() {
-    // Make signatures.
-    let message: &[u8] = b"Hello, world!";
-    let digest = message.digest();
-    let (pubkeys, signatures): (Vec<BLS12381PublicKey>, Vec<BLS12381Signature>) = keys()
-        .into_iter()
-        .take(3)
-        .map(|kp| {
-            let sig = kp.sign(&digest.0);
-            (kp.public().clone(), sig)
-        })
-        .unzip();
+fn verify_empty_batch() {
+    let (digest, _, _) = signature_test_inputs();
 
-    let aggregated_signature = BLS12381AggregateSignature::aggregate(signatures).unwrap();
-
-    // // Verify the batch.
-    let res = aggregated_signature.verify(&pubkeys[..], &digest.0);
-    assert!(res.is_ok(), "{:?}", res);
-}
-
-#[test]
-fn verify_invalid_aggregate_signature_length_mismatch() {
-    // Make signatures.
-    let message: &[u8] = b"Hello, world!";
-    let digest = message.digest();
-    let (pubkeys, signatures): (Vec<BLS12381PublicKey>, Vec<BLS12381Signature>) = keys()
-        .into_iter()
-        .take(3)
-        .map(|kp| {
-            let sig = kp.sign(&digest.0);
-            (kp.public().clone(), sig)
-        })
-        .unzip();
-
-    let aggregated_signature = BLS12381AggregateSignature::aggregate(signatures).unwrap();
-
-    // Verify the batch.
-    let res = aggregated_signature.verify(&pubkeys[..2], &digest.0);
+    let res = BLS12381PublicKey::verify_batch_empty_fail(&digest[..], &[], &[]);
     assert!(res.is_err(), "{:?}", res);
 }
 
 #[test]
-fn verify_invalid_aggregate_signature_public_key_switch() {
-    // Make signatures.
-    let message: &[u8] = b"Hello, world!";
-    let digest = message.digest();
-    let (mut pubkeys, signatures): (Vec<BLS12381PublicKey>, Vec<BLS12381Signature>) = keys()
-        .into_iter()
-        .take(3)
-        .map(|kp| {
-            let sig = kp.sign(&digest.0);
-            (kp.public().clone(), sig)
-        })
-        .unzip();
+fn verify_batch_missing_public_keys() {
+    let (digest, pubkeys, signatures) = signature_test_inputs();
 
-    let aggregated_signature = BLS12381AggregateSignature::aggregate(signatures).unwrap();
+    // missing leading public keys
+    let res = BLS12381PublicKey::verify_batch_empty_fail(&digest, &pubkeys[1..], &signatures);
+    assert!(res.is_err(), "{:?}", res);
 
-    pubkeys[0] = keys()[3].public().clone();
-
-    // // Verify the batch.
-    let res = aggregated_signature.verify(&pubkeys[..], &digest.0);
+    // missing trailing public keys
+    let res = BLS12381PublicKey::verify_batch_empty_fail(
+        &digest,
+        &pubkeys[..pubkeys.len() - 1],
+        &signatures,
+    );
     assert!(res.is_err(), "{:?}", res);
 }
 

--- a/crypto/src/tests/ed25519_tests.rs
+++ b/crypto/src/tests/ed25519_tests.rs
@@ -173,8 +173,7 @@ fn verify_invalid_signature() {
     assert!(kp.public().verify(&digest.0, &signature).is_err());
 }
 
-#[test]
-fn verify_valid_batch() {
+fn signature_test_inputs() -> (Vec<u8>, Vec<Ed25519PublicKey>, Vec<Ed25519Signature>) {
     // Make signatures.
     let message: &[u8] = b"Hello, world!";
     let digest = message.digest();
@@ -187,95 +186,78 @@ fn verify_valid_batch() {
         })
         .unzip();
 
-    // Verify the batch.
-    let res = Ed25519PublicKey::verify_batch(&digest.0, &pubkeys, &signatures);
+    (digest.to_vec(), pubkeys, signatures)
+}
+
+#[test]
+fn verify_valid_batch() {
+    let (digest, pubkeys, signatures) = signature_test_inputs();
+
+    let res = Ed25519PublicKey::verify_batch_empty_fail(&digest[..], &pubkeys, &signatures);
     assert!(res.is_ok(), "{:?}", res);
 }
 
 #[test]
 fn verify_invalid_batch() {
-    // Make signatures.
-    let message: &[u8] = b"Hello, world!";
-    let digest = message.digest();
-    let (pubkeys, mut signatures): (Vec<Ed25519PublicKey>, Vec<Ed25519Signature>) = keys()
-        .into_iter()
-        .take(3)
-        .map(|kp| {
-            let sig = kp.sign(&digest.0);
-            (kp.public().clone(), sig)
-        })
-        .unzip();
-
+    let (digest, pubkeys, mut signatures) = signature_test_inputs();
     // mangle one signature
     signatures[0] = <Ed25519Signature as ToFromBytes>::from_bytes(&[0u8; 64]).unwrap();
 
-    // Verify the batch.
-    let res = Ed25519PublicKey::verify_batch(&digest.0, &pubkeys, &signatures);
+    let res = Ed25519PublicKey::verify_batch_empty_fail(&digest, &pubkeys, &signatures);
     assert!(res.is_err(), "{:?}", res);
 }
 
 #[test]
-fn verify_valid_aggregate_signature() {
-    // Make signatures.
-    let message: &[u8] = b"Hello, world!";
-    let digest = message.digest();
-    let (pubkeys, signatures): (Vec<Ed25519PublicKey>, Vec<Ed25519Signature>) = keys()
-        .into_iter()
-        .take(3)
-        .map(|kp| {
-            let sig = kp.sign(&digest.0);
-            (kp.public().clone(), sig)
-        })
-        .unzip();
+fn verify_empty_batch() {
+    let (digest, _, _) = signature_test_inputs();
 
+    let res = Ed25519PublicKey::verify_batch_empty_fail(&digest[..], &[], &[]);
+    assert!(res.is_err(), "{:?}", res);
+}
+
+#[test]
+fn verify_batch_missing_public_keys() {
+    let (digest, pubkeys, signatures) = signature_test_inputs();
+
+    // missing leading public keys
+    let res = Ed25519PublicKey::verify_batch_empty_fail(&digest, &pubkeys[1..], &signatures);
+    assert!(res.is_err(), "{:?}", res);
+
+    // missing trailing public keys
+    let res = Ed25519PublicKey::verify_batch_empty_fail(
+        &digest,
+        &pubkeys[..pubkeys.len() - 1],
+        &signatures,
+    );
+    assert!(res.is_err(), "{:?}", res);
+}
+
+#[test]
+fn verify_valid_aggregate_signaature() {
+    let (digest, pubkeys, signatures) = signature_test_inputs();
     let aggregated_signature = Ed25519AggregateSignature::aggregate(signatures).unwrap();
 
-    // // Verify the batch.
-    let res = aggregated_signature.verify(&pubkeys[..], &digest.0);
+    let res = aggregated_signature.verify(&pubkeys[..], &digest);
     assert!(res.is_ok(), "{:?}", res);
 }
 
 #[test]
 fn verify_invalid_aggregate_signature_length_mismatch() {
-    // Make signatures.
-    let message: &[u8] = b"Hello, world!";
-    let digest = message.digest();
-    let (pubkeys, signatures): (Vec<Ed25519PublicKey>, Vec<Ed25519Signature>) = keys()
-        .into_iter()
-        .take(3)
-        .map(|kp| {
-            let sig = kp.sign(&digest.0);
-            (kp.public().clone(), sig)
-        })
-        .unzip();
-
+    let (digest, pubkeys, signatures) = signature_test_inputs();
     let aggregated_signature = Ed25519AggregateSignature::aggregate(signatures).unwrap();
 
-    // // Verify the batch.
-    let res = aggregated_signature.verify(&pubkeys[..2], &digest.0);
+    let res = aggregated_signature.verify(&pubkeys[..2], &digest);
     assert!(res.is_err(), "{:?}", res);
 }
 
 #[test]
 fn verify_invalid_aggregate_signature_public_key_switch() {
-    // Make signatures.
-    let message: &[u8] = b"Hello, world!";
-    let digest = message.digest();
-    let (mut pubkeys, signatures): (Vec<Ed25519PublicKey>, Vec<Ed25519Signature>) = keys()
-        .into_iter()
-        .take(3)
-        .map(|kp| {
-            let sig = kp.sign(&digest.0);
-            (kp.public().clone(), sig)
-        })
-        .unzip();
-
+    let (digest, mut pubkeys, signatures) = signature_test_inputs();
     let aggregated_signature = Ed25519AggregateSignature::aggregate(signatures).unwrap();
 
     pubkeys[0] = keys()[3].public().clone();
 
-    // // Verify the batch.
-    let res = aggregated_signature.verify(&pubkeys[..], &digest.0);
+    let res = aggregated_signature.verify(&pubkeys[..], &digest);
     assert!(res.is_err(), "{:?}", res);
 }
 

--- a/crypto/src/traits.rs
+++ b/crypto/src/traits.rs
@@ -98,13 +98,14 @@ pub trait VerifyingKey:
     const LENGTH: usize;
 
     // Expected to be overridden by implementations
-    fn verify_batch(msg: &[u8], pks: &[Self], sigs: &[Self::Sig]) -> Result<(), signature::Error> {
+    fn verify_batch_empty_fail(msg: &[u8], pks: &[Self], sigs: &[Self::Sig]) -> Result<(), eyre::Report> {
         if pks.len() != sigs.len() {
-            return Err(signature::Error::new());
+            return Err(eyre!("Mismatch between number of signatures and public keys provided"));
         }
         pks.iter()
             .zip(sigs)
             .try_for_each(|(pk, sig)| pk.verify(msg, sig))
+            .map_err(|_| eyre!("Signature verification failed"))
     }
 }
 

--- a/crypto/src/traits.rs
+++ b/crypto/src/traits.rs
@@ -99,6 +99,9 @@ pub trait VerifyingKey:
 
     // Expected to be overridden by implementations
     fn verify_batch_empty_fail(msg: &[u8], pks: &[Self], sigs: &[Self::Sig]) -> Result<(), eyre::Report> {
+        if sigs.is_empty() {
+            return Err(eyre!("Critical Error! This behavious can signal something dangerous, and that someone may be trying to bypass signature verification through providing empty batches."));
+        }
         if pks.len() != sigs.len() {
             return Err(eyre!("Mismatch between number of signatures and public keys provided"));
         }

--- a/types/src/primary.rs
+++ b/types/src/primary.rs
@@ -419,7 +419,9 @@ impl Certificate {
         let (pks, sigs): (Vec<PublicKey>, Vec<Signature>) = self.votes.iter().cloned().unzip();
         // Verify the signatures
         let certificate_digest: Digest = Digest::from(self.digest());
-        PublicKey::verify_batch(certificate_digest.as_ref(), &pks, &sigs).map_err(DagError::from)
+        PublicKey::verify_batch_empty_fail(certificate_digest.as_ref(), &pks, &sigs)
+            .map_err(|_| signature::Error::new())
+            .map_err(DagError::from)
     }
 
     pub fn round(&self) -> Round {


### PR DESCRIPTION
1) when passing in an empty array of signatures to `verify_batch()`, some implementations return error, while some return ok. Add tests and fixed
2) Reduced boilerplate in tests
3) Fixed a unhandled panic in Ed25519 verify_batch