### PR TITLE
fix(logging): Put quinn messages under the network logging level

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4190,6 +4190,7 @@ dependencies = [
  "prometheus",
  "rand 0.8.5",
  "serde",
+ "telemetry-subscribers",
  "tempfile",
  "thiserror",
  "tokio",

--- a/executor/src/core.rs
+++ b/executor/src/core.rs
@@ -9,8 +9,7 @@ use crate::{
 use consensus::ConsensusOutput;
 use fastcrypto::Hash;
 use std::{fmt::Debug, sync::Arc};
-use store::rocks::TypedStoreError;
-use store::Store;
+use store::{rocks::TypedStoreError, Store};
 use tokio::{
     sync::{mpsc::Sender, watch},
     task::JoinHandle,

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -130,7 +130,7 @@ fn setup_telemetry(
     network_tracing_level: &str,
     prom_registry: Option<&prometheus::Registry>,
 ) -> TelemetryGuards {
-    let log_filter = format!("{tracing_level},h2={network_tracing_level},tower={network_tracing_level},hyper={network_tracing_level},tonic::transport={network_tracing_level}");
+    let log_filter = format!("{tracing_level},h2={network_tracing_level},tower={network_tracing_level},hyper={network_tracing_level},tonic::transport={network_tracing_level},quinn={network_tracing_level}");
 
     let config = telemetry_subscribers::TelemetryConfig::new("narwhal")
         // load env variables

--- a/primary/Cargo.toml
+++ b/primary/Cargo.toml
@@ -57,8 +57,8 @@ itertools = "0.10.3"
 mockall = "0.11.2"
 node = { path = "../node" }
 proptest = "1.0.0"
-telemetry-subscribers = { git = "https://github.com/mystenlabs/mysten-infra.git", rev = "9deac015fbf66e24b6da9699630e06750eaa094a" }
 tempfile = "3.3.0"
+telemetry-subscribers = { git = "https://github.com/mystenlabs/mysten-infra.git", rev = "9deac015fbf66e24b6da9699630e06750eaa094a" }
 test_utils = { path = "../test_utils" }
 thiserror = "1.0.33"
 tracing = "0.1.36"

--- a/primary/tests/causal_completion_tests.rs
+++ b/primary/tests/causal_completion_tests.rs
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use bytes::Bytes;
 use std::time::Duration;
-use telemetry_subscribers::TelemetryGuards;
-use test_utils::cluster::Cluster;
+use test_utils::cluster::{setup_tracing, Cluster};
 use tracing::info;
 use types::{TransactionProto, TransactionsClient};
 
@@ -162,20 +161,4 @@ async fn test_read_causal_signed_certificates() {
         node_made_progress,
         "Node 0 didn't make progress - causal completion didn't succeed"
     );
-}
-
-fn setup_tracing() -> TelemetryGuards {
-    // Setup tracing
-    let tracing_level = "debug";
-    let network_tracing_level = "info";
-
-    let log_filter = format!("{tracing_level},h2={network_tracing_level},tower={network_tracing_level},hyper={network_tracing_level},tonic::transport={network_tracing_level}");
-
-    telemetry_subscribers::TelemetryConfig::new("narwhal")
-        // load env variables
-        .with_env()
-        // load special log filter
-        .with_log_level(&log_filter)
-        .init()
-        .0
 }

--- a/primary/tests/nodes_bootstrapping_tests.rs
+++ b/primary/tests/nodes_bootstrapping_tests.rs
@@ -1,8 +1,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use std::time::Duration;
-use telemetry_subscribers::TelemetryGuards;
-use test_utils::cluster::Cluster;
+use test_utils::cluster::{setup_tracing, Cluster};
 
 use types::{PublicKeyProto, RoundsRequest};
 
@@ -244,20 +243,4 @@ async fn test_loss_of_liveness_with_recovery() {
         rounds_3.values().all(|v| v > round_2_max),
         "All the nodes should have advanced more from the previous round"
     );
-}
-
-fn setup_tracing() -> TelemetryGuards {
-    // Setup tracing
-    let tracing_level = "debug";
-    let network_tracing_level = "info";
-
-    let log_filter = format!("{tracing_level},h2={network_tracing_level},tower={network_tracing_level},hyper={network_tracing_level},tonic::transport={network_tracing_level}");
-
-    telemetry_subscribers::TelemetryConfig::new("narwhal")
-        // load env variables
-        .with_env()
-        // load special log filter
-        .with_log_level(&log_filter)
-        .init()
-        .0
 }

--- a/test_utils/Cargo.toml
+++ b/test_utils/Cargo.toml
@@ -40,6 +40,7 @@ mysten-network = { git = "https://github.com/mystenlabs/mysten-infra.git", rev =
 
 store = { git = "https://github.com/mystenlabs/mysten-infra.git", package = "typed-store", rev = "9deac015fbf66e24b6da9699630e06750eaa094a" }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
+telemetry-subscribers = { git = "https://github.com/mystenlabs/mysten-infra.git", rev = "9deac015fbf66e24b6da9699630e06750eaa094a" }
 
 anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "6278d0fa78147a49ff2cb9dd2e45e763886be0a0" }
 tower = { version = "0.4.13", features = ["full"] }

--- a/test_utils/src/cluster.rs
+++ b/test_utils/src/cluster.rs
@@ -15,6 +15,7 @@ use node::{
 };
 use prometheus::{proto::Metric, Registry};
 use std::{cell::RefCell, collections::HashMap, path::PathBuf, rc::Rc, sync::Arc, time::Duration};
+use telemetry_subscribers::TelemetryGuards;
 use tokio::{
     sync::{broadcast::Sender, mpsc::channel, RwLock},
     task::JoinHandle,
@@ -774,4 +775,20 @@ impl AuthorityDetails {
         }
         false
     }
+}
+
+pub fn setup_tracing() -> TelemetryGuards {
+    // Setup tracing
+    let tracing_level = "debug";
+    let network_tracing_level = "info";
+
+    let log_filter = format!("{tracing_level},h2={network_tracing_level},tower={network_tracing_level},hyper={network_tracing_level},tonic::transport={network_tracing_level},quinn={network_tracing_level}");
+
+    telemetry_subscribers::TelemetryConfig::new("narwhal")
+        // load env variables
+        .with_env()
+        // load special log filter
+        .with_log_level(&log_filter)
+        .init()
+        .0
 }

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -15,11 +15,11 @@ use futures::Stream;
 use indexmap::IndexMap;
 use multiaddr::Multiaddr;
 use rand::{rngs::StdRng, Rng, SeedableRng as _};
-use std::sync::Arc;
 use std::{
     collections::{BTreeSet, VecDeque},
     ops::RangeInclusive,
     pin::Pin,
+    sync::Arc,
 };
 use store::{reopen, rocks, rocks::DBMap, Store};
 use tokio::sync::mpsc::{channel, Receiver, Sender};

--- a/types/src/primary.rs
+++ b/types/src/primary.rs
@@ -1,9 +1,9 @@
 // Copyright (c) 2021, Facebook, Inc. and its affiliates
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use crate::serde::NarwhalBitmap;
 use crate::{
     error::{DagError, DagResult},
+    serde::NarwhalBitmap,
     CertificateDigestProto,
 };
 use blake2::{digest::Update, VarBlake2b};
@@ -20,9 +20,8 @@ use indexmap::IndexMap;
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
-use std::collections::VecDeque;
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::{BTreeMap, BTreeSet, VecDeque},
     fmt,
     fmt::Formatter,
 };

--- a/types/src/serde.rs
+++ b/types/src/serde.rs
@@ -1,8 +1,10 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use serde::de::{Deserializer, Error};
-use serde::ser::{Error as SerError, Serializer};
+use serde::{
+    de::{Deserializer, Error},
+    ser::{Error as SerError, Serializer},
+};
 use serde_with::{Bytes, DeserializeAs, SerializeAs};
 use std::fmt::Debug;
 


### PR DESCRIPTION
We generally set a special logging level for networking libraries in
both production and tests. This PR puts quinn messages (including
somewhat verbose spans) under that logging level.