### PR TITLE
Require only f+1 leader votes in the proposer

### DIFF
--- a/config/tests/config_tests.rs
+++ b/config/tests/config_tests.rs
@@ -23,8 +23,11 @@ use crypto::PublicKey;
 use insta::assert_json_snapshot;
 use multiaddr::Multiaddr;
 use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
-use std::collections::{BTreeMap, HashMap};
-use std::{fs::File, io::Write};
+use std::{
+    collections::{BTreeMap, HashMap},
+    fs::File,
+    io::Write,
+};
 use tempfile::tempdir;
 use test_utils::CommitteeFixture;
 

--- a/consensus/src/tests/dag_tests.rs
+++ b/consensus/src/tests/dag_tests.rs
@@ -7,8 +7,7 @@ use dag::node_dag::NodeDagError;
 use fastcrypto::Hash;
 use indexmap::IndexMap;
 use prometheus::Registry;
-use std::collections::BTreeSet;
-use std::sync::Arc;
+use std::{collections::BTreeSet, sync::Arc};
 use test_utils::{make_optimal_certificates, CommitteeFixture};
 use types::Certificate;
 

--- a/consensus/src/tusk.rs
+++ b/consensus/src/tusk.rs
@@ -176,8 +176,7 @@ mod tests {
     use prometheus::Registry;
     use rand::Rng;
     use std::collections::BTreeSet;
-    use test_utils::make_consensus_store;
-    use test_utils::CommitteeFixture;
+    use test_utils::{make_consensus_store, CommitteeFixture};
     use types::Certificate;
 
     #[test]

--- a/primary/src/proposer.rs
+++ b/primary/src/proposer.rs
@@ -152,7 +152,7 @@ impl Proposer {
         self.last_leader.is_some()
     }
 
-    /// Check whether if we have (i) 2f+1 votes for the leader, (ii) f+1 nodes not voting for the leader,
+    /// Check whether if we have (i) f+1 votes for the leader, (ii) 2f+1 nodes not voting for the leader,
     /// or (iii) there is no leader to vote for. This is only relevant in partial synchrony.
     fn enough_votes(&self) -> bool {
         let leader = match &self.last_leader {

--- a/primary/src/proposer.rs
+++ b/primary/src/proposer.rs
@@ -171,7 +171,7 @@ impl Proposer {
             }
         }
 
-        let mut enough_votes = votes_for_leader >= self.committee.quorum_threshold();
+        let mut enough_votes = votes_for_leader >= self.committee.validity_threshold();
         if enough_votes {
             if let Some(leader) = self.last_leader.as_ref() {
                 debug!(
@@ -181,7 +181,7 @@ impl Proposer {
                 );
             }
         }
-        enough_votes |= no_votes >= self.committee.validity_threshold();
+        enough_votes |= no_votes >= self.committee.quorum_threshold();
         enough_votes
     }
 

--- a/worker/src/tests/batch_maker_tests.rs
+++ b/worker/src/tests/batch_maker_tests.rs
@@ -3,8 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use super::*;
 use prometheus::Registry;
-use test_utils::transaction;
-use test_utils::CommitteeFixture;
+use test_utils::{transaction, CommitteeFixture};
 
 #[tokio::test]
 async fn make_batch() {


### PR DESCRIPTION
The Narwhal proposer only need to wait for f+1 leader votes since we only run the partially-synchronous part of Bullshark (i.e., no asynchornous fallback).