### PR TITLE
Committee type safety

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3214,6 +3214,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "retain_mut"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4389f1d5789befaf6029ebd9f7dac4af7f7e3d61b69d4f30e2ac02b57e7712b0"
+
+[[package]]
 name = "rfc6979"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3246,6 +3252,17 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "roaring"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd539cab4e32019956fe7e0cf160bb6d4802f4be2b52c4253d76d3bb0f85a5f7"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+ "retain_mut",
 ]
 
 [[package]]
@@ -4447,6 +4464,7 @@ dependencies = [
  "prost",
  "prost-build",
  "rand 0.8.5",
+ "roaring",
  "rustversion",
  "serde",
  "serde_test",
@@ -4855,6 +4873,7 @@ dependencies = [
  "bs58",
  "bstr",
  "bulletproofs",
+ "bytemuck",
  "byteorder",
  "bytes",
  "cast",
@@ -5067,8 +5086,10 @@ dependencies = [
  "regex-automata",
  "regex-syntax",
  "remove_dir_all",
+ "retain_mut",
  "rfc6979",
  "ring",
+ "roaring",
  "rocksdb",
  "rustc-demangle",
  "rustc-hash",

--- a/config/tests/config_tests.rs
+++ b/config/tests/config_tests.rs
@@ -66,8 +66,7 @@ fn update_primary_network_info_test() {
 
     let committee2 = test_utils::committee(42);
     let invalid_new_info = committee2
-        .authorities
-        .iter()
+        .authorities()
         .map(|(pk, a)| (pk.clone(), (a.stake, a.primary.clone())))
         .collect::<BTreeMap<_, (Stake, PrimaryAddresses)>>();
     let res2 = committee
@@ -85,8 +84,7 @@ fn update_primary_network_info_test() {
 
     let committee3 = test_utils::committee(None);
     let invalid_new_info = committee3
-        .authorities
-        .iter()
+        .authorities()
         // change the stake
         .map(|(pk, a)| (pk.clone(), (a.stake + 1, a.primary.clone())))
         .collect::<BTreeMap<_, (Stake, PrimaryAddresses)>>();
@@ -105,7 +103,7 @@ fn update_primary_network_info_test() {
     let mut pk_n_stake = Vec::new();
     let mut addresses = Vec::new();
 
-    committee4.authorities.iter().for_each(|(pk, a)| {
+    committee4.authorities().for_each(|(pk, a)| {
         pk_n_stake.push((pk.clone(), a.stake));
         addresses.push(a.primary.clone())
     });
@@ -122,7 +120,7 @@ fn update_primary_network_info_test() {
     let mut comm = committee;
     let res = comm.update_primary_network_info(new_info.clone());
     assert!(res.is_ok());
-    for (pk, a) in comm.authorities.iter() {
+    for (pk, a) in comm.authorities() {
         assert_eq!(a.primary, new_info.get(pk).unwrap().1);
     }
 }
@@ -207,10 +205,8 @@ fn commmittee_snapshot_matches() {
     // and in Sui (prod)
     let keys = test_utils::keys(None);
 
-    let committee = Committee {
-        epoch: Epoch::default(),
-        authorities: keys
-            .iter()
+    let committee = Committee::new(
+        keys.iter()
             .map(|kp| {
                 let mut port = 0;
                 let increment_port_getter = || {
@@ -223,7 +219,8 @@ fn commmittee_snapshot_matches() {
                 )
             })
             .collect(),
-    };
+        Epoch::default(),
+    );
     // we need authorities to be serialized in order
     let mut settings = insta::Settings::clone_current();
     settings.set_sort_maps(true);

--- a/config/tests/snapshots/config_tests__committee.snap
+++ b/config/tests/snapshots/config_tests__committee.snap
@@ -33,5 +33,17 @@ expression: committee
       }
     }
   },
+  "ordered_authorities": [
+    "ildi4hrBzbOHBELHe0w69Yx87bh3nQJw5tTx4vc2fXQ=",
+    "rvP0pLjsod/DQzYb+OQ2vULeklnAS4MU644gVN1ugqs=",
+    "ucbuFjDvPnERRKZI2wa7sihPcnTPvuU//O5QPMGkkgA=",
+    "zGIzLjS7LVzWn2Dvuyo2y5FsfrRYMB6jZjbE27ASvYg="
+  ],
+  "index_map": {
+    "ildi4hrBzbOHBELHe0w69Yx87bh3nQJw5tTx4vc2fXQ=": 0,
+    "rvP0pLjsod/DQzYb+OQ2vULeklnAS4MU644gVN1ugqs=": 1,
+    "ucbuFjDvPnERRKZI2wa7sihPcnTPvuU//O5QPMGkkgA=": 2,
+    "zGIzLjS7LVzWn2Dvuyo2y5FsfrRYMB6jZjbE27ASvYg=": 3
+  },
   "epoch": 0
 }

--- a/consensus/src/bullshark.rs
+++ b/consensus/src/bullshark.rs
@@ -153,7 +153,7 @@ impl Bullshark {
         cfg_if::cfg_if! {
             if #[cfg(test)] {
                 // consensus tests rely on returning the same leader.
-                let leader = committee.authorities.iter().next().expect("Empty authorities table!").0;
+                let leader = committee.keys().next().expect("Empty authorities table!");
             } else {
                 // Elect the leader in a stake-weighted choice seeded by the round
                 let leader = &committee.leader(round);

--- a/consensus/src/tests/bullshark_tests.rs
+++ b/consensus/src/tests/bullshark_tests.rs
@@ -455,7 +455,7 @@ async fn epoch_change() {
         assert_eq!(output.certificate.round(), 2);
 
         // Move to the next epoch.
-        committee.epoch = epoch + 1;
+        committee.advance_epoch(1);
         let message = ReconfigureNotification::NewEpoch(committee.clone());
         tx_reconfigure.send(message).unwrap();
     }
@@ -538,7 +538,7 @@ async fn restart_with_new_committee() {
         assert_eq!(output.certificate.round(), 2);
 
         // Move to the next epoch.
-        committee.epoch = epoch + 1;
+        committee.advance_epoch(1);
         let message = ReconfigureNotification::Shutdown;
         tx_reconfigure.send(message).unwrap();
 

--- a/consensus/src/tests/tusk_tests.rs
+++ b/consensus/src/tests/tusk_tests.rs
@@ -443,7 +443,7 @@ async fn epoch_change() {
         assert_eq!(output.certificate.round(), 2);
 
         // Move to the next epoch.
-        committee.epoch = epoch + 1;
+        committee.advance_epoch(1);
         let message = ReconfigureNotification::NewEpoch(committee.clone());
         tx_reconfigure.send(message).unwrap();
     }
@@ -519,7 +519,7 @@ async fn restart_with_new_committee() {
         assert_eq!(output.certificate.round(), 2);
 
         // Move to the next epoch.
-        committee.epoch = epoch + 1;
+        committee.advance_epoch(1);
         let message = ReconfigureNotification::Shutdown;
         tx_reconfigure.send(message).unwrap();
 

--- a/consensus/src/tusk.rs
+++ b/consensus/src/tusk.rs
@@ -156,7 +156,7 @@ impl Tusk {
         cfg_if::cfg_if! {
             if #[cfg(test)] {
                 // consensus tests rely on returning the same leader.
-                let leader = committee.authorities.iter().next().expect("Empty authorities table!").0;
+                let leader = committee.keys().next().expect("Empty authorities table!");
             } else {
                 // Elect the leader in a stake-weighted choice seeded by the round
                 let leader = &committee.leader(round);

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -25,6 +25,7 @@ use fastcrypto::ed25519;
 
 pub type PublicKey = ed25519::Ed25519PublicKey;
 pub type Signature = ed25519::Ed25519Signature;
+pub type AggregateSignature = ed25519::Ed25519AggregateSignature;
 pub type PrivateKey = ed25519::Ed25519PrivateKey;
 pub type KeyPair = ed25519::Ed25519KeyPair;
 

--- a/node/src/generate_format.rs
+++ b/node/src/generate_format.rs
@@ -36,10 +36,8 @@ fn get_registry() -> Result<Registry> {
 
     // Trace the corresponding header
     let keys: Vec<_> = (0..4).map(|_| KeyPair::generate(&mut rng)).collect();
-    let committee = Committee {
-        epoch: Epoch::default(),
-        authorities: keys
-            .iter()
+    let committee = Committee::new(
+        keys.iter()
             .enumerate()
             .map(|(i, kp)| {
                 let id = kp.public();
@@ -54,7 +52,8 @@ fn get_registry() -> Result<Registry> {
                 (id.clone(), Authority { stake: 1, primary })
             })
             .collect(),
-    };
+        Epoch::default(),
+    );
 
     let certificates: Vec<Certificate> = Certificate::genesis(&committee);
 

--- a/node/tests/reconfigure.rs
+++ b/node/tests/reconfigure.rs
@@ -73,10 +73,9 @@ impl SingleExecutionState for SimpleExecutionState {
         // this function (they are immediately skipped).
         let mut epoch = self.committee.lock().unwrap().epoch();
         if transaction >= epoch && execution_indices.next_certificate_index % 3 == 0 {
-            epoch += 1;
             {
                 let mut guard = self.committee.lock().unwrap();
-                guard.epoch = epoch;
+                epoch = guard.advance_epoch(1);
             };
 
             let keypair = keys(None)

--- a/node/tests/staged/narwhal.yaml
+++ b/node/tests/staged/narwhal.yaml
@@ -35,6 +35,14 @@ Committee:
             TYPENAME: Ed25519PublicKey
           VALUE:
             TYPENAME: Authority
+    - ordered_authorities:
+        SEQ:
+          TYPENAME: Ed25519PublicKey
+    - index_map:
+        MAP:
+          KEY:
+            TYPENAME: Ed25519PublicKey
+          VALUE: U64
     - epoch: U64
 Ed25519PublicKey:
   NEWTYPESTRUCT: STR
@@ -156,3 +164,4 @@ WorkerPrimaryMessage:
       Reconfigure:
         NEWTYPE:
           TYPENAME: ReconfigureNotification
+

--- a/primary/src/certificate_waiter.rs
+++ b/primary/src/certificate_waiter.rs
@@ -218,11 +218,11 @@ impl CertificateWaiter {
     fn update_metrics(&self, waiting_len: usize) {
         self.metrics
             .pending_elements_certificate_waiter
-            .with_label_values(&[&self.committee.epoch.to_string()])
+            .with_label_values(&[&self.committee.epoch().to_string()])
             .set(self.pending.len() as i64);
         self.metrics
             .waiting_elements_certificate_waiter
-            .with_label_values(&[&self.committee.epoch.to_string()])
+            .with_label_values(&[&self.committee.epoch().to_string()])
             .set(waiting_len as i64);
     }
 }

--- a/primary/src/core.rs
+++ b/primary/src/core.rs
@@ -637,7 +637,7 @@ impl Core {
 
                         self.metrics
                             .gc_core_latency
-                            .with_label_values(&[&self.committee.epoch.to_string()])
+                            .with_label_values(&[&self.committee.epoch().to_string()])
                             .observe(now.elapsed().as_secs_f64());
                     }
 
@@ -658,7 +658,7 @@ impl Core {
 
             self.metrics
                 .core_cancel_handlers_total
-                .with_label_values(&[&self.committee.epoch.to_string()])
+                .with_label_values(&[&self.committee.epoch().to_string()])
                 .set(self.cancel_handlers.len() as i64);
         }
     }

--- a/primary/src/grpc_server/configuration.rs
+++ b/primary/src/grpc_server/configuration.rs
@@ -106,7 +106,7 @@ impl Configuration for NarwhalConfiguration {
         if epoch_number != self.committee.load().epoch() {
             return Err(Status::invalid_argument(format!(
                 "Passed in epoch {epoch_number} does not match current epoch {}",
-                self.committee.load().epoch
+                self.committee.load().epoch()
             )));
         }
         let validators = new_network_info_request.validators;

--- a/primary/src/header_waiter.rs
+++ b/primary/src/header_waiter.rs
@@ -373,7 +373,7 @@ impl HeaderWaiter {
 
                     self.metrics
                         .gc_header_waiter_latency
-                        .with_label_values(&[&self.committee.epoch.to_string()])
+                        .with_label_values(&[&self.committee.epoch().to_string()])
                         .observe(now.elapsed().as_secs_f64());
                 }
             }
@@ -381,17 +381,17 @@ impl HeaderWaiter {
             // measure the pending & parent elements
             self.metrics
                 .pending_elements_header_waiter
-                .with_label_values(&[&self.committee.epoch.to_string()])
+                .with_label_values(&[&self.committee.epoch().to_string()])
                 .set(self.pending.len() as i64);
 
             self.metrics
                 .parent_requests_header_waiter
-                .with_label_values(&[&self.committee.epoch.to_string()])
+                .with_label_values(&[&self.committee.epoch().to_string()])
                 .set(self.parent_requests.len() as i64);
 
             self.metrics
                 .waiting_elements_header_waiter
-                .with_label_values(&[&self.committee.epoch.to_string()])
+                .with_label_values(&[&self.committee.epoch().to_string()])
                 .set(waiting.len() as i64);
         }
     }

--- a/primary/src/proposer.rs
+++ b/primary/src/proposer.rs
@@ -235,7 +235,7 @@ impl Proposer {
                 self.round += 1;
                 self.metrics
                     .current_round
-                    .with_label_values(&[&self.committee.epoch.to_string()])
+                    .with_label_values(&[&self.committee.epoch().to_string()])
                     .set(self.round as i64);
                 debug!("Dag moved to round {}", self.round);
 

--- a/primary/src/state_handler.rs
+++ b/primary/src/state_handler.rs
@@ -103,12 +103,12 @@ impl StateHandler {
                     let shutdown = match &message {
                         ReconfigureNotification::NewEpoch(committee) => {
                             // Cleanup the network.
-                            self.worker_network.cleanup(self.worker_cache.load().network_diff(committee.keys()));
+                            self.worker_network.cleanup(self.worker_cache.load().network_diff(committee.keys().collect()));
 
                             // Update the worker cache.
                             self.worker_cache.swap(Arc::new(WorkerCache {
-                                epoch: committee.epoch,
-                                workers: committee.keys().iter().map(|key|
+                                epoch: committee.epoch(),
+                                workers: committee.keys().map(|key|
                                     (
                                         (*key).clone(),
                                         self.worker_cache
@@ -133,12 +133,12 @@ impl StateHandler {
                         },
                         ReconfigureNotification::UpdateCommittee(committee) => {
                             // Cleanup the network.
-                            self.worker_network.cleanup(self.worker_cache.load().network_diff(committee.keys()));
+                            self.worker_network.cleanup(self.worker_cache.load().network_diff(committee.keys().collect()));
 
                             // Update the worker cache.
                             self.worker_cache.swap(Arc::new(WorkerCache {
-                                epoch: committee.epoch,
-                                workers: committee.keys().iter().map(|key|
+                                epoch: committee.epoch(),
+                                workers: committee.keys().map(|key|
                                     (
                                         (*key).clone(),
                                         self.worker_cache

--- a/primary/src/tests/core_tests.rs
+++ b/primary/src/tests/core_tests.rs
@@ -557,7 +557,7 @@ async fn reconfigure_core() {
     // Make the new committee & worker cache
     let keys_1 = keys(None);
     let mut new_committee = pure_committee_from_keys(&keys_1);
-    new_committee.epoch = 1;
+    new_committee.advance_epoch(1);
 
     // All the channels to interface with the core.
     let (tx_reconfigure, rx_reconfigure) =

--- a/primary/tests/integration_tests_configuration_api.rs
+++ b/primary/tests/integration_tests_configuration_api.rs
@@ -67,7 +67,7 @@ async fn test_new_network_info() {
     // Test gRPC server with client call
     let mut client = authority.new_configuration_client().await;
 
-    let public_keys: Vec<_> = committee.load().authorities.keys().cloned().collect();
+    let public_keys: Vec<_> = committee.load().keys().cloned().collect();
 
     let mut validators = Vec::new();
     for public_key in public_keys.iter() {

--- a/primary/tests/integration_tests_proposer_api.rs
+++ b/primary/tests/integration_tests_proposer_api.rs
@@ -83,14 +83,13 @@ async fn test_rounds_errors() {
 
     // AND create a committee passed exclusively to the DAG that does not include the name public key
     // In this way, the genesis certificate is not run for that authority and is absent when we try to fetch it
-    let no_name_committee = config::Committee {
-        epoch: Epoch::default(),
-        authorities: committee
-            .authorities
-            .iter()
+    let no_name_committee = config::Committee::new(
+        committee
+            .authorities()
             .filter_map(|(pk, a)| (*pk != name).then_some((pk.clone(), a.clone())))
             .collect::<BTreeMap<_, _>>(),
-    };
+        Epoch::default(),
+    );
 
     let consensus_metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
 

--- a/primary/tests/integration_tests_validator_api.rs
+++ b/primary/tests/integration_tests_validator_api.rs
@@ -697,11 +697,7 @@ async fn test_read_causal_unsigned_certificates() {
     let (certificates, _next_parents) = make_optimal_certificates(
         1..=4,
         &genesis,
-        &committee
-            .authorities
-            .keys()
-            .cloned()
-            .collect::<Vec<PublicKey>>(),
+        &committee.keys().cloned().collect::<Vec<PublicKey>>(),
     );
 
     collection_ids.extend(

--- a/test_utils/src/cluster.rs
+++ b/test_utils/src/cluster.rs
@@ -107,7 +107,7 @@ impl Cluster {
         workers_per_authority: Option<usize>,
         boot_wait_time: Option<Duration>,
     ) {
-        let max_authorities = self.committee_shared.load().authorities.len();
+        let max_authorities = self.committee_shared.load().size();
         let authorities = authorities_number.unwrap_or(max_authorities);
 
         if authorities > max_authorities {

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -128,13 +128,12 @@ pub fn committee(rng_seed: impl Into<Option<u64>>) -> Committee {
 }
 
 pub fn pure_committee_from_keys(keys: &[KeyPair]) -> Committee {
-    Committee {
-        epoch: Epoch::default(),
-        authorities: keys
-            .iter()
+    Committee::new(
+        keys.iter()
             .map(|kp| (kp.public().clone(), make_authority()))
             .collect(),
-    }
+        Epoch::default(),
+    )
 }
 
 pub fn make_authority_with_port_getter<F: FnMut() -> u16>(mut get_port: F) -> Authority {
@@ -249,10 +248,8 @@ pub fn initialize_worker_index_with_port_getter<F: FnMut() -> u16>(mut get_port:
 
 // Fixture
 pub fn mock_committee(keys: &[PublicKey]) -> Committee {
-    Committee {
-        epoch: Epoch::default(),
-        authorities: keys
-            .iter()
+    Committee::new(
+        keys.iter()
             .map(|id| {
                 (
                     id.clone(),
@@ -266,7 +263,8 @@ pub fn mock_committee(keys: &[PublicKey]) -> Committee {
                 )
             })
             .collect(),
-    }
+        Epoch::default(),
+    )
 }
 
 // Fixture

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -19,6 +19,7 @@ proptest = "1.0.0"
 proptest-derive = "0.3.0"
 prost = "0.10.4"
 rand = "0.8.5"
+roaring = "0.9.0"
 serde = { version = "1.0.144", features = ["derive"] }
 signature = "1.6.0"
 store = { git = "https://github.com/mystenlabs/mysten-infra.git", package = "typed-store", rev = "8d090689be14078f2ca41c356e7bbc0af21f73ab" }

--- a/types/src/primary.rs
+++ b/types/src/primary.rs
@@ -368,7 +368,6 @@ pub struct Certificate {
 impl Certificate {
     pub fn genesis(committee: &Committee) -> Vec<Self> {
         committee
-            .authorities
             .keys()
             .map(|name| Self {
                 header: Header {

--- a/worker/src/batch_maker.rs
+++ b/worker/src/batch_maker.rs
@@ -163,7 +163,7 @@ impl BatchMaker {
 
         self.node_metrics
             .created_batch_size
-            .with_label_values(&[self.committee.epoch.to_string().as_str(), reason])
+            .with_label_values(&[self.committee.epoch().to_string().as_str(), reason])
             .observe(size as f64);
 
         // Send the batch through the deliver channel for further processing.

--- a/worker/src/synchronizer.rs
+++ b/worker/src/synchronizer.rs
@@ -209,13 +209,13 @@ impl Synchronizer {
                         // Reconfigure this task and update the shared committee.
                         let shutdown = match &message {
                             ReconfigureNotification::NewEpoch(new_committee) => {
-                                self.network.cleanup(self.worker_cache.load().network_diff(new_committee.keys()));
+                                self.network.cleanup(self.worker_cache.load().network_diff(new_committee.keys().collect()));
                                 self.committee.swap(Arc::new(new_committee.clone()));
 
                                 // Update the worker cache.
                                 self.worker_cache.swap(Arc::new(WorkerCache {
-                                    epoch: new_committee.epoch,
-                                    workers: new_committee.keys().iter().map(|key|
+                                    epoch: new_committee.epoch(),
+                                    workers: new_committee.keys().map(|key|
                                         (
                                             (*key).clone(),
                                             self.worker_cache
@@ -237,13 +237,13 @@ impl Synchronizer {
                                 false
                             }
                             ReconfigureNotification::UpdateCommittee(new_committee) => {
-                                self.network.cleanup(self.worker_cache.load().network_diff(new_committee.keys()));
+                                self.network.cleanup(self.worker_cache.load().network_diff(new_committee.keys().collect()));
                                 self.committee.swap(Arc::new(new_committee.clone()));
 
                                 // Update the worker cache.
                                 self.worker_cache.swap(Arc::new(WorkerCache {
-                                    epoch: new_committee.epoch,
-                                    workers: new_committee.keys().iter().map(|key|
+                                    epoch: new_committee.epoch(),
+                                    workers: new_committee.keys().map(|key|
                                         (
                                             (*key).clone(),
                                             self.worker_cache
@@ -329,7 +329,7 @@ impl Synchronizer {
 
                     // Report list of pending elements
                     self.metrics.pending_elements_worker_synchronizer
-                    .with_label_values(&[&self.committee.load().epoch.to_string()])
+                    .with_label_values(&[&self.committee.load().epoch().to_string()])
                     .set(self.pending.len() as i64);
                 },
             }

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -56,6 +56,7 @@ blst = { version = "0.3" }
 bs58 = { version = "0.4", features = ["alloc", "std"] }
 bstr = { version = "0.2", features = ["lazy_static", "regex-automata", "serde", "serde1", "serde1-nostd", "std", "unicode"] }
 bulletproofs = { version = "4", features = ["rand", "std", "thiserror"] }
+bytemuck = { version = "1", default-features = false }
 byteorder = { version = "1", features = ["i128", "std"] }
 bytes = { version = "1", features = ["std"] }
 cast = { version = "0.3", default-features = false }
@@ -222,8 +223,10 @@ regex = { version = "1", features = ["aho-corasick", "memchr", "perf", "perf-cac
 regex-automata = { version = "0.1", features = ["regex-syntax", "std"] }
 regex-syntax = { version = "0.6", features = ["unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
 remove_dir_all = { version = "0.5", default-features = false }
+retain_mut = { version = "0.1", default-features = false }
 rfc6979 = { version = "0.3", default-features = false }
 ring = { version = "0.16", features = ["alloc", "dev_urandom_fallback", "once_cell"] }
+roaring = { version = "0.9", default-features = false }
 rocksdb = { version = "0.19", default-features = false, features = ["lz4", "multi-threaded-cf", "snappy", "zlib", "zstd"] }
 rustc-demangle = { version = "0.1", default-features = false }
 rustc-hash = { version = "1", features = ["std"] }


### PR DESCRIPTION
This makes Committee structs type-safe by ensuring that the list of underlying validators in an epoch is immutable. This is required for the following PRs that we will then later push:
1. Replace Public Keys in certificate with Bitmaps.
2. Replace with vector of signatures with Aggregated Signatures