### PR TITLE
test-utils: introduce CommitteeFixture and friends

### DIFF
--- a/config/tests/snapshots/config_tests__committee.snap
+++ b/config/tests/snapshots/config_tests__committee.snap
@@ -7,29 +7,29 @@ expression: committee
     "ildi4hrBzbOHBELHe0w69Yx87bh3nQJw5tTx4vc2fXQ=": {
       "stake": 1,
       "primary": {
-        "primary_to_primary": "/ip4/127.0.0.1/tcp/1/http",
-        "worker_to_primary": "/ip4/127.0.0.1/tcp/2/http"
+        "primary_to_primary": "/ip4/127.0.0.1/tcp/0/http",
+        "worker_to_primary": "/ip4/127.0.0.1/tcp/0/http"
       }
     },
     "rvP0pLjsod/DQzYb+OQ2vULeklnAS4MU644gVN1ugqs=": {
       "stake": 1,
       "primary": {
-        "primary_to_primary": "/ip4/127.0.0.1/tcp/1/http",
-        "worker_to_primary": "/ip4/127.0.0.1/tcp/2/http"
+        "primary_to_primary": "/ip4/127.0.0.1/tcp/0/http",
+        "worker_to_primary": "/ip4/127.0.0.1/tcp/0/http"
       }
     },
     "ucbuFjDvPnERRKZI2wa7sihPcnTPvuU//O5QPMGkkgA=": {
       "stake": 1,
       "primary": {
-        "primary_to_primary": "/ip4/127.0.0.1/tcp/1/http",
-        "worker_to_primary": "/ip4/127.0.0.1/tcp/2/http"
+        "primary_to_primary": "/ip4/127.0.0.1/tcp/0/http",
+        "worker_to_primary": "/ip4/127.0.0.1/tcp/0/http"
       }
     },
     "zGIzLjS7LVzWn2Dvuyo2y5FsfrRYMB6jZjbE27ASvYg=": {
       "stake": 1,
       "primary": {
-        "primary_to_primary": "/ip4/127.0.0.1/tcp/1/http",
-        "worker_to_primary": "/ip4/127.0.0.1/tcp/2/http"
+        "primary_to_primary": "/ip4/127.0.0.1/tcp/0/http",
+        "worker_to_primary": "/ip4/127.0.0.1/tcp/0/http"
       }
     }
   },

