### PR TITLE
fix: Multiplex messages to the BlockSynchronizer on a single channel

### DIFF
--- a/primary/src/block_synchronizer/responses.rs
+++ b/primary/src/block_synchronizer/responses.rs
@@ -137,6 +137,12 @@ impl CertificatesResponse {
     }
 }
 
+#[derive(Debug, Clone)]
+pub enum AvailabilityResponse {
+    Certificate(CertificatesResponse),
+    Payload(PayloadAvailabilityResponse),
+}
+
 #[derive(Debug, Error, Clone, PartialEq)]
 pub enum CertificatesResponseError {
     #[error("Found invalid certificates form peer {name} - potentially Byzantine.")]

--- a/primary/src/metrics.rs
+++ b/primary/src/metrics.rs
@@ -82,9 +82,7 @@ pub struct PrimaryChannelMetrics {
     /// occupancy of the channel from the `primary::BlockSynchronizerHandler` to the `primary::BlockSynchronizer`
     pub tx_block_synchronizer_commands: IntGauge,
     /// occupancy of the channel from the `primary::PrimaryReceiverHandler` to the `primary::BlockSynchronizer`
-    pub tx_certificate_responses: IntGauge,
-    /// occupancy of the channel from the `primary::PrimaryReceiverHandler` to the `primary::BlockSynchronizer`
-    pub tx_payload_availability_responses: IntGauge,
+    pub tx_availability_responses: IntGauge,
     /// occupancy of the channel from the `primary::WorkerReceiverHandler` to the `primary::StateHandler`
     pub tx_state_handler: IntGauge,
     /// occupancy of the channel from the reconfigure notification to most components.
@@ -189,13 +187,8 @@ impl PrimaryChannelMetrics {
                 "occupancy of the channel from the `primary::BlockSynchronizerHandler` to the `primary::BlockSynchronizer`",
                 registry
             ).unwrap(),
-            tx_certificate_responses: register_int_gauge_with_registry!(
-                "tx_certificate_responses",
-                "occupancy of the channel from the `primary::PrimaryReceiverHandler` to the `primary::BlockSynchronizer`",
-                registry
-            ).unwrap(),
-            tx_payload_availability_responses: register_int_gauge_with_registry!(
-                "tx_payload_availability_responses",
+            tx_availability_responses: register_int_gauge_with_registry!(
+                "tx_availability_responses",
                 "occupancy of the channel from the `primary::PrimaryReceiverHandler` to the `primary::BlockSynchronizer`",
                 registry
             ).unwrap(),


### PR DESCRIPTION
Today, the BlockSynchronizer receives several types of messages from the PrimaryReceiverHandler, which go on a different channel depending on their nature. This does not scale, especially since we are about to add more messages types traveling the same component edge in #848.

We put the messages under an enum and transmit that enum along the channel, which simplified BlockSynchronizer setup and channel patterns overall.