### PR TITLE
[refactor] clean up executor's temporary batch store

### DIFF
--- a/executor/src/lib.rs
+++ b/executor/src/lib.rs
@@ -17,6 +17,7 @@ mod metrics;
 
 pub use errors::{ExecutionStateError, SubscriberError, SubscriberResult};
 pub use state::ExecutionIndices;
+use tracing::info;
 
 use crate::{core::Core, metrics::ExecutorMetrics, subscriber::Subscriber};
 use async_trait::async_trait;
@@ -31,7 +32,6 @@ use tokio::{
     sync::{mpsc::Sender, watch},
     task::JoinHandle,
 };
-use tracing::info;
 use types::{
     metered_channel, Batch, BatchDigest, CertificateDigest, ConsensusStore,
     ReconfigureNotification, SequenceNumber,
@@ -94,7 +94,7 @@ pub struct Executor;
 impl Executor {
     /// Spawn a new client subscriber.
     pub async fn spawn<State>(
-        store: Store<BatchDigest, Batch>,
+        store: Store<(CertificateDigest, BatchDigest), Batch>,
         execution_state: Arc<State>,
         tx_reconfigure: &watch::Sender<ReconfigureNotification>,
         rx_consensus: metered_channel::Receiver<ConsensusOutput>,

--- a/executor/src/tests/fixtures.rs
+++ b/executor/src/tests/fixtures.rs
@@ -12,7 +12,7 @@ use store::{
     Store,
 };
 use test_utils::committee;
-use types::{Batch, BatchDigest, Certificate, Header};
+use types::{Batch, BatchDigest, Certificate, CertificateDigest, Header};
 
 /// A test batch containing specific transactions.
 pub fn test_batch<T: Serialize>(transactions: Vec<T>) -> (BatchDigest, Batch) {
@@ -40,11 +40,12 @@ pub fn test_certificate(payload: IndexMap<BatchDigest, WorkerId>) -> Certificate
 }
 
 /// Make a test storage to hold transaction data.
-pub fn test_store() -> Store<BatchDigest, Batch> {
+pub fn test_store() -> Store<(CertificateDigest, BatchDigest), Batch> {
     let store_path = tempfile::tempdir().unwrap();
     const TEMP_BATCHES_CF: &str = "temp_batches";
     let rocksdb = open_cf(store_path, None, &[TEMP_BATCHES_CF]).unwrap();
-    let temp_batch_map = reopen!(&rocksdb, TEMP_BATCHES_CF;<BatchDigest, Batch>);
+    let temp_batch_map =
+        reopen!(&rocksdb, TEMP_BATCHES_CF;<(CertificateDigest, BatchDigest), Batch>);
     Store::new(temp_batch_map)
 }
 

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -46,7 +46,7 @@ pub struct NodeStorage {
     pub payload_store: Store<(BatchDigest, WorkerId), PayloadToken>,
     pub batch_store: Store<BatchDigest, SerializedBatchMessage>,
     pub consensus_store: Arc<ConsensusStore>,
-    pub temp_batch_store: Store<BatchDigest, Batch>,
+    pub temp_batch_store: Store<(CertificateDigest, BatchDigest), Batch>,
 }
 
 impl NodeStorage {
@@ -95,7 +95,7 @@ impl NodeStorage {
             Self::BATCHES_CF;<BatchDigest, SerializedBatchMessage>,
             Self::LAST_COMMITTED_CF;<PublicKey, Round>,
             Self::SEQUENCE_CF;<SequenceNumber, CertificateDigest>,
-            Self::TEMP_BATCH_CF;<BatchDigest, Batch>
+            Self::TEMP_BATCH_CF;<(CertificateDigest, BatchDigest), Batch>
         );
 
         let header_store = Store::new(header_map);


### PR DESCRIPTION
Resolves: https://github.com/MystenLabs/narwhal/issues/191

The same batch can be referenced by multiple certificates, something that doesn't allow us to securely clean up storage after a certificate's execution. This PR is refactoring the temporary storage in order to reference a batch both by its `id` and the corresponding `certificate's id`. So effectively we are storing a certificate's batches under the key tuples `(certificate_id, batch_id)`. Now that allow us to securely clean up the storage whenever we execute a certificate as we have 1 to 1 semantics. 