### PR TITLE
worker: remove unused client-batch-request api

### DIFF
--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -11,7 +11,6 @@ use fastcrypto::{
     traits::{KeyPair as _, Signer as _},
     Digest, Hash as _,
 };
-use futures::Stream;
 use indexmap::IndexMap;
 use multiaddr::Multiaddr;
 use rand::rngs::OsRng;
@@ -20,7 +19,6 @@ use std::{
     collections::{BTreeMap, BTreeSet, VecDeque},
     num::NonZeroUsize,
     ops::RangeInclusive,
-    pin::Pin,
     sync::Arc,
 };
 use store::{reopen, rocks, rocks::DBMap, Store};
@@ -313,16 +311,6 @@ impl WorkerToWorker for WorkerToWorkerMockServer {
     ) -> Result<tonic::Response<Empty>, tonic::Status> {
         self.sender.send(request.into_inner()).await.unwrap();
         Ok(Response::new(Empty {}))
-    }
-
-    type ClientBatchRequestStream =
-        Pin<Box<dyn Stream<Item = Result<BincodeEncodedPayload, tonic::Status>> + Send>>;
-
-    async fn client_batch_request(
-        &self,
-        _request: tonic::Request<BincodeEncodedPayload>,
-    ) -> Result<tonic::Response<Self::ClientBatchRequestStream>, tonic::Status> {
-        todo!()
     }
 }
 

--- a/types/proto/narwhal.proto
+++ b/types/proto/narwhal.proto
@@ -166,8 +166,6 @@ service Configuration {
 service WorkerToWorker {
     // Sends a worker message
     rpc SendMessage(BincodeEncodedPayload) returns (Empty) {}
-    // requests a number of batches that the service then streams back to the client
-    rpc ClientBatchRequest(BincodeEncodedPayload) returns (stream BincodeEncodedPayload) {}
 }
 
 // The worker-to-primary interface

--- a/worker/src/metrics.rs
+++ b/worker/src/metrics.rs
@@ -91,8 +91,6 @@ pub struct WorkerChannelMetrics {
     pub tx_client_processor: IntGauge,
     /// occupancy of the channel from the `worker::WorkerReceiverHandler` to the `worker::Helper` (carrying worker requests)
     pub tx_worker_helper: IntGauge,
-    /// occupancy of the channel from the `worker::WorkerReceiverHandler` to the `worker::Helper` (carrying client requests)
-    pub tx_client_helper: IntGauge,
 }
 
 impl WorkerChannelMetrics {
@@ -133,11 +131,6 @@ impl WorkerChannelMetrics {
                 "occupancy of the channel from the `worker::WorkerReceiverHandler` to the `worker::Helper` (carrying worker requests)",
                 registry
             ).unwrap(),
-            tx_client_helper: register_int_gauge_with_registry!(
-                "tx_client_helper",
-                "occupancy of the channel from the `worker::WorkerReceiverHandler` to the `worker::Helper` (carrying client requests)",
-                registry
-            ).unwrap()
         }
     }
 }

--- a/worker/src/tests/helper_tests.rs
+++ b/worker/src/tests/helper_tests.rs
@@ -7,13 +7,11 @@ use test_utils::{
     batch, digest_batch, serialize_batch_message, temp_dir, CommitteeFixture,
     WorkerToWorkerMockServer,
 };
-use tokio::sync::mpsc::channel;
 use types::BatchDigest;
 
 #[tokio::test]
 async fn worker_batch_reply() {
     let (tx_worker_request, rx_worker_request) = test_utils::test_channel!(1);
-    let (_tx_client_request, rx_client_request) = test_utils::test_channel!(1);
     let fixture = CommitteeFixture::builder().randomize_ports(true).build();
     let committee = fixture.committee();
     let worker_cache = fixture.shared_worker_cache();
@@ -45,7 +43,6 @@ async fn worker_batch_reply() {
         store,
         rx_reconfiguration,
         rx_worker_request,
-        rx_client_request,
         WorkerNetwork::default(),
     );
 
@@ -64,53 +61,4 @@ async fn worker_batch_reply() {
 
     // Ensure the requestor received the batch (ie. it did not panic).
     assert_eq!(handle.recv().await.unwrap().payload, expected);
-}
-
-#[tokio::test]
-async fn client_batch_reply() {
-    let (_tx_worker_request, rx_worker_request) = test_utils::test_channel!(1);
-    let (tx_client_request, rx_client_request) = test_utils::test_channel!(1);
-    let id = 0;
-    let fixture = CommitteeFixture::builder().randomize_ports(true).build();
-    let committee = fixture.committee();
-    let worker_cache = fixture.shared_worker_cache();
-    let (_tx_reconfiguration, rx_reconfiguration) =
-        watch::channel(ReconfigureNotification::NewEpoch(committee.clone()));
-
-    // Create a new test store.
-    let db = rocks::DBMap::<BatchDigest, SerializedBatchMessage>::open(
-        temp_dir(),
-        None,
-        Some("batches"),
-    )
-    .unwrap();
-    let store = Store::new(db);
-
-    // Add a batch to the store.
-    let batch = batch();
-    let serialized_batch = serialize_batch_message(batch.clone());
-    let batch_digest = digest_batch(batch.clone());
-    store.write(batch_digest, serialized_batch.clone()).await;
-
-    // Spawn an `Helper` instance.
-    let _helper_handler = Helper::spawn(
-        id,
-        committee.clone(),
-        worker_cache.clone(),
-        store,
-        rx_reconfiguration,
-        rx_worker_request,
-        rx_client_request,
-        WorkerNetwork::default(),
-    );
-
-    // Send batch request.
-    let digests = vec![batch_digest];
-    let (sender, mut receiver) = channel(digests.len());
-    tx_client_request.send((digests, sender)).await.unwrap();
-
-    // Wait for the reply and ensure it is as expected.
-    while let Some(bytes) = receiver.recv().await {
-        assert_eq!(bytes, serialized_batch);
-    }
 }

--- a/worker/src/tests/worker_tests.rs
+++ b/worker/src/tests/worker_tests.rs
@@ -2,20 +2,16 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use super::*;
-
 use arc_swap::ArcSwap;
+use bytes::Bytes;
 use fastcrypto::traits::KeyPair;
-use futures::StreamExt;
 use prometheus::Registry;
-use std::time::Duration;
 use store::rocks;
 use test_utils::{
-    batch, digest_batch, serialize_batch_message, temp_dir, CommitteeFixture,
-    WorkerToPrimaryMockServer, WorkerToWorkerMockServer,
+    batch, serialize_batch_message, temp_dir, CommitteeFixture, WorkerToPrimaryMockServer,
+    WorkerToWorkerMockServer,
 };
-use types::{
-    serialized_batch_digest, TransactionsClient, WorkerPrimaryMessage, WorkerToWorkerClient,
-};
+use types::{serialized_batch_digest, TransactionsClient, WorkerPrimaryMessage};
 
 #[tokio::test]
 async fn handle_clients_transactions() {
@@ -100,85 +96,4 @@ async fn handle_clients_transactions() {
 
     // Ensure the primary received the batch's digest (ie. it did not panic).
     assert_eq!(handle.recv().await.unwrap().payload, expected);
-}
-
-#[tokio::test]
-async fn handle_client_batch_request() {
-    let fixture = CommitteeFixture::builder().randomize_ports(true).build();
-    let committee = fixture.committee();
-    let worker_cache = fixture.shared_worker_cache();
-
-    let author = fixture.authorities().last().unwrap();
-    let name = author.public_key();
-
-    let worker_id = 0;
-    let worker_keypair = author.worker(worker_id).keypair().copy();
-
-    let parameters = Parameters {
-        max_header_delay: Duration::from_millis(100_000), // Ensure no batches are created.
-        ..Parameters::default()
-    };
-
-    // Create a new test store.
-    let db = rocks::DBMap::<BatchDigest, SerializedBatchMessage>::open(
-        temp_dir(),
-        None,
-        Some("batches"),
-    )
-    .unwrap();
-    let store = Store::new(db);
-
-    // Add a batch to the store.
-    let batch = batch();
-    store
-        .write(
-            digest_batch(batch.clone()),
-            serialize_batch_message(batch.clone()),
-        )
-        .await;
-
-    let registry = Registry::new();
-    let metrics = Metrics {
-        worker_metrics: Some(WorkerMetrics::new(&registry)),
-        channel_metrics: Some(WorkerChannelMetrics::new(&registry)),
-        endpoint_metrics: Some(WorkerEndpointMetrics::new(&registry)),
-        network_metrics: Some(WorkerNetworkMetrics::new(&registry)),
-    };
-
-    // Spawn a `Worker` instance.
-    Worker::spawn(
-        name.clone(),
-        worker_keypair,
-        worker_id,
-        Arc::new(ArcSwap::from_pointee(committee.clone())),
-        worker_cache.clone(),
-        parameters,
-        store,
-        metrics,
-    );
-
-    // Spawn a client to ask for batches and receive the reply.
-    tokio::task::yield_now().await;
-    let address = worker_cache
-        .load()
-        .worker(&name, &worker_id)
-        .unwrap()
-        .worker_to_worker;
-    let config = mysten_network::config::Config::new();
-    let channel = config.connect_lazy(&address).unwrap();
-    let mut client = WorkerToWorkerClient::new(channel);
-
-    // Send batch request.
-    let digests = vec![digest_batch(batch.clone())];
-    let message = ClientBatchRequest(digests);
-    let mut stream = client
-        .client_batch_request(BincodeEncodedPayload::try_from(&message).unwrap())
-        .await
-        .unwrap()
-        .into_inner();
-
-    // Wait for the reply and ensure it is as expected.
-    let bytes = stream.next().await.unwrap().unwrap().payload;
-    let expected = Bytes::from(serialize_batch_message(batch));
-    assert_eq!(bytes, expected);
 }

--- a/worker/src/worker.rs
+++ b/worker/src/worker.rs
@@ -7,28 +7,23 @@ use crate::{
     synchronizer::Synchronizer,
 };
 use async_trait::async_trait;
-use bytes::Bytes;
 use config::{Parameters, SharedCommittee, SharedWorkerCache, WorkerId};
 use crypto::{KeyPair, PublicKey};
-use futures::{Stream, StreamExt};
+use futures::StreamExt;
 use multiaddr::{Multiaddr, Protocol};
 use network::{metrics::WorkerNetworkMetrics, WorkerNetwork};
 use primary::PrimaryWorkerMessage;
-use std::{net::Ipv4Addr, pin::Pin, sync::Arc};
+use std::{net::Ipv4Addr, sync::Arc};
 use store::Store;
-use tokio::{
-    sync::{mpsc, watch},
-    task::JoinHandle,
-};
+use tokio::{sync::watch, task::JoinHandle};
 use tonic::{Request, Response, Status};
 use tracing::info;
 use types::{
     error::DagError,
     metered_channel::{channel, Sender},
-    BatchDigest, BincodeEncodedPayload, ClientBatchRequest, Empty, PrimaryToWorker,
-    PrimaryToWorkerServer, ReconfigureNotification, SerializedBatchMessage, Transaction,
-    TransactionProto, Transactions, TransactionsServer, WorkerPrimaryMessage, WorkerToWorker,
-    WorkerToWorkerServer,
+    BatchDigest, BincodeEncodedPayload, Empty, PrimaryToWorker, PrimaryToWorkerServer,
+    ReconfigureNotification, SerializedBatchMessage, Transaction, TransactionProto, Transactions,
+    TransactionsServer, WorkerPrimaryMessage, WorkerToWorker, WorkerToWorkerServer,
 };
 
 #[cfg(test)]
@@ -293,8 +288,6 @@ impl Worker {
     ) -> Vec<JoinHandle<()>> {
         let (tx_worker_helper, rx_worker_helper) =
             channel(CHANNEL_CAPACITY, &channel_metrics.tx_worker_helper);
-        let (tx_client_helper, rx_client_helper) =
-            channel(CHANNEL_CAPACITY, &channel_metrics.tx_client_helper);
         let (tx_worker_processor, rx_worker_processor) =
             channel(CHANNEL_CAPACITY, &channel_metrics.tx_worker_processor);
 
@@ -310,7 +303,6 @@ impl Worker {
             .unwrap();
         let worker_handle = WorkerReceiverHandler {
             tx_worker_helper,
-            tx_client_helper,
             tx_processor: tx_worker_processor,
         }
         .spawn(
@@ -331,7 +323,6 @@ impl Worker {
             self.store.clone(),
             tx_reconfigure.subscribe(),
             /* rx_worker_request */ rx_worker_helper,
-            /* rx_client_request */ rx_client_helper,
             worker_network,
         );
 
@@ -434,7 +425,6 @@ impl Transactions for TxReceiverHandler {
 #[derive(Clone)]
 struct WorkerReceiverHandler {
     tx_worker_helper: Sender<(Vec<BatchDigest>, PublicKey)>,
-    tx_client_helper: Sender<(Vec<BatchDigest>, mpsc::Sender<SerializedBatchMessage>)>,
     tx_processor: Sender<SerializedBatchMessage>,
 }
 
@@ -501,41 +491,6 @@ impl WorkerToWorker for WorkerReceiverHandler {
         .map_err(|e| Status::not_found(e.to_string()))?;
 
         Ok(Response::new(Empty {}))
-    }
-
-    type ClientBatchRequestStream =
-        Pin<Box<dyn Stream<Item = Result<BincodeEncodedPayload, Status>> + Send>>;
-
-    async fn client_batch_request(
-        &self,
-        request: Request<BincodeEncodedPayload>,
-    ) -> Result<Response<Self::ClientBatchRequestStream>, Status> {
-        let missing = request
-            .into_inner()
-            .deserialize::<ClientBatchRequest>()
-            .map_err(|e| Status::invalid_argument(e.to_string()))?
-            .0;
-
-        // TODO [issue #7]: Do some accounting to prevent bad actors from use all our
-        // resources (in this case allocate a gigantic channel).
-        let (sender, receiver) = mpsc::channel(missing.len());
-
-        self.tx_client_helper
-            .send((missing, sender))
-            .await
-            .map_err(|_| DagError::ShuttingDown)
-            .map_err(|e| Status::not_found(e.to_string()))?;
-
-        let stream = tokio_stream::wrappers::ReceiverStream::new(receiver).map(|batch| {
-            let payload = BincodeEncodedPayload {
-                payload: Bytes::from(batch),
-            };
-            Ok(payload)
-        });
-
-        Ok(Response::new(
-            Box::pin(stream) as Self::ClientBatchRequestStream
-        ))
     }
 }
 


### PR DESCRIPTION
This patch removes the unused client-batch-request api given its unused.