### PR TITLE
Do not block workers during unreliable_send (extended)

### DIFF
--- a/network/src/primary.rs
+++ b/network/src/primary.rs
@@ -41,6 +41,15 @@ impl PrimaryToWorkerNetwork {
         }
     }
 
+    // used for testing non-blocking behavior
+    #[cfg(test)]
+    fn new_with_concurrency_limit(concurrency_limit: usize) -> Self {
+        Self {
+            executor: BoundedExecutor::new(concurrency_limit, Handle::current()),
+            ..Self::default()
+        }
+    }
+
     fn update_metrics(&self) {
         if let Some(m) = &self.metrics {
             m.set_network_available_tasks(self.executor.available_capacity() as i64, None);
@@ -268,5 +277,37 @@ impl ReliableNetwork2<PrimaryMessage> for PrimaryNetwork {
             .spawn_with_retries(self.retry_config, message_send);
 
         CancelOnDropHandler(handle)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn unreliable_send_doesnt_block() {
+        let test_concurrency_limit = 2;
+        let mut p2p = PrimaryToWorkerNetwork::new_with_concurrency_limit(test_concurrency_limit);
+        // send those messages to localhost. THey won't actually land
+        let addr: Multiaddr = "/ip4/127.0.0.1/tcp/0/http".parse().unwrap();
+        let serialized_msg =
+            BincodeEncodedPayload::try_from(&PrimaryWorkerMessage::Cleanup(42)).unwrap();
+
+        let blast_a_few = async move {
+            for _i in 0..test_concurrency_limit * 2 {
+                let addr = addr.clone();
+                let msg = serialized_msg.clone();
+                p2p.unreliable_send_message(addr, msg).await
+            }
+        };
+
+        // beware: if we happen to set a default connect timeout
+        // (we don't at the time of writing) then the following delay needs to be smaller
+        let blast_timeout = Duration::from_millis(100);
+        tokio::time::timeout(blast_timeout, blast_a_few)
+            .await
+            .expect("The unreliable sends should all have completed instantly!");
     }
 }

--- a/network/src/primary.rs
+++ b/network/src/primary.rs
@@ -94,7 +94,7 @@ impl UnreliableNetwork for PrimaryToWorkerNetwork {
         address: Multiaddr,
         message: BincodeEncodedPayload,
     ) -> Option<JoinHandle<()>> {
-        let mut client = self.client(address.clone());
+        let mut client = self.client(address);
         let handler = self
             .executor
             .try_spawn(async move {

--- a/network/src/primary.rs
+++ b/network/src/primary.rs
@@ -93,14 +93,14 @@ impl UnreliableNetwork for PrimaryToWorkerNetwork {
         &mut self,
         address: Multiaddr,
         message: BincodeEncodedPayload,
-    ) -> JoinHandle<()> {
+    ) -> Option<JoinHandle<()>> {
         let mut client = self.client(address.clone());
         let handler = self
             .executor
-            .spawn(async move {
+            .try_spawn(async move {
                 let _ = client.send_message(message).await;
             })
-            .await;
+            .ok();
 
         self.update_metrics();
 

--- a/network/src/worker.rs
+++ b/network/src/worker.rs
@@ -9,7 +9,7 @@ use async_trait::async_trait;
 use multiaddr::Multiaddr;
 use rand::{rngs::SmallRng, SeedableRng as _};
 use std::collections::HashMap;
-use tokio::{runtime::Handle, task::JoinHandle};
+use tokio::runtime::Handle;
 use tonic::{transport::Channel, Code};
 use tracing::error;
 use types::{
@@ -107,10 +107,9 @@ impl UnreliableNetwork for WorkerNetwork {
         &mut self,
         address: Multiaddr,
         message: BincodeEncodedPayload,
-    ) -> Option<JoinHandle<()>> {
+    ) -> () {
         let mut client = self.client(address.clone());
-        let handler = self
-            .executors
+        self.executors
             .entry(address)
             .or_insert_with(default_executor)
             .try_spawn(async move {
@@ -118,8 +117,6 @@ impl UnreliableNetwork for WorkerNetwork {
             })
             .ok();
         self.update_metrics();
-
-        handler
     }
 }
 

--- a/network/src/worker.rs
+++ b/network/src/worker.rs
@@ -107,16 +107,16 @@ impl UnreliableNetwork for WorkerNetwork {
         &mut self,
         address: Multiaddr,
         message: BincodeEncodedPayload,
-    ) -> JoinHandle<()> {
+    ) -> Option<JoinHandle<()>> {
         let mut client = self.client(address.clone());
         let handler = self
             .executors
             .entry(address)
             .or_insert_with(default_executor)
-            .spawn(async move {
+            .try_spawn(async move {
                 let _ = client.send_message(message).await;
             })
-            .await;
+            .ok();
         self.update_metrics();
 
         handler

--- a/node/src/restarter.rs
+++ b/node/src/restarter.rs
@@ -7,7 +7,7 @@ use crypto::KeyPair;
 use executor::{ExecutionState, ExecutorOutput};
 use fastcrypto::traits::KeyPair as _;
 use futures::future::join_all;
-use network::{PrimaryToWorkerNetwork, ReliableNetwork, UnreliableNetwork, WorkerToPrimaryNetwork};
+use network::{PrimaryToWorkerNetwork, ReliableNetwork, WorkerToPrimaryNetwork};
 use prometheus::Registry;
 use std::{fmt::Debug, path::PathBuf, sync::Arc};
 use tokio::sync::mpsc::{Receiver, Sender};
@@ -101,9 +101,7 @@ impl NodeRestarter {
                 .map(|x| x.primary_to_worker)
                 .collect();
             let message = PrimaryWorkerMessage::Reconfigure(ReconfigureNotification::Shutdown);
-            let worker_cancel_handles = worker_network
-                .unreliable_broadcast(addresses, &message)
-                .await;
+            let worker_cancel_handles = worker_network.broadcast(addresses, &message).await;
 
             // Ensure the message has been received.
             primary_cancel_handle

--- a/node/tests/reconfigure.rs
+++ b/node/tests/reconfigure.rs
@@ -303,9 +303,7 @@ async fn epoch_change() {
                 let message = PrimaryWorkerMessage::Reconfigure(ReconfigureNotification::NewEpoch(
                     committee.clone(),
                 ));
-                let worker_cancel_handles = worker_network
-                    .unreliable_broadcast(addresses, &message)
-                    .await;
+                let worker_cancel_handles = worker_network.broadcast(addresses, &message).await;
 
                 // Ensure the message has been received.
                 primary_cancel_handle.await.unwrap();

--- a/node/tests/reconfigure.rs
+++ b/node/tests/reconfigure.rs
@@ -8,7 +8,7 @@ use crypto::{KeyPair, PublicKey};
 use executor::{ExecutionIndices, ExecutionState, ExecutionStateError};
 use fastcrypto::traits::KeyPair as _;
 use futures::future::join_all;
-use network::{PrimaryToWorkerNetwork, ReliableNetwork, UnreliableNetwork, WorkerToPrimaryNetwork};
+use network::{PrimaryToWorkerNetwork, ReliableNetwork, WorkerToPrimaryNetwork};
 use node::{restarter::NodeRestarter, Node, NodeStorage};
 use primary::PrimaryWorkerMessage;
 use prometheus::Registry;

--- a/worker/src/helper.rs
+++ b/worker/src/helper.rs
@@ -86,7 +86,7 @@ impl Helper {
                     for digest in digests {
                         match self.store.read(digest).await {
                             Ok(Some(data)) => {
-                                let _ = self.network.unreliable_send_message(address.clone(), Bytes::from(data).into()).await;
+                                self.network.unreliable_send_message(address.clone(), Bytes::from(data).into()).await;
                             }
                             Ok(None) => {
                                 trace!("No Batches found for requested digests {:?}", digest);


### PR DESCRIPTION
This is an extension of MystenLabs/narwhal#936 that:
- avoids the cumbersome `JoinHandle`s in `unreliable_send_message` 
- includes rustdoc & tests for the non-blocking behavior of `unreliable_send_message`, 
- switches the reconfiguration message from primary to worker to a reliable send (the reliable send implementation is not de novo, of course), since we rely on its delivery to sequence reconfiguration => asking @asonnino for review,