--- a/config/tests/snapshots/config_tests__worker_cache.snap
+++ b/config/tests/snapshots/config_tests__worker_cache.snap
@@ -6,90 +6,90 @@ expression: worker_cache
   "workers": {
     "ildi4hrBzbOHBELHe0w69Yx87bh3nQJw5tTx4vc2fXQ=": {
       "0": {
-        "transactions": "/ip4/127.0.0.1/tcp/2/http",
-        "worker_to_worker": "/ip4/127.0.0.1/tcp/3/http",
-        "primary_to_worker": "/ip4/127.0.0.1/tcp/1/http"
+        "transactions": "/ip4/127.0.0.1/tcp/0/http",
+        "worker_to_worker": "/ip4/127.0.0.1/tcp/0/http",
+        "primary_to_worker": "/ip4/127.0.0.1/tcp/0/http"
       },
       "1": {
-        "transactions": "/ip4/127.0.0.1/tcp/5/http",
-        "worker_to_worker": "/ip4/127.0.0.1/tcp/6/http",
-        "primary_to_worker": "/ip4/127.0.0.1/tcp/4/http"
+        "transactions": "/ip4/127.0.0.1/tcp/0/http",
+        "worker_to_worker": "/ip4/127.0.0.1/tcp/0/http",
+        "primary_to_worker": "/ip4/127.0.0.1/tcp/0/http"
       },
       "2": {
-        "transactions": "/ip4/127.0.0.1/tcp/8/http",
-        "worker_to_worker": "/ip4/127.0.0.1/tcp/9/http",
-        "primary_to_worker": "/ip4/127.0.0.1/tcp/7/http"
+        "transactions": "/ip4/127.0.0.1/tcp/0/http",
+        "worker_to_worker": "/ip4/127.0.0.1/tcp/0/http",
+        "primary_to_worker": "/ip4/127.0.0.1/tcp/0/http"
       },
       "3": {
-        "transactions": "/ip4/127.0.0.1/tcp/11/http",
-        "worker_to_worker": "/ip4/127.0.0.1/tcp/12/http",
-        "primary_to_worker": "/ip4/127.0.0.1/tcp/10/http"
+        "transactions": "/ip4/127.0.0.1/tcp/0/http",
+        "worker_to_worker": "/ip4/127.0.0.1/tcp/0/http",
+        "primary_to_worker": "/ip4/127.0.0.1/tcp/0/http"
       }
     },
     "rvP0pLjsod/DQzYb+OQ2vULeklnAS4MU644gVN1ugqs=": {
       "0": {
-        "transactions": "/ip4/127.0.0.1/tcp/2/http",
-        "worker_to_worker": "/ip4/127.0.0.1/tcp/3/http",
-        "primary_to_worker": "/ip4/127.0.0.1/tcp/1/http"
+        "transactions": "/ip4/127.0.0.1/tcp/0/http",
+        "worker_to_worker": "/ip4/127.0.0.1/tcp/0/http",
+        "primary_to_worker": "/ip4/127.0.0.1/tcp/0/http"
       },
       "1": {
-        "transactions": "/ip4/127.0.0.1/tcp/5/http",
-        "worker_to_worker": "/ip4/127.0.0.1/tcp/6/http",
-        "primary_to_worker": "/ip4/127.0.0.1/tcp/4/http"
+        "transactions": "/ip4/127.0.0.1/tcp/0/http",
+        "worker_to_worker": "/ip4/127.0.0.1/tcp/0/http",
+        "primary_to_worker": "/ip4/127.0.0.1/tcp/0/http"
       },
       "2": {
-        "transactions": "/ip4/127.0.0.1/tcp/8/http",
-        "worker_to_worker": "/ip4/127.0.0.1/tcp/9/http",
-        "primary_to_worker": "/ip4/127.0.0.1/tcp/7/http"
+        "transactions": "/ip4/127.0.0.1/tcp/0/http",
+        "worker_to_worker": "/ip4/127.0.0.1/tcp/0/http",
+        "primary_to_worker": "/ip4/127.0.0.1/tcp/0/http"
       },
       "3": {
-        "transactions": "/ip4/127.0.0.1/tcp/11/http",
-        "worker_to_worker": "/ip4/127.0.0.1/tcp/12/http",
-        "primary_to_worker": "/ip4/127.0.0.1/tcp/10/http"
+        "transactions": "/ip4/127.0.0.1/tcp/0/http",
+        "worker_to_worker": "/ip4/127.0.0.1/tcp/0/http",
+        "primary_to_worker": "/ip4/127.0.0.1/tcp/0/http"
       }
     },
     "ucbuFjDvPnERRKZI2wa7sihPcnTPvuU//O5QPMGkkgA=": {
       "0": {
-        "transactions": "/ip4/127.0.0.1/tcp/2/http",
-        "worker_to_worker": "/ip4/127.0.0.1/tcp/3/http",
-        "primary_to_worker": "/ip4/127.0.0.1/tcp/1/http"
+        "transactions": "/ip4/127.0.0.1/tcp/0/http",
+        "worker_to_worker": "/ip4/127.0.0.1/tcp/0/http",
+        "primary_to_worker": "/ip4/127.0.0.1/tcp/0/http"
       },
       "1": {
-        "transactions": "/ip4/127.0.0.1/tcp/5/http",
-        "worker_to_worker": "/ip4/127.0.0.1/tcp/6/http",
-        "primary_to_worker": "/ip4/127.0.0.1/tcp/4/http"
+        "transactions": "/ip4/127.0.0.1/tcp/0/http",
+        "worker_to_worker": "/ip4/127.0.0.1/tcp/0/http",
+        "primary_to_worker": "/ip4/127.0.0.1/tcp/0/http"
       },
       "2": {
-        "transactions": "/ip4/127.0.0.1/tcp/8/http",
-        "worker_to_worker": "/ip4/127.0.0.1/tcp/9/http",
-        "primary_to_worker": "/ip4/127.0.0.1/tcp/7/http"
+        "transactions": "/ip4/127.0.0.1/tcp/0/http",
+        "worker_to_worker": "/ip4/127.0.0.1/tcp/0/http",
+        "primary_to_worker": "/ip4/127.0.0.1/tcp/0/http"
       },
       "3": {
-        "transactions": "/ip4/127.0.0.1/tcp/11/http",
-        "worker_to_worker": "/ip4/127.0.0.1/tcp/12/http",
-        "primary_to_worker": "/ip4/127.0.0.1/tcp/10/http"
+        "transactions": "/ip4/127.0.0.1/tcp/0/http",
+        "worker_to_worker": "/ip4/127.0.0.1/tcp/0/http",
+        "primary_to_worker": "/ip4/127.0.0.1/tcp/0/http"
       }
     },
     "zGIzLjS7LVzWn2Dvuyo2y5FsfrRYMB6jZjbE27ASvYg=": {
       "0": {
-        "transactions": "/ip4/127.0.0.1/tcp/2/http",
-        "worker_to_worker": "/ip4/127.0.0.1/tcp/3/http",
-        "primary_to_worker": "/ip4/127.0.0.1/tcp/1/http"
+        "transactions": "/ip4/127.0.0.1/tcp/0/http",
+        "worker_to_worker": "/ip4/127.0.0.1/tcp/0/http",
+        "primary_to_worker": "/ip4/127.0.0.1/tcp/0/http"
       },
       "1": {
-        "transactions": "/ip4/127.0.0.1/tcp/5/http",
-        "worker_to_worker": "/ip4/127.0.0.1/tcp/6/http",
-        "primary_to_worker": "/ip4/127.0.0.1/tcp/4/http"
+        "transactions": "/ip4/127.0.0.1/tcp/0/http",
+        "worker_to_worker": "/ip4/127.0.0.1/tcp/0/http",
+        "primary_to_worker": "/ip4/127.0.0.1/tcp/0/http"
       },
       "2": {
-        "transactions": "/ip4/127.0.0.1/tcp/8/http",
-        "worker_to_worker": "/ip4/127.0.0.1/tcp/9/http",
-        "primary_to_worker": "/ip4/127.0.0.1/tcp/7/http"
+        "transactions": "/ip4/127.0.0.1/tcp/0/http",
+        "worker_to_worker": "/ip4/127.0.0.1/tcp/0/http",
+        "primary_to_worker": "/ip4/127.0.0.1/tcp/0/http"
       },
       "3": {
-        "transactions": "/ip4/127.0.0.1/tcp/11/http",
-        "worker_to_worker": "/ip4/127.0.0.1/tcp/12/http",
-        "primary_to_worker": "/ip4/127.0.0.1/tcp/10/http"
+        "transactions": "/ip4/127.0.0.1/tcp/0/http",
+        "worker_to_worker": "/ip4/127.0.0.1/tcp/0/http",
+        "primary_to_worker": "/ip4/127.0.0.1/tcp/0/http"
       }
     }
   },

