### PR TITLE
[subscriber] convert to sequential approach

### DIFF
--- a/executor/src/metrics.rs
+++ b/executor/src/metrics.rs
@@ -1,13 +1,19 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use prometheus::{default_registry, register_int_gauge_with_registry, IntGauge, Registry};
+use prometheus::{
+    default_registry, register_histogram_with_registry, register_int_counter_with_registry,
+    register_int_gauge_with_registry, Histogram, IntCounter, IntGauge, Registry,
+};
 
 #[derive(Clone, Debug)]
 pub struct ExecutorMetrics {
     /// occupancy of the channel from the `Subscriber` to `Core`
     pub tx_executor: IntGauge,
-    /// Number of elements in the waiting (ready-to-deliver) list of subscriber
-    pub waiting_elements_subscriber: IntGauge,
+    /// Time it takes to download a payload on the Subscriber
+    pub subscriber_download_payload_latency: Histogram,
+    /// The number of certificates processed by Subscriber
+    /// during the recovery period to fetch their payloads.
+    pub subscriber_recovered_certificates_count: IntCounter,
 }
 
 impl ExecutorMetrics {
@@ -19,12 +25,22 @@ impl ExecutorMetrics {
                 registry
             )
             .unwrap(),
-            waiting_elements_subscriber: register_int_gauge_with_registry!(
-                "waiting_elements_subscriber",
-                "Number of waiting elements in the subscriber",
+            subscriber_download_payload_latency: register_histogram_with_registry!(
+                "subscriber_download_payload_latency",
+                "Time it takes to download a payload on the Subscriber",
+                // the buckets defined in seconds
+                vec![
+                    0.005, 0.01, 0.02, 0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 3.0, 5.0, 10.0, 20.0, 40.0,
+                    60.0
+                ],
                 registry
             )
             .unwrap(),
+            subscriber_recovered_certificates_count: register_int_counter_with_registry!(
+                "subscriber_recovered_certificates_count",
+                "The number of certificates processed by Subscriber during the recovery period to fetch their payloads",
+                registry
+            ).unwrap()
         }
     }
 }

