### PR TITLE
primary: don't panic on inbound RPCs when the node is shutting down

### DIFF
--- a/primary/src/primary.rs
+++ b/primary/src/primary.rs
@@ -539,9 +539,8 @@ impl PrimaryToPrimary for PrimaryReceiverHandler {
                 .await
                 .map_err(|_| DagError::ShuttingDown),
         }
-        .unwrap();
-
-        Ok(anemo::Response::new(()))
+        .map(|_| anemo::Response::new(()))
+        .map_err(|e| anemo::rpc::Status::internal(e.to_string()))
     }
 }
 


### PR DESCRIPTION
Fixes a bug where the primary would panic if an RPC comes in while a
node is shutting down. Instead this patch just returns an error to
requester.

Fixes: #891