### PR TITLE
chore(ci): retire ubuntu-latest for performance-sensitive jobs

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -8,3 +8,17 @@ status-level = "skip"
 fail-fast = false
 # Retry failing tests in order to not block builds on flaky tests
 retries = 2
+# Mark tests as slow after 1 minute, kill them after 5
+slow-timeout = { period = "60s", terminate-after = 5 }
+
+[profile.ignored]
+# Print out output for failing tests as soon as they fail, and also at the end
+# of the run (for easy scrollability).
+failure-output = "immediate-final"
+# Show skipped tests in the CI output.
+status-level = "skip"
+# Do not cancel the test run on the first failure.
+fail-fast = false
+# Retry failing tests in order to not block builds on flaky tests
+retries = 2
+# no killing slow tests, by design

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   codecov-grcov:
     name: Generate code coverage
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-ghcloud
     strategy:
       fail-fast: true
     steps:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -43,7 +43,7 @@ jobs:
       # These are considered the end-to-end "slow" tests for us
       - name: cargo nextest
         run: |
-          cargo nextest run -E 'kind(test) + package(primary)' --run-ignored ignored-only
+          cargo nextest run -E 'kind(test) + package(primary)' --profile ignored --run-ignored ignored-only
 
   beta:
     name: Run test on the beta channel
@@ -60,10 +60,13 @@ jobs:
       - name: cargo clippy
         run: cargo xclippy -D warnings
       - name: cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --features celo
+        run: |
+          cargo nextest run --features celo --profile ci
+      - name: Doctests
+        run: |
+          cargo test --doc --features celo
+      # Ensure there are no uncommitted changes in the repo after running tests
+      - run: scripts/changed-files.sh
 
   release:
     name: build release binaries

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,7 +29,7 @@ env:
 jobs:
   end-to-end-tests:
     name: Run long-running end-to-end tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-ghcloud
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
@@ -47,7 +47,7 @@ jobs:
 
   beta:
     name: Run test on the beta channel
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-ghcloud
     steps:
       - uses: actions/checkout@v3
       - name: Install beta toolchain
@@ -67,7 +67,7 @@ jobs:
 
   release:
     name: build release binaries
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-ghcloud
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
@@ -78,7 +78,7 @@ jobs:
           args: --all-targets --features celo --release --profile=release
 
   cargo-udeps:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-ghcloud
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,7 +53,6 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-latest
           - ubuntu-ghcloud
           - windows-ghcloud
       fail-fast: false
@@ -78,7 +77,7 @@ jobs:
       - run: scripts/changed-files.sh
 
   clippy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-ghcloud
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1


### PR DESCRIPTION
The most urgent PRs (#756, #738) are merged.
The only one urgent-ish is #762, which I'll rebase myself.