### PR TITLE
Fix a livelock - do not poll timer if it has already expired

### DIFF
--- a/primary/src/proposer.rs
+++ b/primary/src/proposer.rs
@@ -311,7 +311,7 @@ impl Proposer {
                 }
 
                 // Check whether the timer expired.
-                () = &mut timer => {
+                () = &mut timer, if !timer_expired => {
                     // Nothing to do.
                 }
 


### PR DESCRIPTION
Previously, when the timer expires, the proposer loop will spin on the current thread until messages are eventually received from the channels. This change causes the select! to not poll the timer again once it has expired.