### PR TITLE
Add instrumentation to block synchronizer top level functions

### DIFF
--- a/primary/src/block_synchronizer/mod.rs
+++ b/primary/src/block_synchronizer/mod.rs
@@ -390,6 +390,7 @@ impl BlockSynchronizer {
         }
     }
 
+    #[instrument(level = "trace", skip_all)]
     async fn handle_synchronize_range_command<'a>(
         &mut self,
         respond_to: Sender<CertificateIDsByRounds>,
@@ -433,6 +434,7 @@ impl BlockSynchronizer {
         )
     }
 
+    #[instrument(level = "trace", skip_all)]
     async fn handle_digest_response(&mut self, certificate_digests: CertificateDigestsResponse) {
         let CertificateDigestsResponse {
             certificate_ids,
@@ -530,6 +532,7 @@ impl BlockSynchronizer {
         State::RangeSynchronized { certificate_ids }
     }
 
+    #[instrument(level = "trace", skip_all)]
     async fn notify_requestors_for_result(
         &mut self,
         request: PendingIdentifier,
@@ -644,6 +647,7 @@ impl BlockSynchronizer {
     /// back to the consumer. The method returns a future that is running the
     /// process of waiting to gather the node responses and emits the result as
     /// the next State to be executed.
+    #[instrument(level = "trace", skip_all)]
     async fn handle_synchronize_block_headers_command<'a>(
         &mut self,
         block_ids: Vec<CertificateDigest>,
@@ -905,6 +909,7 @@ impl BlockSynchronizer {
         }
     }
 
+    #[instrument(level = "trace", skip_all, fields(request_id, certificate=?certificate.header.id))]
     async fn wait_for_block_payload<'a>(
         payload_synchronize_timeout: Duration,
         request_id: RequestID,

--- a/primary/src/block_synchronizer/responses.rs
+++ b/primary/src/block_synchronizer/responses.rs
@@ -4,6 +4,7 @@ use blake2::digest::Update;
 use config::{Committee, SharedWorkerCache};
 use crypto::PublicKey;
 use fastcrypto::{Digest, Hash};
+use std::fmt::Debug;
 use std::{
     collections::BTreeMap,
     fmt::{Display, Formatter},
@@ -14,13 +15,19 @@ use types::{Certificate, CertificateDigest, Round};
 
 // RequestID helps us identify an incoming request and
 // all the consequent network requests associated with it.
-#[derive(Clone, Debug, Copy, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct RequestID(pub [u8; fastcrypto::DIGEST_LEN]);
 
 impl RequestID {
     // Create a request key (deterministically) from arbitrary data.
     pub fn new(data: &[u8]) -> Self {
         RequestID(fastcrypto::blake2b_256(|hasher| hasher.update(data)))
+    }
+}
+
+impl Debug for RequestID {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(f, "{}", base64::encode(self.0))
     }
 }
 


### PR DESCRIPTION
This adds instrumentation on every function that is called from top level select of the block synchronizer as well as to futures that are collected into `waiting`. This can shed some light into what is happening inside block synchronizer.

Also, it adds readable `Debug` implementation for `RequestId`, otherwise it is very hard to read in logs.