### PR TITLE
Two small maintenance fixes

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -21,4 +21,5 @@ status-level = "skip"
 fail-fast = false
 # Retry failing tests in order to not block builds on flaky tests
 retries = 2
-# no killing slow tests, by design
+# Mark tests as slow after 25mins, kill them after 50
+slow-timeout = { period = "1500s", terminate-after = 1 }

--- a/network/src/worker.rs
+++ b/network/src/worker.rs
@@ -10,7 +10,8 @@ use multiaddr::Multiaddr;
 use rand::{rngs::SmallRng, SeedableRng as _};
 use std::collections::HashMap;
 use tokio::{runtime::Handle, task::JoinHandle};
-use tonic::transport::Channel;
+use tonic::{transport::Channel, Code};
+use tracing::error;
 use types::{
     BincodeEncodedPayload, WorkerMessage, WorkerPrimaryMessage, WorkerToPrimaryClient,
     WorkerToWorkerClient,
@@ -150,9 +151,19 @@ impl ReliableNetwork for WorkerNetwork {
 
             async move {
                 client.send_message(message).await.map_err(|e| {
-                    // this returns a backoff::Error::Transient
-                    // so that if tonic::Status is returned, we retry
-                    Into::<backoff::Error<eyre::Report>>::into(eyre::Report::from(e))
+                    match e.code() {
+                        Code::FailedPrecondition | Code::InvalidArgument => {
+                            // these errors are not recoverable through retrying, see
+                            // https://github.com/hyperium/tonic/blob/master/tonic/src/status.rs
+                            error!("Irrecoverable network error: {e}");
+                            backoff::Error::permanent(eyre::Report::from(e))
+                        }
+                        _ => {
+                            // this returns a backoff::Error::Transient
+                            // so that if tonic::Status is returned, we retry
+                            Into::<backoff::Error<eyre::Report>>::into(eyre::Report::from(e))
+                        }
+                    }
                 })
             }
         };
@@ -238,9 +249,19 @@ impl ReliableNetwork for WorkerToPrimaryNetwork {
 
             async move {
                 client.send_message(message).await.map_err(|e| {
-                    // this returns a backoff::Error::Transient
-                    // so that if tonic::Status is returned, we retry
-                    Into::<backoff::Error<eyre::Report>>::into(eyre::Report::from(e))
+                    match e.code() {
+                        Code::FailedPrecondition | Code::InvalidArgument => {
+                            // these errors are not recoverable through retrying, see
+                            // https://github.com/hyperium/tonic/blob/master/tonic/src/status.rs
+                            error!("Irrecoverable network error: {e}");
+                            backoff::Error::permanent(eyre::Report::from(e))
+                        }
+                        _ => {
+                            // this returns a backoff::Error::Transient
+                            // so that if tonic::Status is returned, we retry
+                            Into::<backoff::Error<eyre::Report>>::into(eyre::Report::from(e))
+                        }
+                    }
                 })
             }
         };


### PR DESCRIPTION
- the long-running tests have been on a livelock [for a while](https://github.com/MystenLabs/narwhal/actions/workflows/nightly.yml), for reasons that are hard to reproduce. This puts them under a reasonable timeout in the nightly job.
- we stop retrying message sends on some clearly irrecoverable errors.
- ~we import fixes from #670 in the hope of fixing the local benchmarks, which have been broken (but the breakage is hard to reproduce) since https://github.com/MystenLabs/narwhal/commit/babd3d8ee6278652a8fee3b41764787203c17cc1~