### PR TITLE
fix: Make metered channel accounting take unused dropped Permits into account

### DIFF
--- a/executor/src/lib.rs
+++ b/executor/src/lib.rs
@@ -33,9 +33,6 @@ use types::{metered_channel, Batch, BatchDigest, ReconfigureNotification, Sequen
 // Re-export SingleExecutor as a convenience adapter.
 pub use crate::core::SingleExecutor;
 
-/// Default inter-task channel size.
-pub const DEFAULT_CHANNEL_SIZE: usize = 1_000;
-
 /// Convenience type representing a serialized transaction.
 pub type SerializedTransaction = Vec<u8>;
 
@@ -130,7 +127,7 @@ impl Executor {
         let metrics = ExecutorMetrics::new(registry);
 
         let (tx_executor, rx_executor) =
-            metered_channel::channel(DEFAULT_CHANNEL_SIZE, &metrics.tx_executor);
+            metered_channel::channel(primary::CHANNEL_CAPACITY, &metrics.tx_executor);
 
         // Ensure there is a single consensus client modifying the execution state.
         ensure!(

--- a/test_utils/src/cluster.rs
+++ b/test_utils/src/cluster.rs
@@ -5,7 +5,7 @@ use arc_swap::ArcSwap;
 use config::{Committee, Parameters, SharedCommittee, SharedWorkerCache, WorkerId};
 use crypto::KeyPair;
 use crypto::PublicKey;
-use executor::{SerializedTransaction, SingleExecutor, SubscriberResult, DEFAULT_CHANNEL_SIZE};
+use executor::{SerializedTransaction, SingleExecutor, SubscriberResult};
 use fastcrypto::traits::KeyPair as _;
 use itertools::Itertools;
 use multiaddr::Multiaddr;
@@ -363,7 +363,7 @@ impl PrimaryNodeDetails {
         .await
         .unwrap();
 
-        let (tx, _) = tokio::sync::broadcast::channel(DEFAULT_CHANNEL_SIZE);
+        let (tx, _) = tokio::sync::broadcast::channel(primary::CHANNEL_CAPACITY);
         let transactions_sender = tx.clone();
         // spawn a task to listen on the committed transactions
         // and translate to a mpmc channel

--- a/types/tests/metered_channel_tests.rs
+++ b/types/tests/metered_channel_tests.rs
@@ -60,10 +60,25 @@ fn test_reserve() {
     let permit = block_on(tx.reserve()).unwrap();
     assert_eq!(counter.get(), 1);
 
-    permit.send(42);
+    permit.send(item);
     let received_item = block_on(rx.recv()).unwrap();
 
     assert_eq!(received_item, item);
+    assert_eq!(counter.get(), 0);
+}
+
+#[test]
+fn test_reserve_and_drop() {
+    let counter = IntGauge::new("TEST_COUNTER", "test").unwrap();
+    let (tx, _rx) = metered_channel::channel::<i32>(8, &counter);
+
+    assert_eq!(counter.get(), 0);
+
+    let permit = block_on(tx.reserve()).unwrap();
+    assert_eq!(counter.get(), 1);
+
+    std::mem::drop(permit);
+
     assert_eq!(counter.get(), 0);
 }
 


### PR DESCRIPTION
## Context
We introduced metered channels in #682. Then we started using `mpsc::Permit` in #724 to implement composable backpressure.

## The issue
Permits increase the occupancy metric of their underlying channel when acquired. They decrease that occupancy when they are used to send an element that's received. They do not decrease this occupancy when the permit is dropped without being utilized to send anything.

This leads to the following graphs on precisely the three channels which in #724 were made to use permits:
![Screen Shot 2022-08-25 at 11 40 29 AM](https://user-images.githubusercontent.com/4142/186709621-9ae23e00-166a-489c-b6d7-6b6200f5a398.png)

For context, those channels have a bounded capacity of 1000 elements (due to the underlying use of a `tokio::mpsc::channel`). They show occupancy far above that, which constitutes the bug.

## The fix

We first introduce a (failing) test `test_reserve_and_drop` that shows the issue, and fix it by making permits from metered channels decrease the occupancy of their underlying channel when they are dropped without having sent an element.
