### PR TITLE
Small fixes in `block_synchronizer` and friends

### DIFF
--- a/primary/src/block_synchronizer/mod.rs
+++ b/primary/src/block_synchronizer/mod.rs
@@ -477,7 +477,7 @@ impl BlockSynchronizer {
             return None;
         }
 
-        let key = RequestID::from_iter(to_sync.iter());
+        let key = RequestID::from_iter(to_sync.clone());
 
         let message = PrimaryMessage::CertificatesBatchRequest {
             certificate_ids: to_sync.clone(),

--- a/primary/src/block_synchronizer/peers.rs
+++ b/primary/src/block_synchronizer/peers.rs
@@ -355,10 +355,7 @@ mod tests {
                 );
 
                 for c in peer.assigned_values() {
-                    let found = peer_certs
-                        .clone()
-                        .into_iter()
-                        .any(|c| c.digest().eq(&c.digest()));
+                    let found = peer_certs.iter().any(|c| c.digest().eq(&c.digest()));
 
                     assert!(found, "Assigned certificate not in set of expected");
                     assert!(

--- a/primary/src/block_synchronizer/responses.rs
+++ b/primary/src/block_synchronizer/responses.rs
@@ -21,14 +21,14 @@ impl RequestID {
     }
 }
 
-impl<'a> FromIterator<&'a CertificateDigest> for RequestID {
-    fn from_iter<T: IntoIterator<Item = &'a CertificateDigest>>(ids: T) -> Self {
-        let mut ids_sorted: Vec<&CertificateDigest> = ids.into_iter().collect();
+impl FromIterator<CertificateDigest> for RequestID {
+    fn from_iter<T: IntoIterator<Item = CertificateDigest>>(ids: T) -> Self {
+        let mut ids_sorted: Vec<CertificateDigest> = ids.into_iter().collect();
         ids_sorted.sort();
 
         let result: Vec<u8> = ids_sorted
             .into_iter()
-            .flat_map(|d| Digest::from(*d).to_vec())
+            .flat_map(|d| Digest::from(d).to_vec())
             .collect();
 
         RequestID::new(&result)
@@ -37,9 +37,7 @@ impl<'a> FromIterator<&'a CertificateDigest> for RequestID {
 
 impl<'a> FromIterator<&'a Certificate> for RequestID {
     fn from_iter<T: IntoIterator<Item = &'a Certificate>>(certificates: T) -> Self {
-        let ids: Vec<CertificateDigest> = certificates.into_iter().map(|c| c.digest()).collect();
-
-        ids.iter().collect()
+        certificates.into_iter().map(|c| c.digest()).collect()
     }
 }
 
@@ -57,9 +55,7 @@ pub struct PayloadAvailabilityResponse {
 
 impl PayloadAvailabilityResponse {
     pub fn request_id(&self) -> RequestID {
-        let ids: Vec<CertificateDigest> = self.block_ids.iter().map(|entry| entry.0).collect();
-
-        ids.iter().collect()
+        self.block_ids.iter().map(|entry| entry.0).collect()
     }
 
     pub fn available_block_ids(&self) -> Vec<CertificateDigest> {
@@ -78,9 +74,7 @@ pub struct CertificatesResponse {
 
 impl CertificatesResponse {
     pub fn request_id(&self) -> RequestID {
-        let ids: Vec<CertificateDigest> = self.certificates.iter().map(|entry| entry.0).collect();
-
-        ids.iter().collect()
+        self.certificates.iter().map(|entry| entry.0).collect()
     }
 
     /// This method does two things:

--- a/primary/src/block_synchronizer/tests/block_synchronizer_tests.rs
+++ b/primary/src/block_synchronizer/tests/block_synchronizer_tests.rs
@@ -537,7 +537,7 @@ async fn test_multiple_overlapping_requests() {
     }
 
     // AND that the request is pending for all the block_ids
-    let request_id: RequestID = block_ids.iter().collect();
+    let request_id: RequestID = block_ids.clone().into_iter().collect();
 
     assert!(
         block_synchronizer
@@ -564,7 +564,7 @@ async fn test_multiple_overlapping_requests() {
         2
     );
 
-    let request_id: RequestID = vec![extra_certificate_id].iter().collect();
+    let request_id: RequestID = vec![extra_certificate_id].into_iter().collect();
     assert!(
         block_synchronizer
             .map_certificate_responses_senders

--- a/primary/src/block_waiter.rs
+++ b/primary/src/block_waiter.rs
@@ -488,22 +488,16 @@ impl<SynchronizerHandler: Handler + Send + Sync + 'static> BlockWaiter<Synchroni
         let mut ids = Vec::new();
 
         // ensure payloads are synchronized for the found certificates
-        let found_certificates: Vec<Certificate> = certificates
-            .clone()
-            .into_iter()
-            .filter(|(_, c)| c.is_some())
-            .map(|(_, c)| c.unwrap())
-            .collect();
+        let found_certificates: Vec<Certificate> =
+            certificates.iter().flat_map(|(_, c)| c).cloned().collect();
 
         let sync_result = self
             .block_synchronizer_handler
             .synchronize_block_payloads(found_certificates)
             .await;
         let successful_payload_sync_set = sync_result
-            .clone()
-            .into_iter()
-            .flatten()
-            .map(|c| c.digest())
+            .iter()
+            .flat_map(|r| r.as_ref().map(|c| c.digest()).ok())
             .collect::<HashSet<CertificateDigest>>();
 
         for (id, c) in certificates {

--- a/primary/src/block_waiter.rs
+++ b/primary/src/block_waiter.rs
@@ -249,12 +249,12 @@ pub struct BlockWaiter<SynchronizerHandler: Handler + Send + Sync + 'static> {
 
     /// A map that holds the channels we should notify with the
     /// GetBlock responses.
-    tx_get_block_map:
+    get_block_map_requesters:
         HashMap<CertificateDigest, Vec<oneshot::Sender<BlockResult<GetBlockResponse>>>>,
 
     /// A map that holds the channels we should notify with the
     /// GetBlocks responses.
-    tx_get_blocks_map: HashMap<RequestKey, Vec<oneshot::Sender<BlocksResult>>>,
+    get_blocks_map_requesters: HashMap<RequestKey, Vec<oneshot::Sender<BlocksResult>>>,
 
     /// We use the handler of the block synchronizer to interact with the
     /// block synchronizer in a synchronous way. Share a reference of this
@@ -287,8 +287,8 @@ impl<SynchronizerHandler: Handler + Send + Sync + 'static> BlockWaiter<Synchroni
                 rx_reconfigure,
                 rx_batch_receiver: batch_receiver,
                 tx_pending_batch: HashMap::new(),
-                tx_get_block_map: HashMap::new(),
-                tx_get_blocks_map: HashMap::new(),
+                get_block_map_requesters: HashMap::new(),
+                get_blocks_map_requesters: HashMap::new(),
                 block_synchronizer_handler,
             }
             .run()
@@ -379,7 +379,7 @@ impl<SynchronizerHandler: Handler + Send + Sync + 'static> BlockWaiter<Synchroni
 
         let key = Self::construct_get_blocks_request_key(&ids);
 
-        match self.tx_get_blocks_map.remove(&key) {
+        match self.get_blocks_map_requesters.remove(&key) {
             Some(senders) => {
                 for sender in senders {
                     if sender.send(result.clone()).is_err() {
@@ -407,10 +407,10 @@ impl<SynchronizerHandler: Handler + Send + Sync + 'static> BlockWaiter<Synchroni
         // and then we merge all the bytes to form a key
         let key = Self::construct_get_blocks_request_key(&ids);
 
-        if self.tx_get_blocks_map.contains_key(&key) {
+        if self.get_blocks_map_requesters.contains_key(&key) {
             // request already pending, nothing to do, just add the sender to the list
             // of pending to be notified ones.
-            self.tx_get_blocks_map
+            self.get_blocks_map_requesters
                 .entry(key)
                 .or_insert_with(Vec::new)
                 .push(sender);
@@ -425,7 +425,7 @@ impl<SynchronizerHandler: Handler + Send + Sync + 'static> BlockWaiter<Synchroni
         let (get_block_futures, get_blocks_future) = self.get_blocks(certificates).await;
 
         // mark the request as pending
-        self.tx_get_blocks_map
+        self.get_blocks_map_requesters
             .entry(key)
             .or_insert_with(Vec::new)
             .push(sender);
@@ -594,7 +594,7 @@ impl<SynchronizerHandler: Handler + Send + Sync + 'static> BlockWaiter<Synchroni
     ) -> Option<BoxFuture<'a, BlockResult<GetBlockResponse>>> {
         // If similar request is already under processing, don't start a new one
         if self.pending_get_block.contains_key(&id.clone()) {
-            self.tx_get_block_map
+            self.get_block_map_requesters
                 .entry(id)
                 .or_insert_with(Vec::new)
                 .push(sender);
@@ -616,7 +616,7 @@ impl<SynchronizerHandler: Handler + Send + Sync + 'static> BlockWaiter<Synchroni
         // as pending so no other can initiate the process
         self.pending_get_block.insert(id, certificate.clone());
 
-        self.tx_get_block_map
+        self.get_block_map_requesters
             .entry(id)
             .or_insert_with(Vec::new)
             .push(sender);
@@ -665,7 +665,7 @@ impl<SynchronizerHandler: Handler + Send + Sync + 'static> BlockWaiter<Synchroni
     async fn handle_batch_waiting_result(&mut self, result: BlockResult<GetBlockResponse>) {
         let block_id = result.clone().map_or_else(|e| e.id, |r| r.id);
 
-        match self.tx_get_block_map.remove(&block_id) {
+        match self.get_block_map_requesters.remove(&block_id) {
             Some(senders) => {
                 for sender in senders {
                     if sender.send(result.clone()).is_err() {

--- a/primary/src/tests/block_waiter_tests.rs
+++ b/primary/src/tests/block_waiter_tests.rs
@@ -422,8 +422,8 @@ async fn test_one_pending_request_for_block_at_time() {
         rx_reconfigure,
         rx_batch_receiver: rx_batch_messages,
         tx_pending_batch: HashMap::new(),
-        tx_get_block_map: HashMap::new(),
-        tx_get_blocks_map: HashMap::new(),
+        get_block_map_requesters: HashMap::new(),
+        get_blocks_map_requesters: HashMap::new(),
         block_synchronizer_handler: Arc::new(mock_handler),
     };
 
@@ -505,8 +505,8 @@ async fn test_unlocking_pending_get_block_request_after_response() {
         rx_reconfigure,
         rx_batch_receiver: rx_batch_messages,
         tx_pending_batch: HashMap::new(),
-        tx_get_block_map: HashMap::new(),
-        tx_get_blocks_map: HashMap::new(),
+        get_block_map_requesters: HashMap::new(),
+        get_blocks_map_requesters: HashMap::new(),
         block_synchronizer_handler: Arc::new(mock_handler),
     };
 
@@ -532,7 +532,7 @@ async fn test_unlocking_pending_get_block_request_after_response() {
 
     // THEN
     assert!(!waiter.pending_get_block.contains_key(&block_id));
-    assert!(!waiter.tx_get_block_map.contains_key(&block_id));
+    assert!(!waiter.get_block_map_requesters.contains_key(&block_id));
 }
 
 #[tokio::test]


### PR DESCRIPTION
- simplify `RequestID` creation,
- simplify some of the iterator uses in `block_waiter` and friends,
- rename `tx_get_block(s?)_map` to reflect it's not a channel.