### PR TITLE
Use feature for tracking_id

### DIFF
--- a/executor/src/core.rs
+++ b/executor/src/core.rs
@@ -239,7 +239,7 @@ where
         // If the deserialization fail it is safe to ignore the transaction since all correct
         // clients will do the same. Remember that a bad authority or client may input random
         // bytes to the consensus.
-        let transaction: State::Transaction = match State::deserialize(&serialized) {
+        let transaction: State::Transaction = match bincode::deserialize(&serialized) {
             Ok(x) => x,
             Err(e) => bail!(SubscriberError::ClientExecutionError(format!(
                 "Failed to deserialize transaction: {e}"

--- a/executor/src/lib.rs
+++ b/executor/src/lib.rs
@@ -64,11 +64,6 @@ pub trait ExecutionState {
         transaction: Self::Transaction,
     ) -> Result<Self::Outcome, Self::Error>;
 
-    /// Deserialize the message bytes into Transaction type. This allows an implementation of
-    /// ExecutionState to customize how to deserialize the message, in case customized
-    /// serialization was used when sending the message.
-    fn deserialize(bytes: &[u8]) -> Result<Self::Transaction, bincode::Error>;
-
     /// Simple guardrail ensuring there is a single instance using the state
     /// to call `handle_consensus_transaction`. Many instances may read the state,
     /// or use it for other purposes.

--- a/executor/src/tests/execution_state.rs
+++ b/executor/src/tests/execution_state.rs
@@ -60,10 +60,6 @@ impl ExecutionState for TestState {
         }
     }
 
-    fn deserialize(bytes: &[u8]) -> Result<Self::Transaction, bincode::Error> {
-        bincode::deserialize(bytes)
-    }
-
     fn ask_consensus_write_lock(&self) -> bool {
         true
     }

--- a/node/src/execution_state.rs
+++ b/node/src/execution_state.rs
@@ -23,10 +23,6 @@ impl ExecutionState for SimpleExecutionState {
         Ok(Vec::default())
     }
 
-    fn deserialize(bytes: &[u8]) -> Result<Self::Transaction, bincode::Error> {
-        bincode::deserialize(bytes)
-    }
-
     fn ask_consensus_write_lock(&self) -> bool {
         true
     }

--- a/node/tests/reconfigure.rs
+++ b/node/tests/reconfigure.rs
@@ -108,10 +108,6 @@ impl ExecutionState for SimpleExecutionState {
         Ok(epoch)
     }
 
-    fn deserialize(bytes: &[u8]) -> Result<Self::Transaction, bincode::Error> {
-        bincode::deserialize(bytes)
-    }
-
     fn ask_consensus_write_lock(&self) -> bool {
         true
     }

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -44,3 +44,4 @@ test_utils = { path = "../test_utils" }
 
 [features]
 benchmark = []
+trace_transaction = []

--- a/worker/src/batch_maker.rs
+++ b/worker/src/batch_maker.rs
@@ -151,26 +151,29 @@ impl BatchMaker {
                 );
             }
 
-            // The first 8 bytes of each transaction message is reserved for an identifier
-            // that's useful for debugging and tracking the lifetime of messages between
-            // Narwhal and clients.
-            let tracking_ids: Vec<_> = batch
-                .0
-                .iter()
-                .map(|tx| {
-                    let len = tx.len();
-                    if len >= 8 {
-                        (&tx[0..8]).read_u64::<BigEndian>().unwrap_or_default()
-                    } else {
-                        0
-                    }
-                })
-                .collect();
-            tracing::debug!(
-                "Tracking IDs of transactions in the Batch {:?}: {:?}",
-                digest,
-                tracking_ids
-            );
+            #[cfg(feature = "trace_transaction")]
+            {
+                // The first 8 bytes of each transaction message is reserved for an identifier
+                // that's useful for debugging and tracking the lifetime of messages between
+                // Narwhal and clients.
+                let tracking_ids: Vec<_> = batch
+                    .0
+                    .iter()
+                    .map(|tx| {
+                        let len = tx.len();
+                        if len >= 8 {
+                            (&tx[0..8]).read_u64::<BigEndian>().unwrap_or_default()
+                        } else {
+                            0
+                        }
+                    })
+                    .collect();
+                tracing::debug!(
+                    "Tracking IDs of transactions in the Batch {:?}: {:?}",
+                    digest,
+                    tracking_ids
+                );
+            }
 
             // NOTE: This log entry is used to compute performance.
             tracing::info!("Batch {:?} contains {} B", digest, size);

--- a/worker/src/tests/batch_maker_tests.rs
+++ b/worker/src/tests/batch_maker_tests.rs
@@ -3,8 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use super::*;
 use prometheus::Registry;
-use test_utils::transaction;
-use test_utils::CommitteeFixture;
+use test_utils::{transaction, CommitteeFixture};
 
 #[tokio::test]
 async fn make_batch() {


### PR DESCRIPTION
As we discussed, allow the upstream client to choose to whether use this feature.
Also, the current implementation of tracking_id in sui no longer requires customized deserialization. Revert the trait requirement.