### PR TITLE
Fix `test_restore_from_disk`

### DIFF
--- a/primary/src/primary.rs
+++ b/primary/src/primary.rs
@@ -206,11 +206,16 @@ impl Primary {
         let routes = anemo::Router::new()
             .add_rpc_service(primary_service)
             .add_rpc_service(worker_service);
-        let network = anemo::Network::bind(addr)
+        let network = anemo::Network::bind(addr.clone())
             .server_name("narwhal")
             .private_key(network_signer.copy().private().0.to_bytes())
             .start(routes)
-            .unwrap();
+            .unwrap_or_else(|_| {
+                panic!(
+                    "Address {} should be available for the primary Narwhal service",
+                    addr
+                )
+            });
         info!("Primary {} listening on {}", name.encode_base64(), address);
 
         let primaries = committee

--- a/primary/tests/causal_completion_tests.rs
+++ b/primary/tests/causal_completion_tests.rs
@@ -65,7 +65,7 @@ async fn test_restore_from_disk() {
     // Now stop node 0
     cluster.stop_node(0).await;
 
-    // Let other primaries advance and primary 0 shutdown properly.
+    // Let other primaries advance and primary 0 releases its port.
     tokio::time::sleep(Duration::from_secs(10)).await;
 
     // Now start the node 0 again
@@ -129,7 +129,7 @@ async fn test_read_causal_signed_certificates() {
     // Now stop node 0
     cluster.stop_node(0).await;
 
-    // Let other primaries advance
+    // Let other primaries advance and primary 0 releases its port.
     tokio::time::sleep(Duration::from_secs(10)).await;
 
     // Now start the validator 0 again

--- a/primary/tests/causal_completion_tests.rs
+++ b/primary/tests/causal_completion_tests.rs
@@ -65,8 +65,8 @@ async fn test_restore_from_disk() {
     // Now stop node 0
     cluster.stop_node(0).await;
 
-    // Let other primaries advance
-    tokio::time::sleep(Duration::from_secs(2)).await;
+    // Let other primaries advance and primary 0 shutdown properly.
+    tokio::time::sleep(Duration::from_secs(10)).await;
 
     // Now start the node 0 again
     cluster.start_node(0, true, Some(1)).await;

--- a/test_utils/src/cluster.rs
+++ b/test_utils/src/cluster.rs
@@ -173,6 +173,7 @@ impl Cluster {
         } else {
             info!("Node with {id} not found - nothing to stop");
         }
+        // TODO: wait for the node's network port to be released.
     }
 
     /// Returns all the running authorities. Any authority that:
@@ -631,7 +632,7 @@ impl AuthorityDetails {
             .stop();
     }
 
-    /// Stops all the nodes (primary & workers)
+    /// Stops all the nodes (primary & workers).
     pub async fn stop_all(&self) {
         let internal = self.internal.read().await;
 


### PR DESCRIPTION
After #976, it seems stopping a primary via test `Cluster` can take >= 2s to release the primary's port. If restarting the primary within 2s, there will be a port conflict.

I'm not sure if the delayed release of port is an expected behavior. For now, just mitigate the test failure with a longer wait (same as the wait in `test_read_causal_signed_certificates` below) between restarting the primary.