### PR TITLE
[recovery] core to recover the last certificates and forward to proposer

### DIFF
--- a/primary/src/core.rs
+++ b/primary/src/core.rs
@@ -147,6 +147,11 @@ impl Core {
         let now = Instant::now();
 
         // Fetch the certificates that are higher or equal than the last_commit_round
+        // We need that as an indication to filter the certificates after a certain
+        // point that we are confident that we have reached in the past. Then we can
+        // detect the last. This will get refactored to optimise further as common
+        // requirements exist in Consensus as well
+        // TODO https://github.com/MystenLabs/narwhal/issues/813
         let last_commit_round = *self.rx_consensus_round_updates.borrow();
 
         let certificates_after_gc_round = self

--- a/primary/src/metrics.rs
+++ b/primary/src/metrics.rs
@@ -93,6 +93,8 @@ pub struct PrimaryChannelMetrics {
     pub tx_committed_certificates: IntGauge,
     /// occupancy of the channel from the `primary::Core` to the `Consensus`
     pub tx_new_certificates: IntGauge,
+    /// occupancy of the internal channel in the `primary::Core` to recover headers
+    pub tx_recovery_headers: IntGauge,
 }
 
 impl PrimaryChannelMetrics {
@@ -207,6 +209,11 @@ impl PrimaryChannelMetrics {
             tx_reconfigure: register_int_gauge_with_registry!(
                 "tx_reconfigure",
                 "occupancy of the channel from the reconfigure notification to most components.",
+                registry
+            ).unwrap(),
+            tx_recovery_headers: register_int_gauge_with_registry!(
+                "tx_recovery_headers",
+                "occupancy of the internal channel in the `primary::Core` to recover headers",
                 registry
             ).unwrap(),
             tx_committed_certificates: register_int_gauge_with_registry!(

--- a/primary/src/tests/core_tests.rs
+++ b/primary/src/tests/core_tests.rs
@@ -5,9 +5,10 @@ use super::*;
 use crate::common::create_db_stores;
 use crypto::traits::KeyPair;
 use prometheus::Registry;
+use std::collections::BTreeSet;
 use test_utils::{
-    certificate, committee, fixture_batch_with_transactions, header, headers, keys, votes,
-    PrimaryToPrimaryMockServer,
+    certificate, committee, fixture_batch_with_transactions, fixture_headers_round, header,
+    headers, keys, votes, PrimaryToPrimaryMockServer,
 };
 use types::{Header, Vote};
 
@@ -618,4 +619,114 @@ async fn reconfigure_core() {
     // Ensure the header is correctly stored.
     let stored = header_store.read(header.id).await.unwrap();
     assert_eq!(stored, Some(header));
+}
+
+#[tokio::test]
+async fn recover_should_retrieve_last_round_certificates() {
+    let kp = keys(None).pop().unwrap();
+    let name = kp.public().clone();
+    let signature_service = SignatureService::new(kp);
+
+    let (_tx_reconfigure, rx_reconfigure) =
+        watch::channel(ReconfigureNotification::NewEpoch(committee(None)));
+    let (tx_sync_headers, _rx_sync_headers) = test_utils::test_channel!(1);
+    let (tx_sync_certificates, _rx_sync_certificates) = test_utils::test_channel!(1);
+    let (_tx_primary_messages, rx_primary_messages) = test_utils::test_channel!(1);
+    let (_tx_headers_loopback, rx_headers_loopback) = test_utils::test_channel!(1);
+    let (_tx_certificates_loopback, rx_certificates_loopback) = test_utils::test_channel!(1);
+    let (_tx_headers, rx_headers) = test_utils::test_channel!(1);
+    let (tx_consensus, _rx_consensus) = test_utils::test_channel!(1);
+    let (tx_parents, mut rx_parents) = test_utils::test_channel!(10);
+
+    // We are starting from consensus round 2 so we can test the recovery
+    // from last_commit_round - gc_depth ( 2 - 1 = 1)
+    let (_tx_consensus_round_updates, rx_consensus_round_updates) = watch::channel(2u64);
+
+    // We configure depth (1)
+    let gc_depth = 1;
+
+    // Create test stores.
+    let (header_store, certificates_store, payload_store) = create_db_stores();
+
+    // Assume our system had already processed a few certificates and those have been populated
+    // in our storage.
+    // Ensure the certificates are stored.
+    let mut current_round: Vec<_> = Certificate::genesis(&committee(None))
+        .into_iter()
+        .map(|cert| cert.header)
+        .collect();
+    let mut last_round_certificates = HashSet::new();
+    let rounds = 3;
+    for i in 0..rounds {
+        let parents: BTreeSet<_> = current_round
+            .iter()
+            .map(|header| certificate(header).digest())
+            .collect();
+        (_, current_round) = fixture_headers_round(i, &parents);
+
+        let current_round_certs: Vec<Certificate> = current_round.iter().map(certificate).collect();
+
+        // store them in both main and secondary index
+        certificates_store
+            .write_all(
+                current_round_certs
+                    .clone()
+                    .into_iter()
+                    .map(|c| (c.digest(), c)),
+            )
+            .await
+            .unwrap();
+
+        if i == rounds - 1 {
+            last_round_certificates = current_round_certs
+                .into_iter()
+                .map(|c| c.digest())
+                .collect();
+        }
+    }
+
+    // Make a synchronizer for the core.
+    let synchronizer = Synchronizer::new(
+        name.clone(),
+        &committee(None),
+        certificates_store.clone(),
+        payload_store.clone(),
+        /* tx_header_waiter */ tx_sync_headers,
+        /* tx_certificate_waiter */ tx_sync_certificates,
+        None,
+    );
+
+    let metrics = Arc::new(PrimaryMetrics::new(&Registry::new()));
+
+    // Spawn the core.
+    let _core_handle = Core::spawn(
+        name,
+        committee(None),
+        header_store.clone(),
+        certificates_store.clone(),
+        synchronizer,
+        signature_service,
+        rx_consensus_round_updates,
+        /* gc_depth */ gc_depth,
+        rx_reconfigure,
+        /* rx_primaries */ rx_primary_messages,
+        /* rx_header_waiter */ rx_headers_loopback,
+        /* rx_certificate_waiter */ rx_certificates_loopback,
+        /* rx_proposer */ rx_headers,
+        tx_consensus,
+        /* tx_proposer */ tx_parents,
+        metrics.clone(),
+        PrimaryNetwork::default(),
+    );
+
+    // THEN ensures we send to the proposer the last parents
+    let (received_certificates, round, epoch) = rx_parents.recv().await.unwrap();
+
+    assert_eq!(received_certificates.len(), 3);
+    assert_eq!(round, 3);
+    assert_eq!(epoch, 0);
+
+    for certificate in received_certificates {
+        assert!(last_round_certificates.contains(&certificate.digest()));
+    }
 }


### PR DESCRIPTION
Part of MystenLabs/sui#5324 

### Problem

Upon node bootstrap we want to recover the last received certificates and forward them to the proposer so it can have the opportunity to propose a new header and make progress.

### Solution
Read from the `certificate_store` the certificates that are after the `last_commit_round` and figure out the ones with the highest round number.

The current solution is blocking - meaning that core will not initiate its loop until it has finished with recovery. Thought about various approaches but decided to go with that for now. Since our networking stack gets initialised before that it's possible that our node might start receiving certificates, headers etc while we perform the recovery fill up our buffers if our recovery is slow. In the TODO list there is proposals to speed up the recovery.

Also thought about the recovery process in general as:
* making it blocking Vs non-blocking. In some cases makes sense to block and wait for a component to finish its recovery before proceeding
* dependencies between components while we recover
* networking conditions

☝️ points for further discussion

---
TODO:

- [ ] In order for core to successfully recover we need the `last_commit_round` which should be driven/emitted by consensus. To achieve that we first need to make sure that consensus has recovered. We need to make consensus block until we have figured out the last commit round to propagate downstream
- [ ] currently consensus & core are following similar logic in recovery - filtering out the certificate_store to figure out the latest certificates. Building a secondary index https://github.com/MystenLabs/narwhal/issues/813 where certificates are stored by their rounds would help us quickly skip certificates and quickly perform the recovery. The storage can be re-used by both components (and probably more)