### PR TITLE
Add ExecutionState::handle_consensus_without_transactions

### DIFF
--- a/executor/src/errors.rs
+++ b/executor/src/errors.rs
@@ -56,7 +56,7 @@ impl From<Box<bincode::ErrorKind>> for SubscriberError {
     }
 }
 
-/// Trait do separate execution errors in two categories: (i) errors caused by a bad client, (ii)
+/// Trait to separate execution errors in two categories: (i) errors caused by a bad client, (ii)
 /// errors caused by a fault in the authority.
 pub trait ExecutionStateError: std::error::Error {
     /// Whether the error is due to a fault in the authority (eg. internal storage error).

--- a/executor/src/tests/execution_state.rs
+++ b/executor/src/tests/execution_state.rs
@@ -12,6 +12,7 @@ use store::{
     Store,
 };
 use thiserror::Error;
+use types::SequenceNumber;
 
 /// A malformed transaction.
 pub const MALFORMED_TRANSACTION: <TestState as ExecutionState>::Transaction = 400;
@@ -21,7 +22,8 @@ pub const KILLER_TRANSACTION: <TestState as ExecutionState>::Transaction = 500;
 
 /// A dumb execution state for testing.
 pub struct TestState {
-    store: Store<u64, ExecutionIndices>,
+    indices_store: Store<u64, ExecutionIndices>,
+    empty_index_store: Store<u64, SequenceNumber>,
 }
 
 impl std::fmt::Debug for TestState {
@@ -53,11 +55,22 @@ impl ExecutionState for TestState {
         } else if transaction == KILLER_TRANSACTION {
             Err(Self::Error::ServerError)
         } else {
-            self.store
+            self.indices_store
                 .write(Self::INDICES_ADDRESS, execution_indices)
                 .await;
             Ok(Vec::default())
         }
+    }
+
+    async fn handle_consensus_without_transactions(
+        &self,
+        consensus_output: &ConsensusOutput,
+    ) -> Result<(), Self::Error> {
+        eprintln!("HANDLING EMPTY {}", consensus_output.consensus_index);
+        self.empty_index_store
+            .write(Self::EMPTY_INDEX_ADDRESS, consensus_output.consensus_index)
+            .await;
+        Ok(())
     }
 
     fn ask_consensus_write_lock(&self) -> bool {
@@ -68,7 +81,7 @@ impl ExecutionState for TestState {
 
     async fn load_execution_indices(&self) -> Result<ExecutionIndices, Self::Error> {
         let indices = self
-            .store
+            .indices_store
             .read(Self::INDICES_ADDRESS)
             .await
             .unwrap()
@@ -80,20 +93,36 @@ impl ExecutionState for TestState {
 impl TestState {
     /// The address at which to store the indices (rocksdb is a key-value store).
     pub const INDICES_ADDRESS: u64 = 14;
+    /// The address at which to store the last observed empty consensus index.
+    pub const EMPTY_INDEX_ADDRESS: u64 = 15;
 
     /// Create a new test state.
     pub fn new(store_path: &Path) -> Self {
-        const STATE_CF: &str = "test_state";
-        let rocksdb = open_cf(store_path, None, &[STATE_CF]).unwrap();
-        let map = reopen!(&rocksdb, STATE_CF;<u64, ExecutionIndices>);
+        const INDICES_CF: &str = "test_state_indices";
+        const EMPTY_INDEX_CF: &str = "test_state_empty_index";
+        let rocksdb = open_cf(store_path, None, &[INDICES_CF, EMPTY_INDEX_CF]).unwrap();
+        let (indices_map, empty_index_map) = reopen!(&rocksdb,
+            INDICES_CF;<u64, ExecutionIndices>,
+            EMPTY_INDEX_CF;<u64, SequenceNumber>
+        );
         Self {
-            store: Store::new(map),
+            indices_store: Store::new(indices_map),
+            empty_index_store: Store::new(empty_index_map),
         }
     }
 
-    /// Load the execution indices; ie. the state.
+    /// Load the execution indices.
     pub async fn get_execution_indices(&self) -> ExecutionIndices {
         self.load_execution_indices().await.unwrap()
+    }
+
+    /// Load the last consensus index.
+    pub async fn get_last_empty_index(&self) -> SequenceNumber {
+        self.empty_index_store
+            .read(Self::EMPTY_INDEX_ADDRESS)
+            .await
+            .unwrap()
+            .unwrap_or_default()
     }
 }
 

--- a/executor/src/tests/executor_tests.rs
+++ b/executor/src/tests/executor_tests.rs
@@ -80,10 +80,10 @@ async fn execute_empty_certificate() {
 
     // Feed empty certificates to the executor.
     let empty_certificates = 2;
-    for _ in 0..empty_certificates {
+    for i in 0..empty_certificates {
         let message = ConsensusOutput {
             certificate: Certificate::default(),
-            consensus_index: SequenceNumber::default(),
+            consensus_index: i,
         };
         tx_executor.send(message).await.unwrap();
     }
@@ -112,6 +112,7 @@ async fn execute_empty_certificate() {
         next_transaction_index: 0,
     };
     assert_eq!(execution_state.get_execution_indices().await, expected);
+    assert_eq!(execution_state.get_last_empty_index().await, 1);
 }
 
 #[tokio::test]


### PR DESCRIPTION
# Changes
This PR introduces an extra method, `ExecutionState::handle_consensus_without_transactions` that informs the executor about certificates that contain no transactions. 

## Motivation
The motivation to do so is because we want to use Narwhal as the transaction ordering layer to replace the consensus in an existing blockchain, by creating a deterministic chain of blocks from the certificates that Narwhal and Bullshark produce. In that blockchain, there might be a need for blocks to be produced even when there are no transactions (same as in Narwhal), and to make it deterministic, the only source of truth we can rely on that indicates the passage of time across all nodes are the certificates themselves. 
`
## Backwards Compatibility
The change is backwards compatible because the method has a default implementation that does nothing, so it doesn't break Sui in any way. 

This means, however, that the code doesn't put any expectations on what the executor does with the information, namely it doesn't pass `ExecutionIndices` for atomic persistence. This means that in theory these certificates could be passed again after a crash, and the executor has to be able to deduplicate them based on the `consensus_index` in the `ConsensusOutput`. 

## Alternative Designs

The first idea I had was to introduce something like the [BeginBlock / EndBlock](https://docs.tendermint.com/master/spec/abci/abci.html#beginblock) pair in Tendermint's ABCI. We'd have to be careful after a restart not to call _begin_ again, because Narwhal expects that the `ExecutionIndices` passed to `handle_consensus_transaction` are persisted, so like transactions, this event should be skipped. But then I realised that because `ConsensusOutput` and `ExecutionIndices` are passed to `handle_consensus_transaction` every time, it is easy for the executor to detect when a certificate starts or ends. Having _begin_ and _end_ would only make sense if this wasn't the case, to put the responsibility of signaling and persisting indices squarely on those methods, but that would be a breaking change for no obvious benefit, and it would open up different questions about where to replay from.

Another option would be to pass all transactions in the certificate as a single call, which is how the [FinalizeBlock](https://docs.tendermint.com/master/spec/abci++/abci++_methods.html#finalizeblock) method works in Tendermint's ABCI++. That would put the onus of partial batch execution on the executor itself. It would also be a breaking change for Sui. 

## Open Questions

I see in the docstring of `handle_consensus_transaction` that it should be able to return committee changes, but I couldn't find anything about this happening in the current codebase, the `Output` type seems completely opaque. 

If it was possible though, then `handle_consensus_without_transactions` should also be able to return such a result. An example of where this could be useful is to define epochs as a fixed number of blocks; transactions to register new validators and delegations should be allowed to go through during the epoch, but they should only take effect at the end of the epoch, which should not require further transactions to take place. In this case the committee change can be triggered by empty blocks as well as non-empty ones. In Tendermint ABCI, this happens in `EndBlock`. 

With the current `ExecutionState` I would have to detect the last transaction of the certificate, and do extra execution there, then "attach" the result to the `Outcome` of the transaction. That's not exactly the right place to do it, though, since it might not have been that transaction which the effects belong to. 

Currently the `handle_consensus_without_transactions` returns `Result<(), Self::Error>`. I didn't think it would be right to return `Outcome` from it because: 
1. There is no default value for the default method implementation. I could return `Option<Outcome>` from it with `None` begin the default.
2. But it seems tied to the actual transactions, being returned as pairs and passed on to an observer. If I returned `Some(outcome)` I wouldn't have a transaction to pair it with for the observer. 

For these reasons I opted not to return anything, until it becomes clear how committee changes should be carried out.

The situation would be easier if the whole certificate was passed on to the executor, and the return value could optionally contain the new committee. Perhaps the one-by-one executor could be just a special case implementation of it.

EDIT: This alternative with the one-by-one being a special case is available in https://github.com/MystenLabs/narwhal/pull/818

# Related Issues
Resolves MystenLabs/sui#5322 