### PR TITLE
[refactor / possible bug] worker synchronizer to reply back for available batches

### DIFF
--- a/primary/src/payload_receiver.rs
+++ b/primary/src/payload_receiver.rs
@@ -8,6 +8,10 @@ use tokio::task::JoinHandle;
 use tracing::info;
 use types::{metered_channel::Receiver, BatchDigest};
 
+#[cfg(test)]
+#[path = "tests/payload_receiver_tests.rs"]
+mod payload_receiver_tests;
+
 /// Receives batches' digests of other authorities. These are only needed to verify incoming
 /// headers (i.e.. make sure we have their payload).
 pub struct PayloadReceiver {

--- a/primary/src/tests/payload_receiver_tests.rs
+++ b/primary/src/tests/payload_receiver_tests.rs
@@ -1,0 +1,30 @@
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use crate::common::create_db_stores;
+use crate::payload_receiver::PayloadReceiver;
+use types::BatchDigest;
+
+#[tokio::test]
+async fn receive_batch() {
+    // GIVEN
+    let worker_id = 5;
+    let digest = BatchDigest::new([5u8; 32]);
+    let (tx_workers, rx_workers) = test_utils::test_channel!(1);
+    let (_, _, payload_store) = create_db_stores();
+
+    let _handle = PayloadReceiver::spawn(payload_store.clone(), rx_workers);
+
+    for _ in 0..4 {
+        // WHEN - irrespective of how many times will send the same (digest, worker_id)
+        tx_workers.send((digest, worker_id)).await.unwrap();
+
+        // THEN we expected to be stored successfully (no errors thrown) and have an
+        // idempotent behaviour.
+        let result = payload_store
+            .notify_read((digest, worker_id))
+            .await
+            .unwrap();
+
+        assert_eq!(result.unwrap(), 0u8);
+    }
+}

--- a/worker/src/tests/processor_tests.rs
+++ b/worker/src/tests/processor_tests.rs
@@ -8,7 +8,8 @@ use store::rocks;
 use test_utils::{batch, committee, temp_dir};
 
 #[tokio::test]
-async fn hash_and_store() {
+async fn hash_and_store_our_batch() {
+    // GIVEN
     let (tx_batch, rx_batch) = test_utils::test_channel!(1);
     let (tx_digest, mut rx_digest) = test_utils::test_channel!(1);
 
@@ -17,13 +18,7 @@ async fn hash_and_store() {
         watch::channel(ReconfigureNotification::NewEpoch(committee.clone()));
 
     // Create a new test store.
-    let db = rocks::DBMap::<BatchDigest, SerializedBatchMessage>::open(
-        temp_dir(),
-        None,
-        Some("batches"),
-    )
-    .unwrap();
-    let store = Store::new(db);
+    let store = create_batches_store();
 
     // Spawn a new `Processor` instance.
     let id = 0;
@@ -40,20 +35,88 @@ async fn hash_and_store() {
     let batch = batch();
     let message = WorkerMessage::Batch(batch.clone());
     let serialized = bincode::serialize(&message).unwrap();
-    tx_batch.send(serialized.clone()).await.unwrap();
 
-    // Ensure the `Processor` outputs the batch's digest.
-    let digest = batch.digest();
-    match rx_digest.recv().await.unwrap() {
-        WorkerPrimaryMessage::OurBatch(x, y) => {
-            assert_eq!(x, digest);
-            assert_eq!(y, id);
+    // the process should be idempotent - no matter how many times we write
+    // the same batch it should be stored and output the message to the tx_digest channel
+    for _ in 0..3 {
+        // WHEN
+        tx_batch.send(serialized.clone()).await.unwrap();
+
+        // THEN
+        // Ensure the `Processor` outputs the batch's digest.
+        let digest = batch.digest();
+        match rx_digest.recv().await.unwrap() {
+            WorkerPrimaryMessage::OurBatch(x, y) => {
+                assert_eq!(x, digest);
+                assert_eq!(y, id);
+            }
+            _ => panic!("Unexpected protocol message"),
         }
-        _ => panic!("Unexpected protocol message"),
-    }
 
-    // Ensure the `Processor` correctly stored the batch.
-    let stored_batch = store.read(digest).await.unwrap();
-    assert!(stored_batch.is_some(), "The batch is not in the store");
-    assert_eq!(stored_batch.unwrap(), serialized);
+        // Ensure the `Processor` correctly stored the batch.
+        let stored_batch = store.read(digest).await.unwrap();
+        assert!(stored_batch.is_some(), "The batch is not in the store");
+        assert_eq!(stored_batch.unwrap(), serialized);
+    }
+}
+
+#[tokio::test]
+async fn hash_and_store_others_batch() {
+    // GIVEN
+    let (tx_batch, rx_batch) = test_utils::test_channel!(1);
+    let (tx_digest, mut rx_digest) = test_utils::test_channel!(1);
+
+    let committee = committee(None).clone();
+    let (_tx_reconfiguration, rx_reconfiguration) =
+        watch::channel(ReconfigureNotification::NewEpoch(committee.clone()));
+
+    // Create a new test store.
+    let store = create_batches_store();
+
+    // Spawn a new `Processor` instance.
+    let id = 0;
+    let _processor_handler = Processor::spawn(
+        id,
+        store.clone(),
+        rx_reconfiguration,
+        rx_batch,
+        tx_digest,
+        /* own_batch */ false,
+    );
+
+    // Send a batch to the `Processor`.
+    let batch = batch();
+    let message = WorkerMessage::Batch(batch.clone());
+    let serialized = bincode::serialize(&message).unwrap();
+
+    for _ in 0..3 {
+        // WHEN
+        tx_batch.send(serialized.clone()).await.unwrap();
+
+        // THEN
+        // Ensure the `Processor` outputs the batch's digest.
+        let digest = batch.digest();
+        match rx_digest.recv().await.unwrap() {
+            WorkerPrimaryMessage::OthersBatch(x, y) => {
+                assert_eq!(x, digest);
+                assert_eq!(y, id);
+            }
+            _ => panic!("Unexpected protocol message"),
+        }
+
+        // Ensure the `Processor` correctly stored the batch.
+        let stored_batch = store.read(digest).await.unwrap();
+        assert!(stored_batch.is_some(), "The batch is not in the store");
+        assert_eq!(stored_batch.unwrap(), serialized);
+    }
+}
+
+fn create_batches_store() -> Store<BatchDigest, SerializedBatchMessage> {
+    let db = rocks::DBMap::<BatchDigest, SerializedBatchMessage>::open(
+        temp_dir(),
+        None,
+        Some("batches"),
+    )
+    .unwrap();
+    Store::new(db)
 }

--- a/worker/src/tests/synchronizer_tests.rs
+++ b/worker/src/tests/synchronizer_tests.rs
@@ -5,6 +5,7 @@ use super::*;
 use arc_swap::ArcSwap;
 use fastcrypto::traits::KeyPair;
 use prometheus::Registry;
+use test_utils::committee;
 use test_utils::{
     batch, batch_digest, batches, keys, open_batch_store, pure_committee_from_keys,
     resolve_name_committee_and_worker_cache, serialize_batch_message,
@@ -76,6 +77,7 @@ async fn synchronize_when_batch_exists() {
     let (tx_primary, mut rx_primary) = test_utils::test_channel!(1);
 
     let mut keys = keys(None);
+    let worker_cache = shared_worker_cache_from_keys(&keys);
     let name = keys.pop().unwrap().public().clone();
     let id = 0;
 
@@ -93,6 +95,7 @@ async fn synchronize_when_batch_exists() {
         name.clone(),
         id,
         Arc::new(ArcSwap::from_pointee(committee.clone())),
+        worker_cache.clone(),
         store.clone(),
         /* gc_depth */ 50, // Not used in this test.
         /* sync_retry_delay */
@@ -107,7 +110,11 @@ async fn synchronize_when_batch_exists() {
 
     // Spawn a listener to receive our batch requests.
     let target = keys.pop().unwrap().public().clone();
-    let address = committee.worker(&target, &id).unwrap().worker_to_worker;
+    let address = worker_cache
+        .load()
+        .worker(&target, &id)
+        .unwrap()
+        .worker_to_worker;
     let batch_id = batch_digest();
     let missing = vec![batch_id];
 


### PR DESCRIPTION
### Section 1
Currently when we request from the worker synchronizer to synchronize a batch (`PrimaryWorkerMessage::Synchronize`)  it will first check in storage whether the batch is already there. 
1) **If not ,** it will ask from other worker peers to fetch. Primary will be notified about the fetched batch id once the peer worker has sent it
2) **If yes,** it will basically do nothing about it. It _probably assumes_ that since it has been found in storage then the batch has been received by a peer worker and the primary will be notified anyways via the [processor](https://github.com/MystenLabs/narwhal/blob/f08817ee6e2a6e12da3463dfa8da547f2c2afef7/worker/src/processor.rs#L54) will handle it . Now if for some reason this notification message from `worker --> primary` has not been successfully processed for some reason, there is no mechanism to re-trigger and there will be no way for the primary to get notified about the batch availability - although the batch is in worker.

### Section 2
The above case (2) can create deadlock situations. In DevNet we have recently seen an issue with the payload synchronization in the recent incident where I believe is an artifact of the above behaviour. The scenario is the following:

We assume that we have two validators, (A) & (B).

* Validator (A) worker creates a batch with the hypothetical hash `kxmsamyzXZxRPc+C` and forwards to primary
* Validator (A) primary includes this to a header proposal. Let's assume that a certificate is produced, sequenced and even executed. For the execution we fetch the payload via the `block_waiter` which first checks if the payload is available via the `block_synchronizer` . The `block_synchronizer` sees that the header has been created by us (Validator A) and doesn't need to check the near store cache `payload_store` , but rather assumes the payload is already in worker - so the `block_waiter` can just continue and fetch the batch - all OK.
* Now Validator (B) worker creates a batch with the exact same hash `kxmsamyzXZxRPc+C` - yes it happens currently in DevNet currently (since same transactions are posted) . Worker broadcasts the batch to the other workers and just waits for a quorum of them to reply back - once the quorum replies it even cancels the network handlers. Let's assume that because of that - or even some network glitch - Validator (A) hasn't received the batch.
* Because Validator (A) hasn't received validator's B batch _it will never initiate any process to forward the batch id to the primary node_ . So the batch id  `kxmsamyzXZxRPc+C` is still missing from the Validator (A) `payload_store`
* Now Validator (B) creates a header -> certificate -> sequenced and needs to get executed. Validator (A) tries to execute the certificate which references to the batch id `kxmsamyzXZxRPc+C` . The `block_synchronizer` will check the `payload_store` for the batch availability (since it's not our header) . The batch is missing , so it will dictate its worker to synchronize it from the other worker peers. 
* Because of the current behaviour that described in Section 1 the primary will never manage to successfully get the notification about the payload availability as there is not way to re-trigger it.
* **Result: Validator (A) stops its execution and blocks forever**

From the DevNet the bellow logs tell that story - well in a quite abstract way , but that's where I am oriented at:

**Validator A**
<img width="1321" alt="Screenshot 2022-08-22 at 19 06 53" src="https://user-images.githubusercontent.com/17335598/185989701-55f6af4c-b3b7-4f54-8942-f8b09b815ff6.png">

We see that Validator A it will indefinitely send via the `block_synchronizer` a request to its worker to sync the batch `kxmsamyzXZxRPc+C.....`


**Validator B**
<img width="1339" alt="Screenshot 2022-08-22 at 19 07 02" src="https://user-images.githubusercontent.com/17335598/185989756-6234ebeb-f64a-447e-ad6e-92c27f804bc5.png">

We see that Validator B is managing to successfully progress and request the batch from its worker (see log line `primary::block_waiter: Sending batch kxmsamyzXZxRPc+C request to worker id 0`


### Resolution
This PR attempts to resolve this issue by making the worker synchronizer reply back to primary immediately when a batch has been found available in store and not make any assumptions about other processes that might be running to notify the primary.

Also, an addition fix/improvement is made to ensure that the synchronizer will not send synchronization messages to other workers when a vector of `missing` batch ids is empty - we have also seen this happening in DevNet.

**PS: Similar issue with the above can arise even when the worker restarts (so any pending requests from worker to primary are lost) or for some reason primary doesn't store the batch id in the `payload_store`**

TODO
-----

- [ ] Follow up PR to store all the batch ids in the near cache `payload_store` in primary irrespective of wether "we" or an "other" primary has created. Will need to confirm we'll not break there some other assumptions - which I believe it won't