--- a/primary/src/tests/certificate_tests.rs
+++ b/primary/src/tests/certificate_tests.rs
@@ -3,154 +3,142 @@
 
 // This test file tests the validity of the 'certificates' implementation.
 
-use fastcrypto::{
-    traits::{KeyPair, Signer},
-    Hash, SignatureService,
-};
-use test_utils::{
-    committee, fixture_batch_with_transactions, fixture_header_builder, keys, keys_with_len,
-    pure_committee_from_keys_with_mock_ports, shared_worker_cache,
-};
-use types::{Certificate, Header, Vote};
-
-fn generate_header() -> Header {
-    let batch = fixture_batch_with_transactions(10);
-    let proposer = &keys(None).pop().unwrap();
-
-    fixture_header_builder()
-        .with_payload_batch(batch, 0)
-        .build(proposer)
-        .unwrap()
-}
+use crypto::KeyPair;
+use fastcrypto::traits::KeyPair as _;
+use std::num::NonZeroUsize;
+use test_utils::CommitteeFixture;
+use types::{Certificate, Vote};
 
 #[test]
 fn test_empty_certificate_verification() {
-    let header = generate_header();
-    // You should not be allowed to create a certificate that does not satisfying quorum requirements
-    assert!(Certificate::new(&committee(None), header.clone(), Vec::new()).is_err());
+    let fixture = CommitteeFixture::builder().build();
 
-    let certificate = Certificate::new_unsigned(&committee(None), header, Vec::new()).unwrap();
+    let committee = fixture.committee();
+    let header = fixture.header();
+    // You should not be allowed to create a certificate that does not satisfying quorum requirements
+    assert!(Certificate::new(&committee, header.clone(), Vec::new()).is_err());
+
+    let certificate = Certificate::new_unsigned(&committee, header, Vec::new()).unwrap();
     assert!(certificate
-        .verify(&committee(None), shared_worker_cache(None))
+        .verify(&committee, fixture.worker_cache().into())
         .is_err());
 }
 
