### PR TITLE
fix: make sure dependabot patching re-triggers CI

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -36,10 +36,11 @@ jobs:
         run: echo ::set-output name=modified::$(if git diff-index --quiet HEAD --; then echo "false"; else echo "true"; fi)
       - name: Push changes
         if: steps.git-check.outputs.modified == 'true'
+        # using secrets.AUTOMERGE_TOKEN in the below is key to re-trigger CI
         run: |
           git config --global user.name 'Francois Garillot'
           git config --global user.email 'francois@mystenlabs.com'
-          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
+          git remote set-url origin https://x-access-token:${{ secrets.AUTOMERGE_TOKEN }}@github.com/${{ github.repository }}
           git commit -am "chore(deps): cargo hakari"
           git push
       - uses: ahmadnassri/action-dependabot-auto-merge@v2.6


### PR DESCRIPTION
Our dependabot PRs have no CI run on it, because we amend them in a way that prevents further workflow runs. This fixes it by allowing further workflow runs.
See doc:
https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow