### PR TITLE
[executor] Add deserialize to ExecuteState trait

### DIFF
--- a/executor/src/core.rs
+++ b/executor/src/core.rs
@@ -215,7 +215,7 @@ where
         // If the deserialization fail it is safe to ignore the transaction since all correct
         // clients will do the same. Remember that a bad authority or client may input random
         // bytes to the consensus.
-        let transaction: State::Transaction = match bincode::deserialize(&serialized) {
+        let transaction: State::Transaction = match State::deserialize(&serialized) {
             Ok(x) => x,
             Err(e) => bail!(SubscriberError::ClientExecutionError(format!(
                 "Failed to deserialize transaction: {e}"

--- a/executor/src/lib.rs
+++ b/executor/src/lib.rs
@@ -60,6 +60,11 @@ pub trait ExecutionState {
         transaction: Self::Transaction,
     ) -> Result<Self::Outcome, Self::Error>;
 
+    /// Deserialize the message bytes into Transaction type. This allows an implementation of
+    /// ExecutionState to customize how to deserialize the message, in case customized
+    /// serialization was used when sending the message.
+    fn deserialize(bytes: &[u8]) -> Result<Self::Transaction, bincode::Error>;
+
     /// Simple guardrail ensuring there is a single instance using the state
     /// to call `handle_consensus_transaction`. Many instances may read the state,
     /// or use it for other purposes.

--- a/executor/src/tests/execution_state.rs
+++ b/executor/src/tests/execution_state.rs
@@ -60,6 +60,10 @@ impl ExecutionState for TestState {
         }
     }
 
+    fn deserialize(bytes: &[u8]) -> Result<Self::Transaction, bincode::Error> {
+        bincode::deserialize(bytes)
+    }
+
     fn ask_consensus_write_lock(&self) -> bool {
         true
     }

--- a/node/src/execution_state.rs
+++ b/node/src/execution_state.rs
@@ -23,6 +23,10 @@ impl ExecutionState for SimpleExecutionState {
         Ok(Vec::default())
     }
 
+    fn deserialize(bytes: &[u8]) -> Result<Self::Transaction, bincode::Error> {
+        bincode::deserialize(bytes)
+    }
+
     fn ask_consensus_write_lock(&self) -> bool {
         true
     }

--- a/node/tests/reconfigure.rs
+++ b/node/tests/reconfigure.rs
@@ -84,6 +84,10 @@ impl ExecutionState for SimpleExecutionState {
         Ok(epoch)
     }
 
+    fn deserialize(bytes: &[u8]) -> Result<Self::Transaction, bincode::Error> {
+        bincode::deserialize(bytes)
+    }
+
     fn ask_consensus_write_lock(&self) -> bool {
         true
     }


### PR DESCRIPTION
This PR allows the implementation of the `ExecuteState` to customize message deserialization, in case custom serialization was used before the message was sent.
The goal is to allow Sui to be able to add a unique tracking_id padding to every consensus message, so that we can print it in the log in both Narwhal and Sui to track the lifetime of messages between Sui and Narwhal.