### PR TITLE
Support range synchronization of missing certificates

### DIFF
--- a/primary/src/core.rs
+++ b/primary/src/core.rs
@@ -416,6 +416,10 @@ impl Core {
             .await
             .map_err(|_| DagError::ShuttingDown)?;
 
+        // Checks if there are too many missing rounds locally. If yes, start a process to catch up certificates
+        // in the missing rounds.
+        self.synchronizer.maybe_catch_up(certificate.round()).await;
+
         // Process the header embedded in the certificate if we haven't already voted for it (if we already
         // voted, it means we already processed it). Since this header got certified, we are sure that all
         // the data it refers to (ie. its payload and its parents) are available. We can thus continue the

--- a/primary/src/core.rs
+++ b/primary/src/core.rs
@@ -416,10 +416,6 @@ impl Core {
             .await
             .map_err(|_| DagError::ShuttingDown)?;
 
-        // Checks if there are too many missing rounds locally. If yes, start a process to catch up certificates
-        // in the missing rounds.
-        self.synchronizer.maybe_catch_up(certificate.round()).await;
-
         // Process the header embedded in the certificate if we haven't already voted for it (if we already
         // voted, it means we already processed it). Since this header got certified, we are sure that all
         // the data it refers to (ie. its payload and its parents) are available. We can thus continue the

--- a/primary/src/helper.rs
+++ b/primary/src/helper.rs
@@ -282,9 +282,9 @@ impl Helper {
             certificate_ids: result,
             from: self.name.clone(),
         };
-        self.primary_network
-            .unreliable_send(self.committee.network_key(&origin).unwrap(), &message)
-            .await;
+        let _ = self
+            .primary_network
+            .unreliable_send(self.committee.network_key(&origin).unwrap(), &message);
 
         Ok(())
     }

--- a/primary/src/metrics.rs
+++ b/primary/src/metrics.rs
@@ -297,6 +297,8 @@ pub struct PrimaryMetrics {
     pub waiting_elements_certificate_waiter: IntGaugeVec,
     /// Number of votes that were requested but not sent due to previously having voted differently
     pub votes_dropped_equivocation_protection: IntCounterVec,
+    /// Number of times range sync is started to catch up missing rounds
+    pub range_sync_started: IntCounterVec,
 }
 
 impl PrimaryMetrics {
@@ -418,6 +420,13 @@ impl PrimaryMetrics {
                 "votes_dropped_equivocation_protection",
                 "Number of votes that were requested but not sent due to previously having voted differently",
                 &["epoch", "source"],
+                registry
+            )
+            .unwrap(),
+            range_sync_started: register_int_counter_vec_with_registry!(
+                "range_sync_started",
+                "Number of times range sync is started to catch up missing rounds",
+                &["epoch"],
                 registry
             )
             .unwrap(),

--- a/primary/src/primary.rs
+++ b/primary/src/primary.rs
@@ -492,6 +492,11 @@ impl PrimaryToPrimary for PrimaryReceiverHandler {
                 .send(message)
                 .await
                 .map_err(|_| DagError::ShuttingDown),
+            PrimaryMessage::CertificatesRangeRequest { .. } => self
+                .tx_helper_requests
+                .send(message)
+                .await
+                .map_err(|_| DagError::ShuttingDown),
             PrimaryMessage::CertificatesRangeResponse {
                 certificate_ids,
                 from,

--- a/primary/src/primary.rs
+++ b/primary/src/primary.rs
@@ -249,6 +249,7 @@ impl Primary {
             payload_store.clone(),
             /* tx_header_waiter */ tx_sync_headers,
             /* tx_certificate_waiter */ tx_sync_certificates,
+            tx_get_block_commands.clone(),
             dag.clone(),
         );
 
@@ -294,6 +295,8 @@ impl Primary {
             parameters
                 .block_synchronizer
                 .handler_certificate_deliver_timeout,
+            (**committee.load()).clone(),
+            node_metrics.clone(),
         ));
 
         // Retrieves a block's data by contacting the worker nodes that contain the

--- a/primary/src/synchronizer.rs
+++ b/primary/src/synchronizer.rs
@@ -15,9 +15,6 @@ use types::{
     Round,
 };
 
-/// The number of missing rounds when a catch up process using range synchronization should be started.
-const MISSING_ROUNDS_CATCH_UP_THRESHOLD: Round = 2;
-
 #[cfg(test)]
 #[path = "tests/synchronizer_tests.rs"]
 pub mod synchronizer_tests;
@@ -175,10 +172,12 @@ impl Synchronizer {
 
     /// Checks if this primary is missing > 2 rounds of certificates and needs to start a range sync to catch up.
     /// Returns whether a catch up process is started. Does not block on finishing the catch up process.
-    pub async fn maybe_catch_up(&self, cert_round: Round) -> bool {
+    /// NOTE: this needs to be called in process_certificate(), but currently we do not.
+    #[allow(dead_code)]
+    pub async fn maybe_catch_up(&self, cert_round: Round, threshold: Round) -> bool {
         let latest_round = self.certificate_store.last_round_number().unwrap_or(0);
         let round_lag = cert_round.saturating_sub(latest_round);
-        if round_lag <= MISSING_ROUNDS_CATCH_UP_THRESHOLD {
+        if round_lag <= threshold {
             // No catch up is needed.
             return false;
         }

--- a/primary/src/tests/certificate_waiter_tests.rs
+++ b/primary/src/tests/certificate_waiter_tests.rs
@@ -33,6 +33,8 @@ async fn process_certificate_missing_parents_in_reverse() {
     let (tx_sync_headers, rx_sync_headers) = test_utils::test_channel!(1);
     // synchronizer to certificate waiter
     let (tx_sync_certificates, rx_sync_certificates) = test_utils::test_channel!(1);
+    // synchronizer to block waiter: use a large queue since there is no consumer
+    let (tx_get_block_commands, _rx_get_block_commands) = test_utils::test_channel!(1000);
     // primary messages
     let (tx_primary_messages, rx_primary_messages) = test_utils::test_channel!(1);
     // header waiter to primary
@@ -60,6 +62,7 @@ async fn process_certificate_missing_parents_in_reverse() {
         payload_store.clone(),
         /* tx_header_waiter */ tx_sync_headers,
         /* tx_certificate_waiter */ tx_sync_certificates,
+        tx_get_block_commands,
         None,
     );
 
@@ -187,6 +190,8 @@ async fn process_certificate_check_gc_fires() {
     let (tx_sync_headers, rx_sync_headers) = test_utils::test_channel!(1);
     // synchronizer to certificate waiter
     let (tx_sync_certificates, rx_sync_certificates) = test_utils::test_channel!(1);
+    // synchronizer to block waiter: use a large queue since there is no consumer
+    let (tx_get_block_commands, _rx_get_block_commands) = test_utils::test_channel!(1000);
     // primary messages
     let (tx_primary_messages, rx_primary_messages) = test_utils::test_channel!(1);
     // header waiter to primary
@@ -214,6 +219,7 @@ async fn process_certificate_check_gc_fires() {
         payload_store.clone(),
         /* tx_header_waiter */ tx_sync_headers,
         /* tx_certificate_waiter */ tx_sync_certificates,
+        tx_get_block_commands,
         None,
     );
 

--- a/primary/src/tests/core_tests.rs
+++ b/primary/src/tests/core_tests.rs
@@ -29,6 +29,7 @@ async fn process_header() {
         watch::channel(ReconfigureNotification::NewEpoch(committee.clone()));
     let (tx_sync_headers, _rx_sync_headers) = test_utils::test_channel!(1);
     let (tx_sync_certificates, _rx_sync_certificates) = test_utils::test_channel!(1);
+    let (tx_get_block_commands, _rx_get_block_commands) = test_utils::test_channel!(1);
     let (tx_primary_messages, rx_primary_messages) = test_utils::test_channel!(1);
     let (_tx_headers_loopback, rx_headers_loopback) = test_utils::test_channel!(1);
     let (_tx_certificates_loopback, rx_certificates_loopback) = test_utils::test_channel!(1);
@@ -56,6 +57,7 @@ async fn process_header() {
         payload_store,
         /* tx_header_waiter */ tx_sync_headers,
         /* tx_certificate_waiter */ tx_sync_certificates,
+        tx_get_block_commands,
         None,
     );
 
@@ -157,6 +159,7 @@ async fn process_header_missing_parent() {
     let (_, rx_reconfigure) = watch::channel(ReconfigureNotification::NewEpoch(committee.clone()));
     let (tx_sync_headers, _rx_sync_headers) = test_utils::test_channel!(1);
     let (tx_sync_certificates, _rx_sync_certificates) = test_utils::test_channel!(1);
+    let (tx_get_block_commands, _rx_get_block_commands) = test_utils::test_channel!(1);
     let (tx_primary_messages, rx_primary_messages) = test_utils::test_channel!(1);
     let (_tx_headers_loopback, rx_headers_loopback) = test_utils::test_channel!(1);
     let (_tx_certificates_loopback, rx_certificates_loopback) = test_utils::test_channel!(1);
@@ -176,6 +179,7 @@ async fn process_header_missing_parent() {
         payload_store.clone(),
         /* tx_header_waiter */ tx_sync_headers,
         /* tx_certificate_waiter */ tx_sync_certificates,
+        tx_get_block_commands,
         None,
     );
 
@@ -245,6 +249,7 @@ async fn process_header_missing_payload() {
     let (_, rx_reconfigure) = watch::channel(ReconfigureNotification::NewEpoch(committee.clone()));
     let (tx_sync_headers, _rx_sync_headers) = test_utils::test_channel!(1);
     let (tx_sync_certificates, _rx_sync_certificates) = test_utils::test_channel!(1);
+    let (tx_get_block_commands, _rx_get_block_commands) = test_utils::test_channel!(1);
     let (tx_primary_messages, rx_primary_messages) = test_utils::test_channel!(1);
     let (_tx_headers_loopback, rx_headers_loopback) = test_utils::test_channel!(1);
     let (_tx_certificates_loopback, rx_certificates_loopback) = test_utils::test_channel!(1);
@@ -264,6 +269,7 @@ async fn process_header_missing_payload() {
         payload_store.clone(),
         /* tx_header_waiter */ tx_sync_headers,
         /* tx_certificate_waiter */ tx_sync_certificates,
+        tx_get_block_commands,
         None,
     );
 
@@ -334,6 +340,7 @@ async fn process_votes() {
         watch::channel(ReconfigureNotification::NewEpoch(committee.clone()));
     let (tx_sync_headers, _rx_sync_headers) = test_utils::test_channel!(1);
     let (tx_sync_certificates, _rx_sync_certificates) = test_utils::test_channel!(1);
+    let (tx_get_block_commands, _rx_get_block_commands) = test_utils::test_channel!(1);
     let (tx_primary_messages, rx_primary_messages) = test_utils::test_channel!(1);
     let (_tx_headers_loopback, rx_headers_loopback) = test_utils::test_channel!(1);
     let (_tx_certificates_loopback, rx_certificates_loopback) = test_utils::test_channel!(1);
@@ -353,6 +360,7 @@ async fn process_votes() {
         payload_store.clone(),
         /* tx_header_waiter */ tx_sync_headers,
         /* tx_certificate_waiter */ tx_sync_certificates,
+        tx_get_block_commands,
         None,
     );
 
@@ -454,6 +462,7 @@ async fn process_certificates() {
         watch::channel(ReconfigureNotification::NewEpoch(committee.clone()));
     let (tx_sync_headers, _rx_sync_headers) = test_utils::test_channel!(1);
     let (tx_sync_certificates, _rx_sync_certificates) = test_utils::test_channel!(1);
+    let (tx_get_block_commands, _rx_get_block_commands) = test_utils::test_channel!(1);
     let (tx_primary_messages, rx_primary_messages) = test_utils::test_channel!(3);
     let (_tx_headers_loopback, rx_headers_loopback) = test_utils::test_channel!(1);
     let (_tx_certificates_loopback, rx_certificates_loopback) = test_utils::test_channel!(1);
@@ -473,6 +482,7 @@ async fn process_certificates() {
         payload_store.clone(),
         /* tx_header_waiter */ tx_sync_headers,
         /* tx_certificate_waiter */ tx_sync_certificates,
+        tx_get_block_commands,
         None,
     );
 
@@ -572,6 +582,7 @@ async fn shutdown_core() {
         watch::channel(ReconfigureNotification::NewEpoch(committee.clone()));
     let (tx_sync_headers, _rx_sync_headers) = test_utils::test_channel!(1);
     let (tx_sync_certificates, _rx_sync_certificates) = test_utils::test_channel!(1);
+    let (tx_get_block_commands, _rx_get_block_commands) = test_utils::test_channel!(1);
     let (_tx_primary_messages, rx_primary_messages) = test_utils::test_channel!(1);
     let (_tx_headers_loopback, rx_headers_loopback) = test_utils::test_channel!(1);
     let (_tx_certificates_loopback, rx_certificates_loopback) = test_utils::test_channel!(1);
@@ -591,6 +602,7 @@ async fn shutdown_core() {
         payload_store,
         /* tx_header_waiter */ tx_sync_headers,
         /* tx_certificate_waiter */ tx_sync_certificates,
+        tx_get_block_commands,
         None,
     );
 
@@ -650,6 +662,7 @@ async fn reconfigure_core() {
         watch::channel(ReconfigureNotification::NewEpoch(committee.clone()));
     let (tx_sync_headers, _rx_sync_headers) = test_utils::test_channel!(1);
     let (tx_sync_certificates, _rx_sync_certificates) = test_utils::test_channel!(1);
+    let (tx_get_block_commands, _rx_get_block_commands) = test_utils::test_channel!(1);
     let (tx_primary_messages, rx_primary_messages) = test_utils::test_channel!(1);
     let (_tx_headers_loopback, rx_headers_loopback) = test_utils::test_channel!(1);
     let (_tx_certificates_loopback, rx_certificates_loopback) = test_utils::test_channel!(1);
@@ -678,6 +691,7 @@ async fn reconfigure_core() {
         payload_store,
         /* tx_header_waiter */ tx_sync_headers,
         /* tx_certificate_waiter */ tx_sync_certificates,
+        tx_get_block_commands,
         None,
     );
 

--- a/primary/src/tests/synchronizer_tests.rs
+++ b/primary/src/tests/synchronizer_tests.rs
@@ -19,6 +19,7 @@ async fn deliver_certificate_using_dag() {
     let (_, certificates_store, payload_store) = create_db_stores();
     let (tx_header_waiter, _rx_header_waiter) = test_utils::test_channel!(1);
     let (tx_certificate_waiter, _rx_certificate_waiter) = test_utils::test_channel!(1);
+    let (tx_get_block_commands, _rx_get_block_commands) = test_utils::test_channel!(1);
     let (_tx_consensus, rx_consensus) = test_utils::test_channel!(1);
 
     let consensus_metrics = Arc::new(ConsensusMetrics::new(&Registry::new()));
@@ -31,6 +32,7 @@ async fn deliver_certificate_using_dag() {
         payload_store,
         tx_header_waiter,
         tx_certificate_waiter,
+        tx_get_block_commands,
         Some(dag.clone()),
     );
 
@@ -76,6 +78,7 @@ async fn deliver_certificate_using_store() {
     let (_, certificates_store, payload_store) = create_db_stores();
     let (tx_header_waiter, _rx_header_waiter) = test_utils::test_channel!(1);
     let (tx_certificate_waiter, _rx_certificate_waiter) = test_utils::test_channel!(1);
+    let (tx_get_block_commands, _rx_get_block_commands) = test_utils::test_channel!(1);
 
     let mut synchronizer = Synchronizer::new(
         name,
@@ -84,6 +87,7 @@ async fn deliver_certificate_using_store() {
         payload_store,
         tx_header_waiter,
         tx_certificate_waiter,
+        tx_get_block_commands,
         None,
     );
 
@@ -129,6 +133,7 @@ async fn deliver_certificate_not_found_parents() {
     let (_, certificates_store, payload_store) = create_db_stores();
     let (tx_header_waiter, _rx_header_waiter) = test_utils::test_channel!(1);
     let (tx_certificate_waiter, mut rx_certificate_waiter) = test_utils::test_channel!(1);
+    let (tx_get_block_commands, _rx_get_block_commands) = test_utils::test_channel!(1);
 
     let mut synchronizer = Synchronizer::new(
         name,
@@ -137,6 +142,7 @@ async fn deliver_certificate_not_found_parents() {
         payload_store,
         tx_header_waiter,
         tx_certificate_waiter,
+        tx_get_block_commands,
         None,
     );
 


### PR DESCRIPTION
Part 2/n of MystenLabs/sui#5268

This PR continues from MystenLabs/narwhal#848, by adding the request handler for range sync, and the logic to kick start range sync when more than 2 rounds of certificates are missing. This number of missing rounds threshold is a constant.

Pseudo code for whether to start range sync:
```
for each certificate received by primary
    if there are too many missing rounds between local store and the received certificate
        kick start the range sync process, without blocking additional processing at primary
```

Range sync logic is now placed into a few different components:
- `Synchronizer`: checks if range sync should be started, and sends a message to block waiter.
- `BlockWaiter`: runs range sync without blocking other operations.
- `BlockSynchronizerHandler`: synchronize certificate digests in a range of rounds, then synchronize certificates for the received digests.
- `BlockSynchronizer`: (implemented in MystenLabs/narwhal#848) drives the protocol for getting certificate digests in a range of rounds
- `Helper`: handles range sync requests, fetches and returns certificate digests.

For now, range synchronization is disabled. It will be enabled in `process_certificate()` later once we finalize the plan to refactor synchronization logic.