### PR TITLE
network: don't block on unreliable_send

### DIFF
--- a/network/src/p2p.rs
+++ b/network/src/p2p.rs
@@ -81,7 +81,7 @@ impl P2pNetwork {
         Self::new(network)
     }
 
-    async fn unreliable_send<F, R, Fut>(
+    fn unreliable_send<F, R, Fut>(
         &mut self,
         peer: NetworkPublicKey,
         f: F,
@@ -165,10 +165,9 @@ impl Lucky for P2pNetwork {
 // Primary-to-Primary
 //
 
-#[async_trait]
 impl UnreliableNetwork<PrimaryMessage> for P2pNetwork {
     type Response = ();
-    async fn unreliable_send(
+    fn unreliable_send(
         &mut self,
         peer: NetworkPublicKey,
         message: &PrimaryMessage,
@@ -179,7 +178,7 @@ impl UnreliableNetwork<PrimaryMessage> for P2pNetwork {
                 .send_message(message)
                 .await
         };
-        self.unreliable_send(peer, f).await
+        self.unreliable_send(peer, f)
     }
 }
 
@@ -209,10 +208,9 @@ impl ReliableNetwork<PrimaryMessage> for P2pNetwork {
 // Primary-to-Worker
 //
 
-#[async_trait]
 impl UnreliableNetwork<PrimaryWorkerMessage> for P2pNetwork {
     type Response = ();
-    async fn unreliable_send(
+    fn unreliable_send(
         &mut self,
         peer: NetworkPublicKey,
         message: &PrimaryWorkerMessage,
@@ -220,7 +218,7 @@ impl UnreliableNetwork<PrimaryWorkerMessage> for P2pNetwork {
         let message = message.to_owned();
         let f =
             move |peer| async move { PrimaryToWorkerClient::new(peer).send_message(message).await };
-        self.unreliable_send(peer, f).await
+        self.unreliable_send(peer, f)
     }
 }
 
@@ -246,10 +244,9 @@ impl ReliableNetwork<PrimaryWorkerMessage> for P2pNetwork {
 // Worker-to-Primary
 //
 
-#[async_trait]
 impl UnreliableNetwork<WorkerPrimaryMessage> for P2pNetwork {
     type Response = ();
-    async fn unreliable_send(
+    fn unreliable_send(
         &mut self,
         peer: NetworkPublicKey,
         message: &WorkerPrimaryMessage,
@@ -257,7 +254,7 @@ impl UnreliableNetwork<WorkerPrimaryMessage> for P2pNetwork {
         let message = message.to_owned();
         let f =
             move |peer| async move { WorkerToPrimaryClient::new(peer).send_message(message).await };
-        self.unreliable_send(peer, f).await
+        self.unreliable_send(peer, f)
     }
 }
 
@@ -283,10 +280,9 @@ impl ReliableNetwork<WorkerPrimaryMessage> for P2pNetwork {
 // Worker-to-Worker
 //
 
-#[async_trait]
 impl UnreliableNetwork<WorkerMessage> for P2pNetwork {
     type Response = ();
-    async fn unreliable_send(
+    fn unreliable_send(
         &mut self,
         peer: NetworkPublicKey,
         message: &WorkerMessage,
@@ -294,7 +290,7 @@ impl UnreliableNetwork<WorkerMessage> for P2pNetwork {
         let message = message.to_owned();
         let f =
             move |peer| async move { WorkerToWorkerClient::new(peer).send_message(message).await };
-        self.unreliable_send(peer, f).await
+        self.unreliable_send(peer, f)
     }
 }
 
@@ -316,10 +312,9 @@ impl ReliableNetwork<WorkerMessage> for P2pNetwork {
     }
 }
 
-#[async_trait]
 impl UnreliableNetwork<WorkerBatchRequest> for P2pNetwork {
     type Response = WorkerBatchResponse;
-    async fn unreliable_send(
+    fn unreliable_send(
         &mut self,
         peer: NetworkPublicKey,
         message: &WorkerBatchRequest,
@@ -330,7 +325,7 @@ impl UnreliableNetwork<WorkerBatchRequest> for P2pNetwork {
                 .request_batches(message)
                 .await
         };
-        self.unreliable_send(peer, f).await
+        self.unreliable_send(peer, f)
     }
 }
 

--- a/primary/src/block_remover.rs
+++ b/primary/src/block_remover.rs
@@ -557,7 +557,8 @@ impl BlockRemover {
             let message = PrimaryWorkerMessage::DeleteBatches(batch_ids.clone());
 
             // send the request
-            self.worker_network
+            let _ = self
+                .worker_network
                 .unreliable_send(worker_name.clone(), &message)
                 .await;
 

--- a/primary/src/block_remover.rs
+++ b/primary/src/block_remover.rs
@@ -559,8 +559,7 @@ impl BlockRemover {
             // send the request
             let _ = self
                 .worker_network
-                .unreliable_send(worker_name.clone(), &message)
-                .await;
+                .unreliable_send(worker_name.clone(), &message);
 
             debug!(
                 "Sending DeleteBatches request for batch ids {:?} to worker {}",

--- a/primary/src/block_synchronizer/mod.rs
+++ b/primary/src/block_synchronizer/mod.rs
@@ -900,7 +900,7 @@ impl BlockSynchronizer {
 
             let message =
                 PrimaryWorkerMessage::Synchronize(batch_ids.clone(), primary_peer_name.clone());
-            self.network.unreliable_send(worker_name, &message).await;
+            let _ = self.network.unreliable_send(worker_name, &message).await;
 
             debug!(
                 "Sent request for batch ids {:?} to worker id {}",

--- a/primary/src/block_synchronizer/mod.rs
+++ b/primary/src/block_synchronizer/mod.rs
@@ -832,9 +832,7 @@ impl BlockSynchronizer {
             .map(|(name, _address, network_key)| (name, network_key))
             .unzip();
 
-        self.network
-            .unreliable_broadcast(network_keys.clone(), &message)
-            .await;
+        self.network.unreliable_broadcast(network_keys, &message);
 
         keys
     }
@@ -900,7 +898,7 @@ impl BlockSynchronizer {
 
             let message =
                 PrimaryWorkerMessage::Synchronize(batch_ids.clone(), primary_peer_name.clone());
-            let _ = self.network.unreliable_send(worker_name, &message).await;
+            let _ = self.network.unreliable_send(worker_name, &message);
 
             debug!(
                 "Sent request for batch ids {:?} to worker id {}",

--- a/primary/src/block_waiter.rs
+++ b/primary/src/block_waiter.rs
@@ -755,10 +755,7 @@ impl<SynchronizerHandler: Handler + Send + Sync + 'static> BlockWaiter<Synchroni
 
                 let message = PrimaryWorkerMessage::RequestBatch(digest);
 
-                let _ = self
-                    .worker_network
-                    .unreliable_send(worker_name, &message)
-                    .await;
+                let _ = self.worker_network.unreliable_send(worker_name, &message);
             }
 
             // add the receiver to a vector to poll later

--- a/primary/src/block_waiter.rs
+++ b/primary/src/block_waiter.rs
@@ -755,7 +755,8 @@ impl<SynchronizerHandler: Handler + Send + Sync + 'static> BlockWaiter<Synchroni
 
                 let message = PrimaryWorkerMessage::RequestBatch(digest);
 
-                self.worker_network
+                let _ = self
+                    .worker_network
                     .unreliable_send(worker_name, &message)
                     .await;
             }

--- a/primary/src/header_waiter.rs
+++ b/primary/src/header_waiter.rs
@@ -232,7 +232,7 @@ impl HeaderWaiter {
 
                                 // TODO [issue #423]: This network transmission needs to be reliable: the worker may crash-recover.
                                 let message = PrimaryWorkerMessage::Synchronize(digests, author.clone());
-                                let _ = self.network.unreliable_send(worker_name, &message).await;
+                                let _ = self.network.unreliable_send(worker_name, &message);
                             }
                         }
 
@@ -272,7 +272,7 @@ impl HeaderWaiter {
                             }
                             if !requires_sync.is_empty() {
                                 let message = PrimaryMessage::CertificatesRequest(requires_sync, self.name.clone());
-                                let _ = self.network.unreliable_send(self.committee.network_key(&author).unwrap(), &message).await;
+                                let _ = self.network.unreliable_send(self.committee.network_key(&author).unwrap(), &message);
                             }
                         }
                     }
@@ -316,7 +316,7 @@ impl HeaderWaiter {
                             .map(|(_, _, network_key)| network_key)
                             .collect();
                         let message = PrimaryMessage::CertificatesRequest(retry, self.name.clone());
-                        self.network.lucky_broadcast(network_keys, &message, self.sync_retry_nodes).await;
+                        self.network.lucky_broadcast(network_keys, &message, self.sync_retry_nodes);
                     }
                     // Reschedule the timer.
                     timer.as_mut().reset(Instant::now() + Duration::from_millis(TIMER_RESOLUTION));

--- a/primary/src/header_waiter.rs
+++ b/primary/src/header_waiter.rs
@@ -232,7 +232,7 @@ impl HeaderWaiter {
 
                                 // TODO [issue #423]: This network transmission needs to be reliable: the worker may crash-recover.
                                 let message = PrimaryWorkerMessage::Synchronize(digests, author.clone());
-                                self.network.unreliable_send(worker_name, &message).await;
+                                let _ = self.network.unreliable_send(worker_name, &message).await;
                             }
                         }
 
@@ -272,7 +272,7 @@ impl HeaderWaiter {
                             }
                             if !requires_sync.is_empty() {
                                 let message = PrimaryMessage::CertificatesRequest(requires_sync, self.name.clone());
-                                self.network.unreliable_send(self.committee.network_key(&author).unwrap(), &message).await;
+                                let _ = self.network.unreliable_send(self.committee.network_key(&author).unwrap(), &message).await;
                             }
                         }
                     }

--- a/primary/src/helper.rs
+++ b/primary/src/helper.rs
@@ -158,8 +158,7 @@ impl Helper {
                 };
                 let _ = self
                     .primary_network
-                    .unreliable_send(self.committee.network_key(&origin).unwrap(), &message)
-                    .await;
+                    .unreliable_send(self.committee.network_key(&origin).unwrap(), &message);
 
                 return Err(HelperError::StoreError(err));
             }
@@ -197,8 +196,7 @@ impl Helper {
         };
         let _ = self
             .primary_network
-            .unreliable_send(self.committee.network_key(&origin).unwrap(), &message)
-            .await;
+            .unreliable_send(self.committee.network_key(&origin).unwrap(), &message);
 
         Ok(())
     }
@@ -247,16 +245,14 @@ impl Helper {
 
             let _ = self
                 .primary_network
-                .unreliable_send(self.committee.network_key(&origin).unwrap(), &message)
-                .await;
+                .unreliable_send(self.committee.network_key(&origin).unwrap(), &message);
         } else {
             for certificate in certificates.into_iter().flatten() {
                 // TODO: Remove this deserialization-serialization in the critical path.
                 let message = PrimaryMessage::Certificate(certificate);
                 let _ = self
                     .primary_network
-                    .unreliable_send(self.committee.network_key(&origin).unwrap(), &message)
-                    .await;
+                    .unreliable_send(self.committee.network_key(&origin).unwrap(), &message);
             }
         }
 

--- a/primary/src/helper.rs
+++ b/primary/src/helper.rs
@@ -156,7 +156,8 @@ impl Helper {
                     payload_availability: result,
                     from: self.name.clone(),
                 };
-                self.primary_network
+                let _ = self
+                    .primary_network
                     .unreliable_send(self.committee.network_key(&origin).unwrap(), &message)
                     .await;
 
@@ -194,7 +195,8 @@ impl Helper {
             payload_availability: result,
             from: self.name.clone(),
         };
-        self.primary_network
+        let _ = self
+            .primary_network
             .unreliable_send(self.committee.network_key(&origin).unwrap(), &message)
             .await;
 
@@ -243,14 +245,16 @@ impl Helper {
                 from: self.name.clone(),
             };
 
-            self.primary_network
+            let _ = self
+                .primary_network
                 .unreliable_send(self.committee.network_key(&origin).unwrap(), &message)
                 .await;
         } else {
             for certificate in certificates.into_iter().flatten() {
                 // TODO: Remove this deserialization-serialization in the critical path.
                 let message = PrimaryMessage::Certificate(certificate);
-                self.primary_network
+                let _ = self
+                    .primary_network
                     .unreliable_send(self.committee.network_key(&origin).unwrap(), &message)
                     .await;
             }

--- a/primary/src/state_handler.rs
+++ b/primary/src/state_handler.rs
@@ -82,7 +82,7 @@ impl StateHandler {
                 .map(|x| x.name)
                 .collect();
             let message = PrimaryWorkerMessage::Cleanup(round);
-            self.network.unreliable_broadcast(addresses, &message).await;
+            self.network.unreliable_broadcast(addresses, &message);
         }
     }
 

--- a/worker/src/synchronizer.rs
+++ b/worker/src/synchronizer.rs
@@ -195,7 +195,7 @@ impl Synchronizer {
                             // TODO: restore ability to cancel these requests when primary->worker RPCs are
                             // made synchronous and this one becomes a child of those.
                             let message = WorkerBatchRequest{digests: missing.into_iter().collect::<Vec<_>>() };
-                            if let Ok(request) = self.network.unreliable_send(worker_name, &message).await {
+                            if let Ok(request) = self.network.unreliable_send(worker_name, &message) {
                                 waiting.push(request);
                             }
                         } else {
@@ -338,7 +338,9 @@ impl Synchronizer {
                         let message = WorkerBatchRequest{digests: retry};
                         for fut in self.network
                             .lucky_broadcast(names, &message, self.sync_retry_nodes)
-                            .await.into_iter().flatten() {
+                            .into_iter()
+                            .flatten()
+                        {
                             waiting.push(fut);
                         }
                     }


### PR DESCRIPTION
Re-introduce the fix from #940 that was unintentionally reverted while migrating to anemo.