--- a/executor/src/metrics.rs
+++ b/executor/src/metrics.rs
@@ -45,7 +45,7 @@ impl ExecutorMetrics {
                 registry
             ).unwrap(),
             subscriber_download_payload_attempts: register_histogram_with_registry!(
-                "subscriber_download_payload_retries",
+                "subscriber_download_payload_attempts",
                 "The number of attempts to successfully download a certificate's payload in Subscriber",
                 vec![
                     1.0, 2.0, 3.0, 4.0, 5.0, 7.0, 10.0, 15.0, 20.0

--- a/executor/src/metrics.rs
+++ b/executor/src/metrics.rs
@@ -11,6 +11,9 @@ pub struct ExecutorMetrics {
     pub tx_executor: IntGauge,
     /// Time it takes to download a payload on the Subscriber
     pub subscriber_download_payload_latency: Histogram,
+    /// The number of attempts to successfully download
+    /// a certificate's payload in Subscriber.
+    pub subscriber_download_payload_attempts: Histogram,
     /// The number of certificates processed by Subscriber
     /// during the recovery period to fetch their payloads.
     pub subscriber_recovered_certificates_count: IntCounter,
@@ -39,6 +42,14 @@ impl ExecutorMetrics {
             subscriber_recovered_certificates_count: register_int_counter_with_registry!(
                 "subscriber_recovered_certificates_count",
                 "The number of certificates processed by Subscriber during the recovery period to fetch their payloads",
+                registry
+            ).unwrap(),
+            subscriber_download_payload_attempts: register_histogram_with_registry!(
+                "subscriber_download_payload_retries",
+                "The number of attempts to successfully download a certificate's payload in Subscriber",
+                vec![
+                    1.0, 2.0, 3.0, 4.0, 5.0, 7.0, 10.0, 15.0, 20.0
+                ],
                 registry
             ).unwrap()
         }

--- a/executor/src/subscriber.rs
+++ b/executor/src/subscriber.rs
@@ -94,7 +94,7 @@ impl Subscriber {
         // This needs to happen before we start listening on rx_consensus and receive messages
         // sequenced after these.
         if let Err(err) = self
-            .recover_consensus_output(restored_consensus_output)
+            .recover_from_consensus_output(restored_consensus_output)
             .await
         {
             error!("Executor subscriber is shutting down: {err}");
@@ -128,7 +128,7 @@ impl Subscriber {
     /// blocking operation. We should expect to block if executor is saturated, but
     /// this is desired to avoid overloading our system making this easier to trace.
     #[instrument(level="info", skip_all, fields(num_of_certificates = restored_consensus_output.len()), err)]
-    async fn recover_consensus_output(
+    async fn recover_from_consensus_output(
         &self,
         restored_consensus_output: Vec<ConsensusOutput>,
     ) -> SubscriberResult<()> {

--- a/executor/src/subscriber.rs
+++ b/executor/src/subscriber.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use crate::{
-    errors::SubscriberResult, metrics::ExecutorMetrics, try_fut_and_permit, SubscriberError,
+    errors::SubscriberResult, metrics::ExecutorMetrics, SubscriberError,
     SubscriberError::PayloadRetrieveError,
 };
 use backoff::{Error, ExponentialBackoff};
@@ -14,11 +14,8 @@ use tokio::{
     sync::{oneshot, watch},
     task::JoinHandle,
 };
-use tracing::error;
-use types::{
-    bounded_future_queue::BoundedFuturesOrdered, metered_channel, Batch, BatchDigest,
-    CertificateDigest, ReconfigureNotification,
-};
+use tracing::{error, instrument};
+use types::{metered_channel, Batch, BatchDigest, CertificateDigest, ReconfigureNotification};
 
 #[cfg(test)]
 #[path = "tests/subscriber_tests.rs"]
@@ -48,9 +45,6 @@ pub struct Subscriber {
 }
 
 impl Subscriber {
-    /// Returns the max amount of pending consensus messages we should expect.
-    const MAX_PENDING_CONSENSUS_MESSAGES: usize = 2000;
-
     /// Spawn a new subscriber in a new tokio task.
     #[must_use]
     pub fn spawn(
@@ -92,47 +86,47 @@ impl Subscriber {
         &mut self,
         restored_consensus_output: Vec<ConsensusOutput>,
     ) -> SubscriberResult<()> {
-        // It's important to have the futures in ordered fashion as we want
-        // to guarantee that will deliver to the executor the certificates
-        // in the same order we received from rx_consensus. So it doesn't
-        // mater if we somehow managed to fetch the batches from a later
-        // certificate. Unless the earlier certificate's payload has been
-        // fetched, no later certificate will be delivered.
-        let mut waiting =
-            BoundedFuturesOrdered::with_capacity(Self::MAX_PENDING_CONSENSUS_MESSAGES);
+        // It's important to process the consensus output in strictly ordered
+        // fashion to guarantee that we will deliver to the executor the certificates
+        // in the same order we received from rx_consensus.
 
         // First handle any consensus output messages that were restored due to a restart.
-        // This needs to happen before we start listening on rx_consensus and receive messages sequenced after these.
-        for message in restored_consensus_output {
-            let future = Self::wait_on_payload(
-                self.get_block_retry_policy.clone(),
-                self.store.clone(),
-                self.tx_get_block_commands.clone(),
-                message,
-            );
-            waiting.push(future).await;
+        // This needs to happen before we start listening on rx_consensus and receive messages
+        // sequenced after these.
+        if let Err(err) = self
+            .recover_consensus_output(restored_consensus_output)
+            .await
+        {
+            error!("Executor subscriber is shutting down: {err}");
+            return Ok(());
         }
 
         // Listen to sequenced consensus message and process them.
         loop {
             tokio::select! {
                 // Receive the ordered sequence of consensus messages from a consensus node.
-                Some(message) = self.rx_consensus.recv(), if waiting.available_permits() > 0 => {
+                Some(message) = self.rx_consensus.recv() => {
                     // Fetch the certificate's payload from the workers. This is done via the
                     // block_waiter component. If the batches are not available in the workers then
                     // block_waiter will do its best to sync from the other peers. Once all batches
                     // are available, we forward the certificate to the Executor Core.
                     let future = Self::wait_on_payload(
+                        self.metrics.clone(),
                         self.get_block_retry_policy.clone(),
                         self.store.clone(),
                         self.tx_get_block_commands.clone(),
                         message);
-                    waiting.push(future).await;
-                },
 
-                // Receive here consensus messages for which we have downloaded all transactions data.
-                (Some(message), permit) = try_fut_and_permit!(waiting.try_next(), self.tx_executor) => {
-                    permit.send(message)
+                    match future.await {
+                        Ok(output) =>
+                            if let Err(err) = self.tx_executor.send(output).await {
+                                error!("Executor subscriber is shutting down: {err}");
+                                return Ok(());
+                            }
+                        Err(err) => {
+                            panic!("Irrecoverable error occurred while retrieving block payload: {err}");
+                        }
+                    }
                 },
 
                 // Check whether the committee changed.
@@ -144,10 +138,6 @@ impl Subscriber {
                     }
                 }
             }
-
-            self.metrics
-                .waiting_elements_subscriber
-                .set(waiting.len() as i64);
         }
     }
 
@@ -157,11 +147,16 @@ impl Subscriber {
     /// sequenced we will not quit this method until we have successfully
     /// fetched the payload.
     async fn wait_on_payload(
+        metrics: Arc<ExecutorMetrics>,
         back_off_policy: ExponentialBackoff,
         store: Store<(CertificateDigest, BatchDigest), Batch>,
         tx_get_block_commands: metered_channel::Sender<BlockCommand>,
         deliver: ConsensusOutput,
     ) -> SubscriberResult<ConsensusOutput> {
+        // the latency will be measured automatically once the guard
+        // goes out of scope and dropped
+        let _start_guard = metrics.subscriber_download_payload_latency.start_timer();
+
         let get_block = move || {
             let message = deliver.clone();
             let certificate_id = message.certificate.digest();
@@ -212,5 +207,49 @@ impl Subscriber {
         };
 
         backoff::future::retry(back_off_policy, get_block).await
+    }
+
+    /// Reads all the restored_consensus_output one by one, fetches their payload
+    /// in order, and delivers them to the tx_executor channel. This is a sequential
+    /// blocking operation. We should expect to block if executor is saturated, but
+    /// this is desired to avoid overloading our system making this easier to trace.
+    #[instrument(level="info", skip_all, fields(num_of_certificates = restored_consensus_output.len()), err)]
+    async fn recover_consensus_output(
+        &self,
+        restored_consensus_output: Vec<ConsensusOutput>,
+    ) -> SubscriberResult<()> {
+        for message in restored_consensus_output {
+            // we are making this a sequential/blocking operation as the number of payloads
+            // that needs to be fetched might exceed the size of the waiting list and then
+            // we'll never be able to empty it until as we'll never reach the following loop.
+            // Also throttling the recovery is another measure to ensure we don't flood our
+            // network with messages.
+            let result = Self::wait_on_payload(
+                self.metrics.clone(),
+                self.get_block_retry_policy.clone(),
+                self.store.clone(),
+                self.tx_get_block_commands.clone(),
+                message,
+            )
+            .await;
+
+            match result {
+                Ok(output) => {
+                    // intentionally block here until the executor becomes
+                    // available. Alternatively we could create buffers to keep
+                    // downloaded messages, but prioritised a more straightforward approach
+                    if self.tx_executor.send(output).await.is_err() {
+                        return Err(SubscriberError::ClosedChannel(
+                            stringify!(self.tx_executor).to_owned(),
+                        ));
+                    }
+                }
+                Err(err) => return Err(err),
+            }
+
+            self.metrics.subscriber_recovered_certificates_count.inc();
+        }
+
+        Ok(())
     }
 }


### PR DESCRIPTION
Given the recent issues we've seen I am converting the Subscriber to work in a sequential / head of line blocking approach. No attempt will be made to download the payload of the next certificate, unless we have finished downloading the preceding one. The assumption is that we are willing to sacrifice part of our performance for a more straightforward approach that will prevent us from monopolizing our resources especially in cases of stress.

The PR is also refactoring the recovery method to follow the same approach - comments have been added with the decisions. Also metrics have been introduced for better visibility.