-#[tokio::test]
-async fn test_valid_certificate_verification() {
-    let header = generate_header();
+#[test]
+fn test_valid_certificate_verification() {
+    let fixture = CommitteeFixture::builder().build();
+    let committee = fixture.committee();
+    let header = fixture.header();
 
     let mut signatures = Vec::new();
 
     // 3 Signers satisfies the 2F + 1 signed stake requirement
-    for key in &keys(None)[..3] {
-        let mut signature_service = SignatureService::new(key.copy());
-        let vote = Vote::new(&header, key.public(), &mut signature_service).await;
+    for authority in fixture.authorities().take(3) {
+        let vote = authority.vote(&header);
         signatures.push((vote.author.clone(), vote.signature.clone()));
     }
 
-    let certificate = Certificate::new(&committee(None), header, signatures).unwrap();
+    let certificate = Certificate::new(&committee, header, signatures).unwrap();
 
     assert!(certificate
-        .verify(&committee(None), shared_worker_cache(None))
+        .verify(&committee, fixture.worker_cache().into())
         .is_ok());
 }
 
-#[tokio::test]
-async fn test_certificate_insufficient_signatures() {
-    let header = generate_header();
+#[test]
+fn test_certificate_insufficient_signatures() {
+    let fixture = CommitteeFixture::builder().build();
+    let committee = fixture.committee();
+    let header = fixture.header();
 
     let mut signatures = Vec::new();
 
     // 2 Signatures. This is less than 2F + 1 (3).
-    for key in &keys(None)[..2] {
-        let mut signature_service = SignatureService::new(key.copy());
-        let vote = Vote::new(&header, key.public(), &mut signature_service).await;
+    for authority in fixture.authorities().take(2) {
+        let vote = authority.vote(&header);
         signatures.push((vote.author.clone(), vote.signature.clone()));
     }
 
-    assert!(Certificate::new(&committee(None), header.clone(), signatures.clone()).is_err());
+    assert!(Certificate::new(&committee, header.clone(), signatures.clone()).is_err());
 
-    let certificate = Certificate::new_unsigned(&committee(None), header, signatures).unwrap();
+    let certificate = Certificate::new_unsigned(&committee, header, signatures).unwrap();
 
     assert!(certificate
-        .verify(&committee(None), shared_worker_cache(None))
+        .verify(&committee, fixture.worker_cache().into())
         .is_err());
 }
 
-#[tokio::test]
-async fn test_certificate_validly_repeated_public_keys() {
-    let header = generate_header();
+#[test]
+fn test_certificate_validly_repeated_public_keys() {
+    let fixture = CommitteeFixture::builder().build();
+    let committee = fixture.committee();
+    let header = fixture.header();
 
     let mut signatures = Vec::new();
 
-    // 2 Signatures. This is less than 2F + 1 (3).
-    for key in &keys(None)[..3] {
+    // 3 Signers satisfies the 2F + 1 signed stake requirement
+    for authority in fixture.authorities().take(3) {
+        let vote = authority.vote(&header);
         // We double every (pk, signature) pair - these should be ignored when forming the certificate.
-        let mut signature_service = SignatureService::new(key.copy());
-        let vote = Vote::new(&header, key.public(), &mut signature_service).await;
         signatures.push((vote.author.clone(), vote.signature.clone()));
         signatures.push((vote.author.clone(), vote.signature.clone()));
     }
 
-    let certificate_res = Certificate::new(&committee(None), header, signatures);
+    let certificate_res = Certificate::new(&committee, header, signatures);
     assert!(certificate_res.is_ok());
     let certificate = certificate_res.unwrap();
 
     assert!(certificate
-        .verify(&committee(None), shared_worker_cache(None))
+        .verify(&committee, fixture.worker_cache().into())
         .is_ok());
 }
 
-#[tokio::test]
-async fn test_unknown_signature_in_certificate() {
-    let header = generate_header();
+#[test]
+fn test_unknown_signature_in_certificate() {
+    let fixture = CommitteeFixture::builder().build();
+    let committee = fixture.committee();
+    let header = fixture.header();
 
     let mut signatures = Vec::new();
 
     // 2 Signatures. This is less than 2F + 1 (3).
-    for key in &keys(None)[..2] {
-        // We double every (pk, signature) pair - these should be ignored when forming the certificate.
-        let mut signature_service = SignatureService::new(key.copy());
-        let vote = Vote::new(&header, key.public(), &mut signature_service).await;
+    for authority in fixture.authorities().take(2) {
+        let vote = authority.vote(&header);
         signatures.push((vote.author.clone(), vote.signature.clone()));
     }
 
-    let malicious_key = keys(Some(2)).pop().unwrap();
-    let mut signature_service = SignatureService::new(malicious_key.copy());
-    let vote = Vote::new(&header, malicious_key.public(), &mut signature_service).await;
+    let malicious_key = KeyPair::generate(&mut rand::rngs::OsRng);
+
+    let vote = Vote::new_with_signer(&header, malicious_key.public(), &malicious_key);
     signatures.push((vote.author.clone(), vote.signature));
 
-    assert!(Certificate::new(&committee(None), header, signatures).is_err());
+    assert!(Certificate::new(&committee, header, signatures).is_err());
 }
 
-//
-// This takes really long to run due to an optimization we didn't make (we should cache the genesis committee).
-//
 proptest::proptest! {
-    #[ignore]
     #[test]
     fn test_certificate_verification(
         committee_size in 4..35_usize
     ) {
-        let keys = &keys_with_len(None, committee_size);
-        let committee = &pure_committee_from_keys_with_mock_ports(&keys[..]);
-        let header = generate_header();
+        let fixture = CommitteeFixture::builder()
+            .committee_size(NonZeroUsize::new(committee_size).unwrap())
+            .build();
+        let committee = fixture.committee();
+        let header = fixture.header();
 
         let mut signatures = Vec::new();
 
         let quorum_threshold = committee.quorum_threshold() as usize;
 
-        let unsigned_certificate = Certificate::new_unsigned(committee, header.clone(), vec![]).unwrap();
-
-        for key in &keys[..quorum_threshold] {
-            let signature = key.sign(unsigned_certificate.digest().as_ref());
-            signatures.push((key.public().clone(), signature));
+        for authority in fixture.authorities().take(quorum_threshold) {
+            let vote = authority.vote(&header);
+            signatures.push((vote.author.clone(), vote.signature.clone()));
         }
 
-        let certificate = Certificate::new(committee, header, signatures).unwrap();
+        let certificate = Certificate::new(&committee, header, signatures).unwrap();
 
         assert!(certificate
-            .verify(committee, shared_worker_cache(None))
+            .verify(&committee, fixture.worker_cache().into())
             .is_ok());
     }
 }

--- a/primary/src/tests/synchronizer_tests.rs
+++ b/primary/src/tests/synchronizer_tests.rs
@@ -42,7 +42,7 @@ async fn deliver_certificate_using_dag() {
         .collect::<BTreeSet<_>>();
 
     let (mut certificates, _next_parents) =
-        make_optimal_signed_certificates(1..=4, &genesis, &keys(None)[..3]);
+        make_optimal_signed_certificates(1..=4, &genesis, &committee, &keys(None)[..3]);
 
     // insert the certificates in the DAG
     for certificate in certificates.clone() {
@@ -90,7 +90,7 @@ async fn deliver_certificate_using_store() {
         .collect::<BTreeSet<_>>();
 
     let (mut certificates, _next_parents) =
-        make_optimal_signed_certificates(1..=4, &genesis, &keys(None)[..3]);
+        make_optimal_signed_certificates(1..=4, &genesis, &committee, &keys(None)[..3]);
 
     // insert the certificates in the DAG
     for certificate in certificates.clone() {
@@ -138,7 +138,7 @@ async fn deliver_certificate_not_found_parents() {
         .collect::<BTreeSet<_>>();
 
     let (mut certificates, _next_parents) =
-        make_optimal_signed_certificates(1..=4, &genesis, &keys(None)[..3]);
+        make_optimal_signed_certificates(1..=4, &genesis, &committee, &keys(None)[..3]);
 
     // take the last one (top) and test for parents
     let test_certificate = certificates.pop_back().unwrap();

--- a/primary/tests/integration_tests_proposer_api.rs
+++ b/primary/tests/integration_tests_proposer_api.rs
@@ -275,7 +275,8 @@ async fn test_node_read_causal_signed_certificates() {
         .map(|x| x.digest())
         .collect::<BTreeSet<_>>();
 
-    let (certificates, _next_parents) = make_optimal_signed_certificates(1..=4, &genesis, &k);
+    let (certificates, _next_parents) =
+        make_optimal_signed_certificates(1..=4, &genesis, &committee, &k);
 
     collection_ids.extend(
         certificates

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -149,16 +149,6 @@ pub fn pure_committee_from_keys(keys: &[KeyPair]) -> Committee {
     }
 }
 
-pub fn pure_committee_from_keys_with_mock_ports(keys: &[KeyPair]) -> Committee {
-    Committee {
-        epoch: Epoch::default(),
-        authorities: keys
-            .iter()
-            .map(|kp| (kp.public().clone(), make_authority_with_port_getter(|| 0)))
-            .collect(),
-    }
-}
-
 pub fn make_authority_with_port_getter<F: FnMut() -> u16>(mut get_port: F) -> Authority {
     let primary = PrimaryAddresses {
         primary_to_primary: format!("/ip4/127.0.0.1/tcp/{}/http", get_port())

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -130,6 +130,10 @@ pub fn keys(rng_seed: impl Into<Option<u64>>) -> Vec<KeyPair> {
     keys_with_len(rng_seed, 4)
 }
 
+pub fn random_key() -> KeyPair {
+    KeyPair::generate(&mut OsRng)
+}
+
 // Fixture
 pub fn committee(rng_seed: impl Into<Option<u64>>) -> Committee {
     pure_committee_from_keys(&keys(rng_seed))

--- a/types/src/primary.rs
+++ b/types/src/primary.rs
@@ -282,6 +282,25 @@ impl Vote {
         Self { signature, ..vote }
     }
 
+    pub fn new_with_signer<S>(header: &Header, author: &PublicKey, signer: &S) -> Self
+    where
+        S: Signer<Signature>,
+    {
+        let vote = Self {
+            id: header.id,
+            round: header.round,
+            epoch: header.epoch,
+            origin: header.author.clone(),
+            author: author.clone(),
+            signature: Signature::default(),
+        };
+
+        let vote_digest: Digest = vote.digest().into();
+        let signature = signer.sign(vote_digest.as_ref());
+
+        Self { signature, ..vote }
+    }
+
     pub fn verify(&self, committee: &Committee) -> DagResult<()> {
         // Ensure the header is from the correct epoch.
         ensure!(


### PR DESCRIPTION
Today for testing in narwhal we heavily rely on a number of fixture generation utility functions for generating keys, committees, etc. One present issue with them is that if you can a test helper you generally don't know if it's expecting to use a fixture generated at a fixed seed or not. This could result in the helper using a different committee than you expected.

This pr introduces the concept of a CommitteeFixture as well as corresponding types for workers and primaries in order to make testing helpers a bit more transparent and easier to use.