### PR TITLE
Pass a host string to get_available_port.

### DIFF
--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -145,8 +145,9 @@ pub struct PrometheusMetricsParameters {
 
 impl Default for PrometheusMetricsParameters {
     fn default() -> Self {
+        let host = "127.0.0.1";
         Self {
-            socket_addr: format!("/ip4/127.0.0.1/tcp/{}/http", get_available_port())
+            socket_addr: format!("/ip4/{}/tcp/{}/http", host, get_available_port(host))
                 .parse()
                 .unwrap(),
         }
@@ -167,8 +168,9 @@ pub struct ConsensusAPIGrpcParameters {
 
 impl Default for ConsensusAPIGrpcParameters {
     fn default() -> Self {
+        let host = "127.0.0.1";
         Self {
-            socket_addr: format!("/ip4/127.0.0.1/tcp/{}/http", get_available_port())
+            socket_addr: format!("/ip4/{}/tcp/{}/http", host, get_available_port(host))
                 .parse()
                 .unwrap(),
             get_collections_timeout: Duration::from_millis(5_000),

--- a/config/src/utils.rs
+++ b/config/src/utils.rs
@@ -6,11 +6,11 @@ use std::net::{TcpListener, TcpStream};
 /// Return an ephemeral, available port. On unix systems, the port returned will be in the
 /// TIME_WAIT state ensuring that the OS won't hand out this port for some grace period.
 /// Callers should be able to bind to this port given they use SO_REUSEADDR.
-pub fn get_available_port() -> u16 {
+pub fn get_available_port(host: &str) -> u16 {
     const MAX_PORT_RETRIES: u32 = 1000;
 
     for _ in 0..MAX_PORT_RETRIES {
-        if let Ok(port) = get_ephemeral_port() {
+        if let Ok(port) = get_ephemeral_port(host) {
             return port;
         }
     }
@@ -18,9 +18,9 @@ pub fn get_available_port() -> u16 {
     panic!("Error: could not find an available port");
 }
 
-fn get_ephemeral_port() -> ::std::io::Result<u16> {
+fn get_ephemeral_port(host: &str) -> ::std::io::Result<u16> {
     // Request a random available port from the OS
-    let listener = TcpListener::bind(("localhost", 0))?;
+    let listener = TcpListener::bind((host, 0))?;
     let addr = listener.local_addr()?;
 
     // Create and accept a connection (which we'll promptly drop) in order to force the port


### PR DESCRIPTION
Previously, `get_available_port` was using `"localhost"`, which may resolve to the ipv6 loopback instead of ipv4. We then use the obtained port in an ipv4 multiaddr in every case that was calling `get_available_port()`

This was probably working 99.9% of the time before by chance, since there isn't much ephemeral port contention most of the time.