### PR TITLE
Add a BlockSynchronizer command to fetch certificate digests with a starting round

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -38,6 +38,7 @@ node_params = {
     'batch_size': 500_000,
     'max_batch_delay': '100ms',
     'block_synchronizer': {
+        'range_synchronize_timeout': '30s',
         'certificates_synchronize_timeout': '30s',
         'payload_synchronize_timeout': '30s',
         'payload_availability_timeout': '30s',
@@ -59,6 +60,7 @@ They are defined as follows:
 * `sync_retry_nodes`: How many nodes to sync when re-trying to send sync-request. These nodes are picked at random from the committee.
 * `batch_size`: The preferred batch size. The workers seal a batch of transactions when it reaches this size. Denominated in bytes.
 * `max_batch_delay`: The delay after which the workers seal a batch of transactions, even if `max_batch_size` is not reached. Denominated in ms.
+* `range_synchronize_timeout`: The timeout configuration when synchronizing a range of certificates from peers.
 * `certificates_synchronize_timeout`: The timeout configuration when requesting certificates from peers.
 * `payload_synchronize_timeout`: Timeout when has requested the payload for a certificate and is waiting to receive them.
 * `payload_availability_timeout`: The timeout configuration when for when we ask the other peers to discover who has the payload available for the dictated certificates.

--- a/benchmark/fabfile.py
+++ b/benchmark/fabfile.py
@@ -32,6 +32,7 @@ def local(ctx, debug=True):
         'batch_size': 500_000,  # bytes
         'max_batch_delay': '200ms',  # ms,
         'block_synchronizer': {
+            'range_synchronize_timeout': '30_000ms',
             'certificates_synchronize_timeout': '2_000ms',
             'payload_synchronize_timeout': '2_000ms',
             'payload_availability_timeout': '2_000ms',
@@ -69,6 +70,7 @@ def demo(ctx, debug=True):
     node_params = {
         "batch_size": 500000,
         "block_synchronizer": {
+            'range_synchronize_timeout': '30_000ms',
             "certificates_synchronize_timeout": "2_000ms",
             "handler_certificate_deliver_timeout": "2_000ms",
             "payload_availability_timeout": "2_000ms",
@@ -194,6 +196,7 @@ def remote(ctx, debug=False):
         'batch_size': 500_000,  # bytes
         'max_batch_delay': '200ms',  # ms,
         'block_synchronizer': {
+            'range_synchronize_timeout': '30_000ms',
             'certificates_synchronize_timeout': '2_000ms',
             'payload_synchronize_timeout': '2_000ms',
             'payload_availability_timeout': '2_000ms',

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -182,6 +182,12 @@ impl Default for ConsensusAPIGrpcParameters {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(default)]
 pub struct BlockSynchronizerParameters {
+    /// The timeout configuration for synchronizing certificate digests from a starting round.
+    #[serde(
+        with = "duration_format",
+        default = "BlockSynchronizerParameters::default_range_synchronize_timeout"
+    )]
+    pub range_synchronize_timeout: Duration,
     /// The timeout configuration when requesting certificates from peers.
     #[serde(
         with = "duration_format",
@@ -216,6 +222,9 @@ pub struct BlockSynchronizerParameters {
 }
 
 impl BlockSynchronizerParameters {
+    fn default_range_synchronize_timeout() -> Duration {
+        Duration::from_secs(30)
+    }
     fn default_certificates_synchronize_timeout() -> Duration {
         Duration::from_secs(30)
     }
@@ -233,6 +242,8 @@ impl BlockSynchronizerParameters {
 impl Default for BlockSynchronizerParameters {
     fn default() -> Self {
         Self {
+            range_synchronize_timeout:
+                BlockSynchronizerParameters::default_range_synchronize_timeout(),
             certificates_synchronize_timeout:
                 BlockSynchronizerParameters::default_certificates_synchronize_timeout(),
             payload_synchronize_timeout:
@@ -280,6 +291,10 @@ impl Parameters {
         info!(
             "Max batch delay set to {} ms",
             self.max_batch_delay.as_millis()
+        );
+        info!(
+            "Synchronize range timeout set to {} s",
+            self.block_synchronizer.range_synchronize_timeout.as_secs()
         );
         info!(
             "Synchronize certificates timeout set to {} s",

--- a/config/tests/config_tests.rs
+++ b/config/tests/config_tests.rs
@@ -171,6 +171,7 @@ fn parameters_import_snapshot_matches() {
          "batch_size": 500000,
          "max_batch_delay": "100ms",
          "block_synchronizer": {
+             "range_synchronize_timeout": "30s",
              "certificates_synchronize_timeout": "2s",
              "payload_synchronize_timeout": "3_000ms",
              "payload_availability_timeout": "4_000ms"

--- a/config/tests/snapshots/config_tests__parameters.snap
+++ b/config/tests/snapshots/config_tests__parameters.snap
@@ -11,6 +11,7 @@ expression: parameters
   "batch_size": 500000,
   "max_batch_delay": "100ms",
   "block_synchronizer": {
+    "range_synchronize_timeout": "30000ms",
     "certificates_synchronize_timeout": "30000ms",
     "payload_synchronize_timeout": "30000ms",
     "payload_availability_timeout": "30000ms",

--- a/config/tests/snapshots/config_tests__parameters_import.snap
+++ b/config/tests/snapshots/config_tests__parameters_import.snap
@@ -11,6 +11,7 @@ expression: params
   "batch_size": 500000,
   "max_batch_delay": "100ms",
   "block_synchronizer": {
+    "range_synchronize_timeout": "30000ms",
     "certificates_synchronize_timeout": "2000ms",
     "payload_synchronize_timeout": "3000ms",
     "payload_availability_timeout": "4000ms",

--- a/primary/src/block_synchronizer/mock.rs
+++ b/primary/src/block_synchronizer/mock.rs
@@ -51,6 +51,9 @@ impl MockBlockSynchronizerCore {
             tokio::select! {
                 Some(command) = self.rx_commands.recv() => {
                     match command {
+                        Command::SynchronizeRange { .. } => {
+                            todo!("MockBlockSynchronizerCore for Command::SynchronizeRange is unimplemented!")
+                        }
                         Command::SynchronizeBlockHeaders { block_ids, respond_to } => {
                             let (times, results) = self
                                 .block_headers_expected_requests

--- a/primary/src/block_synchronizer/mod.rs
+++ b/primary/src/block_synchronizer/mod.rs
@@ -73,14 +73,12 @@ pub type BlockSynchronizeResult<T> = Result<T, SyncError>;
 
 #[derive(Debug)]
 pub enum Command {
-    #[allow(dead_code)]
     /// A request to have this authority catch up with others on certificates as much as possible.
     /// It is intended to be used when this authority has just restarted, or has detected that it is
     /// missing a significant number of latest rounds from the dag.
     SynchronizeRange {
         respond_to: Sender<CertificateIDsByRounds>,
     },
-    #[allow(dead_code)]
     /// A request to synchronize and output the block headers
     /// This will not perform any attempt to fetch the header's
     /// batches. This component does NOT check whether the
@@ -102,7 +100,6 @@ pub enum Command {
     /// This component does NOT check whether the
     //  requested block_ids are already synchronized. This is the
     //  consumer's responsibility.
-    #[allow(dead_code)]
     SynchronizeBlockPayload {
         certificates: Vec<Certificate>,
         respond_to: ResultSender,

--- a/primary/src/block_synchronizer/mod.rs
+++ b/primary/src/block_synchronizer/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     primary::PrimaryMessage,
     utils, PayloadToken, CHANNEL_CAPACITY,
 };
-use config::{BlockSynchronizerParameters, Committee, SharedWorkerCache, WorkerId};
+use config::{BlockSynchronizerParameters, Committee, SharedWorkerCache, Stake, WorkerId};
 use crypto::PublicKey;
 use fastcrypto::Hash;
 use futures::{
@@ -20,11 +20,12 @@ use futures::{
 use network::{P2pNetwork, UnreliableNetwork};
 use rand::{rngs::SmallRng, SeedableRng};
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     time::Duration,
 };
 use storage::CertificateStore;
 use store::Store;
+use tap::TapFallible;
 use thiserror::Error;
 use tokio::{
     sync::{
@@ -37,7 +38,7 @@ use tokio::{
 use tracing::{debug, error, info, instrument, trace, warn};
 use types::{
     metered_channel, BatchDigest, Certificate, CertificateDigest, PrimaryWorkerMessage,
-    ReconfigureNotification,
+    ReconfigureNotification, Round,
 };
 
 use self::responses::AvailabilityResponse;
@@ -67,11 +68,19 @@ pub struct BlockHeader {
     pub fetched_from_storage: bool,
 }
 
+type CertificateIDsByRounds = BTreeMap<Round, Vec<CertificateDigest>>;
 type ResultSender = Sender<BlockSynchronizeResult<BlockHeader>>;
 pub type BlockSynchronizeResult<T> = Result<T, SyncError>;
 
 #[derive(Debug)]
 pub enum Command {
+    #[allow(dead_code)]
+    /// A request to have this authority catch up with others on certificates as much as possible.
+    /// It is intended to be used when this authority has just restarted, or has detected that it is
+    /// missing a significant number of latest rounds from the dag.
+    SynchronizeRange {
+        respond_to: Sender<CertificateIDsByRounds>,
+    },
     #[allow(dead_code)]
     /// A request to synchronize and output the block headers
     /// This will not perform any attempt to fetch the header's
@@ -106,6 +115,9 @@ pub enum Command {
 // one state to the other those commands are being used.
 #[allow(clippy::large_enum_variant)]
 enum State {
+    RangeSynchronized {
+        certificate_ids: CertificateIDsByRounds,
+    },
     HeadersSynchronized {
         request_id: RequestID,
         certificates: HashMap<CertificateDigest, BlockSynchronizeResult<BlockHeader>>,
@@ -154,6 +166,20 @@ impl PendingIdentifier {
     }
 }
 
+// Tracks the responses from the inflight synchronize range request.
+#[derive(Default)]
+struct SyncRangeState {
+    // Wehther there is an active range sync request.
+    // When active, both item_sender and result_sender are valid. And both are None when inactive.
+    running: bool,
+    // Keeps track of peers that have responded, to avoid processing duplicated responses.
+    responded_peers: BTreeSet<PublicKey>,
+    // Relays each range sync response to the waiter for processing.
+    item_sender: Option<Sender<(CertificateIDsByRounds, PublicKey)>>,
+    // Relies the final response to the original caller of the range sync.
+    result_sender: Option<Sender<CertificateIDsByRounds>>,
+}
+
 pub struct BlockSynchronizer {
     /// The public key of this primary.
     name: PublicKey,
@@ -176,6 +202,9 @@ pub struct BlockSynchronizer {
     /// Pending block requests either for header or payload type
     pending_requests: HashMap<PendingIdentifier, Vec<ResultSender>>,
 
+    /// Status of the inflight range sync request if there is one running.
+    sync_range_state: SyncRangeState,
+
     /// Requests managers
     map_certificate_responses_senders: HashMap<RequestID, Sender<CertificatesResponse>>,
 
@@ -191,6 +220,9 @@ pub struct BlockSynchronizer {
 
     /// The persistent storage for payload markers from workers
     payload_store: Store<(BatchDigest, WorkerId), PayloadToken>,
+
+    /// Timeout when synchronizing a range of certificate digests
+    range_synchronize_timeout: Duration,
 
     /// Timeout when synchronizing the certificates
     certificates_synchronize_timeout: Duration,
@@ -225,11 +257,13 @@ impl BlockSynchronizer {
                 rx_commands,
                 rx_availability_responses,
                 pending_requests: HashMap::new(),
+                sync_range_state: SyncRangeState::default(),
                 map_certificate_responses_senders: HashMap::new(),
                 map_payload_availability_responses_senders: HashMap::new(),
                 network,
                 payload_store,
                 certificate_store,
+                range_synchronize_timeout: parameters.range_synchronize_timeout,
                 certificates_synchronize_timeout: parameters.certificates_synchronize_timeout,
                 payload_synchronize_timeout: parameters.payload_availability_timeout,
                 payload_availability_timeout: parameters.payload_availability_timeout,
@@ -257,6 +291,12 @@ impl BlockSynchronizer {
             tokio::select! {
                 Some(command) = self.rx_commands.recv() => {
                     match command {
+                        Command::SynchronizeRange { respond_to } => {
+                            let fut = self.handle_synchronize_range_command(respond_to).await;
+                            if fut.is_some() {
+                                waiting.push(fut.unwrap());
+                            }
+                        },
                         Command::SynchronizeBlockHeaders { block_ids, respond_to } => {
                             let fut = self.handle_synchronize_block_headers_command(block_ids, respond_to).await;
                             if fut.is_some() {
@@ -275,10 +315,21 @@ impl BlockSynchronizer {
                     match response {
                         AvailabilityResponse::Certificate(certificate_response) => self.handle_certificates_response(certificate_response).await,
                         AvailabilityResponse::Payload(payload_availability_response) => self.handle_payload_availability_response(payload_availability_response).await,
+                // Some(PrimaryMessage::CertificatesRangeResponse { certificate_ids, from }) = self.rx_range_responses.recv() => {
+                //     self.handle_range_response(certificate_ids, from).await;
+                // },
                     }
                 },
                 Some(state) = waiting.next() => {
                     match state {
+                        State::RangeSynchronized { certificate_ids } => {
+                            assert!(self.sync_range_state.running);
+                            if let Err(e) = self.sync_range_state.result_sender.as_ref().unwrap().send(certificate_ids).await {
+                                error!("Failed to send back range sync result {e}");
+                            }
+                            // Range sync is done. Clear the state.
+                            self.sync_range_state = SyncRangeState::default();
+                        },
                         State::HeadersSynchronized { request_id, certificates } => {
                             debug!("Result for the block headers synchronize request id {request_id}");
 
@@ -331,6 +382,130 @@ impl BlockSynchronizer {
                 }
             }
         }
+    }
+
+    async fn handle_synchronize_range_command<'a>(
+        &mut self,
+        respond_to: Sender<CertificateIDsByRounds>,
+    ) -> Option<BoxFuture<'a, State>> {
+        // Allow only one range sync running at a time, to avoid repeated range sync on certain rounds.
+        // It is expected that if there are still missing rounds after the current sync, another
+        // range sync will be triggered.
+        if self.sync_range_state.running {
+            return None;
+        }
+
+        // Initialize range sync state.
+        let (sender, receiver) = channel(self.committee.size());
+        assert!(self.sync_range_state.responded_peers.is_empty());
+        self.sync_range_state.running = true;
+        self.sync_range_state.result_sender = Some(respond_to);
+        self.sync_range_state.item_sender = Some(sender);
+
+        // Broadcast range sync request.
+        let last_round = self.certificate_store.last_round_number().tap_err(|e| {
+            warn!("Failed to read past rounds: {e:?}");
+        });
+        let last_round = if let Ok(r) = last_round {
+            r
+        } else {
+            return None;
+        };
+        // NOTE: Assuming locally missing certificates in existing rounds are negligible issues,
+        // range sync starts from the next round where there is no certificate stored locally.
+        // We can switch to a more fine grained per-certificate-author range sync if necessary.
+        // Start sync from round 0, if there is no certificate in store.
+        let range_start = if let Some(r) = last_round { r + 1 } else { 0 };
+        let message = PrimaryMessage::CertificatesRangeRequest {
+            range_start,
+            requestor: self.name.clone(),
+        };
+        self.broadcast_batch_request(message.clone()).await;
+
+        // Responses are not await here to avoid blocking the BlockSynchronizer loop.
+        Some(
+            Self::wait_for_range_sync_responses(
+                receiver,
+                self.committee.clone(),
+                self.range_synchronize_timeout,
+            )
+            .boxed(),
+        )
+    }
+
+    async fn handle_range_response(
+        &mut self,
+        certificate_ids: CertificateIDsByRounds,
+        from: PublicKey,
+    ) {
+        if !self.sync_range_state.running {
+            // Drop if there is no active range request.
+            return;
+        }
+        if from == self.name || self.committee.stake(&from) == 0 {
+            // Drop when the response is from the same primary
+            // or from an origin that is not in the committe.
+            return;
+        }
+        let state = &mut self.sync_range_state;
+        if !state.responded_peers.insert(from.clone()) {
+            // Skip duplicated response from the same peer.
+            return;
+        }
+        // Since range sync state is active, item_sender must be valid.
+        if let Err(e) = state
+            .item_sender
+            .as_ref()
+            .unwrap()
+            .send((certificate_ids, from))
+            .await
+        {
+            error!("Failed to forward range sync response {e}");
+        }
+    }
+
+    async fn wait_for_range_sync_responses(
+        mut receiver: Receiver<(CertificateIDsByRounds, PublicKey)>,
+        committee: Committee,
+        range_synchronize_timeout: Duration,
+    ) -> State {
+        let total_expected_responses = committee.size() - 1;
+        let mut num_of_responses: usize = 0;
+        let mut received_certificates_ids = BTreeMap::<(Round, CertificateDigest), Stake>::new();
+
+        let timer = sleep(range_synchronize_timeout);
+        tokio::pin!(timer);
+
+        loop {
+            tokio::select! {
+                Some((certificate_ids, from)) = receiver.recv() => {
+                    let stake = committee.stake(&from);
+                    for (round, cert_ids) in &certificate_ids {
+                        for cert_id in cert_ids {
+                            let s = received_certificates_ids.entry((*round, *cert_id)).or_default();
+                            *s += stake;
+                        }
+                    }
+
+                    num_of_responses += 1;
+                    if num_of_responses == total_expected_responses {
+                        break;
+                    }
+                },
+                () = &mut timer => {
+                    break;
+                }
+            }
+        }
+
+        let mut certificate_ids = BTreeMap::<Round, Vec<CertificateDigest>>::new();
+        for ((round, cert_id), stake) in received_certificates_ids {
+            if stake >= committee.validity_threshold() {
+                certificate_ids.entry(round).or_default().push(cert_id);
+            }
+        }
+
+        State::RangeSynchronized { certificate_ids }
     }
 
     async fn notify_requestors_for_result(

--- a/primary/src/block_synchronizer/responses.rs
+++ b/primary/src/block_synchronizer/responses.rs
@@ -4,10 +4,13 @@ use blake2::digest::Update;
 use config::{Committee, SharedWorkerCache};
 use crypto::PublicKey;
 use fastcrypto::{Digest, Hash};
-use std::fmt::{Display, Formatter};
+use std::{
+    collections::BTreeMap,
+    fmt::{Display, Formatter},
+};
 use thiserror::Error;
 use tracing::{error, warn};
-use types::{Certificate, CertificateDigest};
+use types::{Certificate, CertificateDigest, Round};
 
 // RequestID helps us identify an incoming request and
 // all the consequent network requests associated with it.
@@ -138,7 +141,15 @@ impl CertificatesResponse {
 }
 
 #[derive(Debug, Clone)]
+pub struct CertificateDigestsResponse {
+    // Certificate digests, grouped by round numbers.
+    pub certificate_ids: BTreeMap<Round, Vec<CertificateDigest>>,
+    pub from: PublicKey,
+}
+
+#[derive(Debug, Clone)]
 pub enum AvailabilityResponse {
+    CertificateDigest(CertificateDigestsResponse),
     Certificate(CertificatesResponse),
     Payload(PayloadAvailabilityResponse),
 }

--- a/primary/src/block_synchronizer/tests/block_synchronizer_tests.rs
+++ b/primary/src/block_synchronizer/tests/block_synchronizer_tests.rs
@@ -190,10 +190,12 @@ async fn test_successful_range_synchronization() {
         match primary_responses.remove(0) {
             PrimaryMessage::CertificatesRangeRequest {
                 range_start,
+                max_rounds,
                 requestor,
             } => {
                 info!("Received range sync response from {requestor}");
                 assert_eq!(range_start, 5, "Start of requested range is incorrect");
+                assert_eq!(max_rounds, 50, "Max rounds is incorrect");
                 tx_range_responses
                     .send(PrimaryMessage::CertificatesRangeResponse {
                         certificate_ids: certificate_ids[i].clone(),

--- a/primary/src/block_synchronizer/tests/block_synchronizer_tests.rs
+++ b/primary/src/block_synchronizer/tests/block_synchronizer_tests.rs
@@ -57,18 +57,16 @@ async fn test_successful_range_synchronization() {
     let (_, rx_certificate_responses) = test_utils::test_channel!(10);
     let (_, rx_payload_availability_responses) = test_utils::test_channel!(10);
 
-    let own_address =
-        network::multiaddr_to_address(&committee.primary(&name).unwrap().primary_to_primary)
-            .unwrap();
+    let own_address = network::multiaddr_to_address(&committee.primary(&name).unwrap()).unwrap();
     let network = anemo::Network::bind(own_address)
         .server_name("narwhal")
         .private_key(network_key)
         .start(anemo::Router::new())
         .unwrap();
 
-    for (_pubkey, addresses, network_pubkey) in committee.others_primaries(&name) {
+    for (_pubkey, address, network_pubkey) in committee.others_primaries(&name) {
         let peer_id = PeerId(network_pubkey.0.to_bytes());
-        let address = network::multiaddr_to_address(&addresses.primary_to_primary).unwrap();
+        let address = network::multiaddr_to_address(&address).unwrap();
         let peer_info = PeerInfo {
             peer_id,
             affinity: anemo::types::PeerAffinity::High,
@@ -151,10 +149,7 @@ async fn test_successful_range_synchronization() {
         .authorities()
         .filter(|a| a.public_key() != name)
         .map(|a| {
-            let address = committee
-                .primary(&a.public_key())
-                .unwrap()
-                .primary_to_primary;
+            let address = committee.primary(&a.public_key()).unwrap();
             primary_listener(1, a.network_keypair().copy(), address)
         })
         .collect();

--- a/primary/src/block_synchronizer/tests/block_synchronizer_tests.rs
+++ b/primary/src/block_synchronizer/tests/block_synchronizer_tests.rs
@@ -15,7 +15,7 @@ use fastcrypto::Hash;
 use futures::{future::try_join_all, stream::FuturesUnordered};
 use network::P2pNetwork;
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     time::Duration,
 };
 use test_utils::{fixture_batch_with_transactions, CommitteeFixture, PrimaryToPrimaryMockServer};
@@ -24,12 +24,215 @@ use tokio::{
     task::JoinHandle,
     time::{sleep, timeout},
 };
-use types::ReconfigureNotification;
+use types::{ReconfigureNotification, Round};
 
 use crypto::NetworkKeyPair;
 use fastcrypto::traits::KeyPair as _;
-use tracing::debug;
+use tracing::{debug, info};
 use types::{Certificate, CertificateDigest};
+
+#[tokio::test]
+async fn test_successful_range_synchronization() {
+    telemetry_subscribers::init_for_testing();
+    // GIVEN
+    let (_, certificate_store, payload_store) = create_db_stores();
+
+    let fixture = CommitteeFixture::builder().randomize_ports(true).build();
+    let committee = fixture.committee();
+    let worker_cache = fixture.shared_worker_cache();
+    let author = fixture.authorities().next().unwrap();
+    let primary = fixture.authorities().nth(1).unwrap();
+    let name = primary.public_key();
+    let network_key = primary.network_keypair().copy().private().0.to_bytes();
+    assert_eq!(
+        committee.size(),
+        4,
+        "This test assumes the committee has four members (with equal stake)"
+    );
+
+    let (_tx_reconfigure, rx_reconfigure) =
+        watch::channel(ReconfigureNotification::NewEpoch(committee.clone()));
+    let (tx_commands, rx_commands) = test_utils::test_channel!(10);
+    let (tx_range_responses, rx_range_responses) = test_utils::test_channel!(10);
+    let (_, rx_certificate_responses) = test_utils::test_channel!(10);
+    let (_, rx_payload_availability_responses) = test_utils::test_channel!(10);
+
+    let own_address =
+        network::multiaddr_to_address(&committee.primary(&name).unwrap().primary_to_primary)
+            .unwrap();
+    let network = anemo::Network::bind(own_address)
+        .server_name("narwhal")
+        .private_key(network_key)
+        .start(anemo::Router::new())
+        .unwrap();
+
+    for (_pubkey, addresses, network_pubkey) in committee.others_primaries(&name) {
+        let peer_id = PeerId(network_pubkey.0.to_bytes());
+        let address = network::multiaddr_to_address(&addresses.primary_to_primary).unwrap();
+        let peer_info = PeerInfo {
+            peer_id,
+            affinity: anemo::types::PeerAffinity::High,
+            address: vec![address],
+        };
+        network.known_peers().insert(peer_info);
+    }
+
+    // AND create the synchronizer
+    let _synchronizer_handle = BlockSynchronizer::spawn(
+        name.clone(),
+        committee.clone(),
+        worker_cache.clone(),
+        rx_reconfigure,
+        rx_commands,
+        rx_range_responses,
+        rx_certificate_responses,
+        rx_payload_availability_responses,
+        P2pNetwork::new(network.clone()),
+        payload_store.clone(),
+        certificate_store.clone(),
+        BlockSynchronizerParameters::default(),
+    );
+
+    // AND propulate certificates from round 0 ~ 4 in the local store.
+    let worker_id_0 = 0;
+    let worker_id_1 = 1;
+    for r in 0..5 {
+        let batch_1 = fixture_batch_with_transactions(10);
+        let batch_2 = fixture_batch_with_transactions(10);
+
+        let mut header = author
+            .header_builder(&committee)
+            .with_payload_batch(batch_1.clone(), worker_id_0)
+            .with_payload_batch(batch_2.clone(), worker_id_1)
+            .build(author.keypair())
+            .unwrap();
+        header.round = r;
+        let certificate = fixture.certificate(&header);
+        // Intentionally only store one certificate per round.
+        certificate_store.write(certificate).unwrap();
+    }
+
+    // AND generate certificate digests for response from each authority (3 responses in total).
+    let mut certificate_ids = Vec::new();
+    for _ in 0..3 {
+        certificate_ids.push(BTreeMap::<Round, Vec<CertificateDigest>>::new());
+    }
+    for r in 5..20 {
+        for _ in 0..committee.size() {
+            let batch_1 = fixture_batch_with_transactions(10);
+            let batch_2 = fixture_batch_with_transactions(10);
+
+            let mut header = author
+                .header_builder(&committee)
+                .with_payload_batch(batch_1.clone(), worker_id_0)
+                .with_payload_batch(batch_2.clone(), worker_id_1)
+                .build(author.keypair())
+                .unwrap();
+            header.round = r;
+            let certificate = fixture.certificate(&header);
+            // Round 5 ~ 9: will exist in all 3 range sync responses.
+            // Round 10 ~ 14: will exist in 2 range sync responses.
+            // Round 15 ~ 19: will exist in only 1 range sync response, below the validity threshold (f + 1 stake).
+            for j in 0..(certificate_ids.len() - (r - 5) as usize / 5) {
+                certificate_ids[j]
+                    .entry(r)
+                    .or_default()
+                    .push(certificate.digest());
+            }
+        }
+    }
+
+    // AND the channel to respond to
+    let (tx_synchronize, mut rx_synchronize) = mpsc::channel(10);
+
+    // AND let's assume that all the primaries are responding with the full set
+    // of requested certificate digests.
+    let handlers: FuturesUnordered<JoinHandle<Vec<PrimaryMessage>>> = fixture
+        .authorities()
+        .filter(|a| a.public_key() != name)
+        .map(|a| {
+            let address = committee
+                .primary(&a.public_key())
+                .unwrap()
+                .primary_to_primary;
+            primary_listener(1, a.network_keypair().copy(), address)
+        })
+        .collect();
+
+    // Wait for connectivity
+    let (mut events, mut peers) = network.subscribe();
+    while peers.len() != committee.size() - 1 {
+        let event = events.recv().await.unwrap();
+        match event {
+            anemo::types::PeerEvent::NewPeer(peer_id) => peers.push(peer_id),
+            anemo::types::PeerEvent::LostPeer(_, _) => {
+                panic!("we shouldn't see any lost peer events")
+            }
+        }
+    }
+
+    // WHEN
+    tx_commands
+        .send(Command::SynchronizeRange {
+            respond_to: tx_synchronize,
+        })
+        .await
+        .ok()
+        .unwrap();
+
+    // wait for the primaries to receive all the requests
+    let mut result = timeout(Duration::from_secs(5), try_join_all(handlers))
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(result.len(), 3);
+    let mut primaries = committee.others_primaries(&name);
+    for i in 0..result.len() {
+        // ensure that only one request has been received
+        let primary_responses = &mut result[i];
+        assert_eq!(primary_responses.len(), 1, "Expected only one request");
+
+        match primary_responses.remove(0) {
+            PrimaryMessage::CertificatesRangeRequest {
+                range_start,
+                requestor,
+            } => {
+                info!("Received range sync response from {requestor}");
+                assert_eq!(range_start, 5, "Start of requested range is incorrect");
+                tx_range_responses
+                    .send(PrimaryMessage::CertificatesRangeResponse {
+                        certificate_ids: certificate_ids[i].clone(),
+                        from: primaries.pop().unwrap().0,
+                    })
+                    .await
+                    .unwrap();
+            }
+            _ => {
+                panic!("Unexpected request has been received!");
+            }
+        }
+    }
+
+    // THEN the received certificate digests should be expected.
+    let timer = sleep(Duration::from_secs(10));
+    tokio::pin!(timer);
+    tokio::select! {
+        Some(mut result) = rx_synchronize.recv() => {
+            // This response contains digests from rounds 5 ~ 14, which are the digests with total stake above validity threshold.
+            assert_eq!(result.len(), certificate_ids[1].len());
+            for (r, cert_ids) in &mut result {
+                cert_ids.sort();
+                let expected_cert_ids = certificate_ids[1].get_mut(r).unwrap();
+                expected_cert_ids.sort();
+                assert_eq!(cert_ids, expected_cert_ids, "Round {r} digests mismatch");
+            }
+            // Only one result is expected.
+        },
+        () = &mut timer => {
+            panic!("Timeout, no result has been received in time")
+        }
+    }
+}
 
 #[tokio::test]
 async fn test_successful_headers_synchronization() {
@@ -491,11 +694,13 @@ async fn test_multiple_overlapping_requests() {
         rx_commands,
         rx_availability_responses,
         pending_requests: HashMap::new(),
+        sync_range_state: Default::default(),
         map_certificate_responses_senders: HashMap::new(),
         map_payload_availability_responses_senders: HashMap::new(),
         network: P2pNetwork::new(network),
         payload_store,
         certificate_store,
+        range_synchronize_timeout: Duration::from_secs(10),
         certificates_synchronize_timeout: Duration::from_secs(1),
         payload_synchronize_timeout: Duration::from_secs(1),
         payload_availability_timeout: Duration::from_secs(1),
@@ -709,11 +914,13 @@ async fn test_reply_with_certificates_already_in_storage() {
         rx_commands,
         rx_availability_responses,
         pending_requests: Default::default(),
+        sync_range_state: Default::default(),
         map_certificate_responses_senders: Default::default(),
         map_payload_availability_responses_senders: Default::default(),
         network: P2pNetwork::new(network),
         certificate_store: certificate_store.clone(),
         payload_store,
+        range_synchronize_timeout: Default::default(),
         certificates_synchronize_timeout: Default::default(),
         payload_synchronize_timeout: Default::default(),
         payload_availability_timeout: Default::default(),
@@ -811,11 +1018,13 @@ async fn test_reply_with_payload_already_in_storage() {
         rx_commands,
         rx_availability_responses,
         pending_requests: Default::default(),
+        sync_range_state: Default::default(),
         map_certificate_responses_senders: Default::default(),
         map_payload_availability_responses_senders: Default::default(),
         network: P2pNetwork::new(network),
         certificate_store: certificate_store.clone(),
         payload_store: payload_store.clone(),
+        range_synchronize_timeout: Default::default(),
         certificates_synchronize_timeout: Default::default(),
         payload_synchronize_timeout: Default::default(),
         payload_availability_timeout: Default::default(),
@@ -919,11 +1128,13 @@ async fn test_reply_with_payload_already_in_storage_for_own_certificates() {
         rx_commands,
         rx_availability_responses,
         pending_requests: Default::default(),
+        sync_range_state: Default::default(),
         map_certificate_responses_senders: Default::default(),
         map_payload_availability_responses_senders: Default::default(),
         network: P2pNetwork::new(network),
         certificate_store: certificate_store.clone(),
         payload_store: payload_store.clone(),
+        range_synchronize_timeout: Default::default(),
         certificates_synchronize_timeout: Default::default(),
         payload_synchronize_timeout: Default::default(),
         payload_availability_timeout: Default::default(),

--- a/primary/src/block_synchronizer/tests/block_synchronizer_tests.rs
+++ b/primary/src/block_synchronizer/tests/block_synchronizer_tests.rs
@@ -12,7 +12,7 @@ use crate::{
     PrimaryWorkerMessage,
 };
 use anemo::{types::PeerInfo, PeerId};
-use config::BlockSynchronizerParameters;
+use config::{BlockSynchronizerParameters, Parameters};
 use fastcrypto::Hash;
 use futures::{future::try_join_all, stream::FuturesUnordered};
 use network::P2pNetwork;
@@ -86,7 +86,7 @@ async fn test_successful_range_synchronization() {
         P2pNetwork::new(network.clone()),
         payload_store.clone(),
         certificate_store.clone(),
-        BlockSynchronizerParameters::default(),
+        Parameters::default(),
     );
 
     // AND propulate certificates from round 0 ~ 4 in the local store.
@@ -304,7 +304,7 @@ async fn test_successful_headers_synchronization() {
         P2pNetwork::new(network.clone()),
         payload_store.clone(),
         certificate_store.clone(),
-        BlockSynchronizerParameters::default(),
+        Parameters::default(),
     );
 
     // AND the channel to respond to
@@ -486,7 +486,7 @@ async fn test_successful_payload_synchronization() {
         P2pNetwork::new(network.clone()),
         payload_store.clone(),
         certificate_store.clone(),
-        BlockSynchronizerParameters::default(),
+        Parameters::default(),
     );
 
     // AND the channel to respond to
@@ -697,6 +697,7 @@ async fn test_multiple_overlapping_requests() {
         network: P2pNetwork::new(network),
         payload_store,
         certificate_store,
+        range_request_max_rounds: 50,
         range_synchronize_timeout: Duration::from_secs(10),
         certificates_synchronize_timeout: Duration::from_secs(1),
         payload_synchronize_timeout: Duration::from_secs(1),
@@ -811,8 +812,11 @@ async fn test_timeout_while_waiting_for_certificates() {
         .unwrap();
 
     // AND create the synchronizer
-    let params = BlockSynchronizerParameters {
-        certificates_synchronize_timeout: Duration::from_secs(1),
+    let params = Parameters {
+        block_synchronizer: BlockSynchronizerParameters {
+            certificates_synchronize_timeout: Duration::from_secs(1),
+            ..Default::default()
+        },
         ..Default::default()
     };
     let _synchronizer_handle = BlockSynchronizer::spawn(
@@ -825,7 +829,7 @@ async fn test_timeout_while_waiting_for_certificates() {
         P2pNetwork::new(network),
         payload_store.clone(),
         certificate_store.clone(),
-        params,
+        params.clone(),
     );
 
     // AND the channel to respond to
@@ -917,6 +921,7 @@ async fn test_reply_with_certificates_already_in_storage() {
         network: P2pNetwork::new(network),
         certificate_store: certificate_store.clone(),
         payload_store,
+        range_request_max_rounds: Default::default(),
         range_synchronize_timeout: Default::default(),
         certificates_synchronize_timeout: Default::default(),
         payload_synchronize_timeout: Default::default(),
@@ -1021,6 +1026,7 @@ async fn test_reply_with_payload_already_in_storage() {
         network: P2pNetwork::new(network),
         certificate_store: certificate_store.clone(),
         payload_store: payload_store.clone(),
+        range_request_max_rounds: Default::default(),
         range_synchronize_timeout: Default::default(),
         certificates_synchronize_timeout: Default::default(),
         payload_synchronize_timeout: Default::default(),
@@ -1131,6 +1137,7 @@ async fn test_reply_with_payload_already_in_storage_for_own_certificates() {
         network: P2pNetwork::new(network),
         certificate_store: certificate_store.clone(),
         payload_store: payload_store.clone(),
+        range_request_max_rounds: Default::default(),
         range_synchronize_timeout: Default::default(),
         certificates_synchronize_timeout: Default::default(),
         payload_synchronize_timeout: Default::default(),

--- a/primary/src/core.rs
+++ b/primary/src/core.rs
@@ -567,7 +567,6 @@ impl Core {
                                 Ok(()) => self.process_header(&header).await,
                                 error => error
                             }
-
                         },
                         PrimaryMessage::Vote(vote) => {
                             match self.sanitize_vote(&vote) {

--- a/primary/src/metrics.rs
+++ b/primary/src/metrics.rs
@@ -63,7 +63,7 @@ pub struct PrimaryChannelMetrics {
     pub tx_sync_certificates: IntGauge,
     /// occupancy of the channel from the `primary::HeaderWaiter` to the `primary::Core`
     pub tx_headers_loopback: IntGauge,
-    /// occupancy of the channel from the `primary::CertificateWaiter` to the `primary::Core`    
+    /// occupancy of the channel from the `primary::CertificateWaiter` to the `primary::Core`
     pub tx_certificates_loopback: IntGauge,
     /// occupancy of the channel from the `primary::PrimaryReceiverHandler` to the `primary::Core`
     pub tx_primary_messages: IntGauge,

--- a/primary/src/primary.rs
+++ b/primary/src/primary.rs
@@ -476,6 +476,11 @@ impl PrimaryToPrimary for PrimaryReceiverHandler {
         let message = request.into_body();
 
         match message {
+            PrimaryMessage::CertificatesRangeResponse { .. } => self
+                .tx_range_responses
+                .send(message)
+                .await
+                .map_err(|_| DagError::ShuttingDown),
             PrimaryMessage::CertificatesRequest(_, _) => self
                 .tx_helper_requests
                 .send(message)

--- a/primary/src/primary.rs
+++ b/primary/src/primary.rs
@@ -334,7 +334,7 @@ impl Primary {
             block_synchronizer_network,
             payload_store.clone(),
             certificate_store.clone(),
-            parameters.block_synchronizer,
+            parameters.clone(),
         );
 
         // Whenever the `Synchronizer` does not manage to validate a header due to missing parent certificates of

--- a/primary/tests/integration_tests_validator_api.rs
+++ b/primary/tests/integration_tests_validator_api.rs
@@ -865,6 +865,7 @@ async fn test_get_collections_with_missing_certificates() {
     let parameters = Parameters {
         batch_size: 200, // Two transactions.
         block_synchronizer: BlockSynchronizerParameters {
+            range_synchronize_timeout: Duration::from_secs(10),
             certificates_synchronize_timeout: Duration::from_secs(1),
             payload_synchronize_timeout: Duration::from_secs(1),
             payload_availability_timeout: Duration::from_secs(1),

--- a/storage/src/certificate_store.rs
+++ b/storage/src/certificate_store.rs
@@ -428,13 +428,28 @@ mod test {
 
         // WHEN
         let result = store.last_round().unwrap();
+        let last_round = store.last_round_number().unwrap();
 
         // THEN
         assert_eq!(result.len(), 4);
-
+        assert_eq!(last_round, 50);
         for certificate in result {
-            assert_eq!(certificate.round(), 50);
+            assert_eq!(certificate.round(), last_round);
         }
+    }
+
+    #[tokio::test]
+    async fn test_last_round_in_empty_store() {
+        // GIVEN
+        let store = new_store(temp_dir());
+
+        // WHEN
+        let result = store.last_round().unwrap();
+        let last_round = store.last_round_number();
+
+        // THEN
+        assert!(result.is_empty());
+        assert!(last_round.is_none());
     }
 
     #[tokio::test]

--- a/storage/src/certificate_store.rs
+++ b/storage/src/certificate_store.rs
@@ -284,6 +284,20 @@ impl CertificateStore {
         Ok(certificates)
     }
 
+    /// Retrieves the latest round number of certificates in store.
+    pub fn last_round_number(&self) -> StoreResult<Option<Round>> {
+        if let Some(((last_round_num, _), _)) = self
+            .certificate_ids_by_round
+            .iter()
+            .skip_to_last()
+            .reverse()
+            .next()
+        {
+            return Ok(Some(last_round_num));
+        }
+        Ok(None)
+    }
+
     /// Clears both the main storage of the certificates and the secondary index
     pub fn clear(&self) -> StoreResult<()> {
         self.certificates_by_id.clear()?;

--- a/storage/src/certificate_store.rs
+++ b/storage/src/certificate_store.rs
@@ -285,7 +285,8 @@ impl CertificateStore {
     }
 
     /// Retrieves the latest round number of certificates in store.
-    pub fn last_round_number(&self) -> StoreResult<Option<Round>> {
+    /// Returns None if there is no certificate.
+    pub fn last_round_number(&self) -> Option<Round> {
         if let Some(((last_round_num, _), _)) = self
             .certificate_ids_by_round
             .iter()
@@ -293,9 +294,9 @@ impl CertificateStore {
             .reverse()
             .next()
         {
-            return Ok(Some(last_round_num));
+            return Some(last_round_num);
         }
-        Ok(None)
+        None
     }
 
     /// Clears both the main storage of the certificates and the secondary index

--- a/types/src/primary.rs
+++ b/types/src/primary.rs
@@ -666,6 +666,8 @@ pub enum PrimaryMessage {
         // certificate digests from an authority are returned: e.g. a response can be
         // 32B / digest * 200 authorities * 50 rounds ~ 320KB
         range_start: Round,
+        // Maximum number of rounds that should be contained in each reply.
+        max_rounds: u32,
         requestor: PublicKey,
     },
     CertificatesRangeResponse {

--- a/types/src/primary.rs
+++ b/types/src/primary.rs
@@ -659,6 +659,21 @@ pub enum PrimaryMessage {
         from: PublicKey,
     },
 
+    CertificatesRangeRequest {
+        // Requests certificate digests with rounds >= `range_start` to be sent back.
+        // No upper range limit is specified, because the requestor does not know the
+        // current upper limit. The response size should still be acceptable if all
+        // certificate digests from an authority are returned: e.g. a response can be
+        // 32B / digest * 200 authorities * 50 rounds ~ 320KB
+        range_start: Round,
+        requestor: PublicKey,
+    },
+    CertificatesRangeResponse {
+        // Certificate digests, grouped by round numbers.
+        certificate_ids: BTreeMap<Round, Vec<CertificateDigest>>,
+        from: PublicKey,
+    },
+
     PayloadAvailabilityRequest {
         certificate_ids: Vec<CertificateDigest>,
         requestor: PublicKey,

--- a/types/src/primary.rs
+++ b/types/src/primary.rs
@@ -667,7 +667,7 @@ pub enum PrimaryMessage {
         // 32B / digest * 200 authorities * 50 rounds ~ 320KB
         range_start: Round,
         // Maximum number of rounds that should be contained in each reply.
-        max_rounds: u32,
+        max_rounds: u64,
         requestor: PublicKey,
     },
     CertificatesRangeResponse {


### PR DESCRIPTION
Part 1/n of MystenLabs/sui#5268

This PR adds logic to `BlockSynchronizer` to broadcast a request to fetch certificate digests with a starting round, and collect valid certificate digests from the received responses.

High level overview of the algorithm (as discussed with @huitseeker):
1. When a primary needs to sync a range of certificates, it first finds the last round of certificate it has. Then it broadcasts a requests to synchronize certificate from higher rounds (last round + 1).
2. Other primaries / authorities will reply with certificate digests at or above the requested round (to be implemented later).
3. The requesting primary will collect the responses until heard from all, or timeout. Then, certificate digests having collected stakes above the committee validity threshold (f + 1 stake) are considered valid. Valid digests are returned.

Notably, this PR does not contain the logic to handle the range sync request on primary, or the logic to drive fetching certificates based on the valid digests.

A unit test is added for the happy path.