### PR TITLE
Add primary->worker Synchronize RPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2691,6 +2691,7 @@ version = "0.1.0"
 dependencies = [
  "anemo",
  "anemo-tower",
+ "anyhow",
  "arc-swap",
  "async-trait",
  "bincode",
@@ -2711,6 +2712,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "tap",
+ "telemetry-subscribers",
  "tempfile",
  "tokio",
  "tokio-stream",

--- a/node/src/generate_format.rs
+++ b/node/src/generate_format.rs
@@ -14,7 +14,7 @@ use std::{fs::File, io::Write};
 use structopt::{clap::arg_enum, StructOpt};
 use types::{
     Batch, BatchDigest, Certificate, CertificateDigest, Header, HeaderDigest,
-    ReconfigureNotification, WorkerPrimaryError, WorkerPrimaryMessage,
+    ReconfigureNotification, WorkerPrimaryError, WorkerPrimaryMessage, WorkerSynchronizeMessage,
 };
 
 fn get_registry() -> Result<Registry> {
@@ -114,7 +114,10 @@ fn get_registry() -> Result<Registry> {
     let cleanup = PrimaryWorkerMessage::Cleanup(1u64);
     let request_batch = PrimaryWorkerMessage::RequestBatch(BatchDigest([0u8; 32]));
     let delete_batch = PrimaryWorkerMessage::DeleteBatches(vec![BatchDigest([0u8; 32])]);
-    let sync = PrimaryWorkerMessage::Synchronize(vec![BatchDigest([0u8; 32])], pk);
+    let sync = WorkerSynchronizeMessage {
+        digests: vec![BatchDigest([0u8; 32])],
+        target: pk,
+    };
     let epoch_change =
         PrimaryWorkerMessage::Reconfigure(ReconfigureNotification::NewEpoch(committee.clone()));
     let update_committee =

--- a/node/tests/staged/narwhal.yaml
+++ b/node/tests/staged/narwhal.yaml
@@ -68,23 +68,17 @@ HeaderDigest:
 PrimaryWorkerMessage:
   ENUM:
     0:
-      Synchronize:
-        TUPLE:
-          - SEQ:
-              TYPENAME: BatchDigest
-          - STR
-    1:
       Cleanup:
         NEWTYPE: U64
-    2:
+    1:
       Reconfigure:
         NEWTYPE:
           TYPENAME: ReconfigureNotification
-    3:
+    2:
       RequestBatch:
         NEWTYPE:
           TYPENAME: BatchDigest
-    4:
+    3:
       DeleteBatches:
         NEWTYPE:
           SEQ:
@@ -154,4 +148,10 @@ WorkerPrimaryMessage:
       Reconfigure:
         NEWTYPE:
           TYPENAME: ReconfigureNotification
+WorkerSynchronizeMessage:
+  STRUCT:
+    - digests:
+        SEQ:
+          TYPENAME: BatchDigest
+    - target: STR
 

--- a/primary/src/block_synchronizer/mod.rs
+++ b/primary/src/block_synchronizer/mod.rs
@@ -36,8 +36,8 @@ use tokio::{
 };
 use tracing::{debug, error, info, instrument, trace, warn};
 use types::{
-    metered_channel, BatchDigest, Certificate, CertificateDigest, PrimaryWorkerMessage,
-    ReconfigureNotification, Round,
+    metered_channel, BatchDigest, Certificate, CertificateDigest, ReconfigureNotification, Round,
+    WorkerSynchronizeMessage,
 };
 
 use self::responses::{AvailabilityResponse, CertificateDigestsResponse};
@@ -896,8 +896,10 @@ impl BlockSynchronizer {
                 .expect("Worker id not found")
                 .name;
 
-            let message =
-                PrimaryWorkerMessage::Synchronize(batch_ids.clone(), primary_peer_name.clone());
+            let message = WorkerSynchronizeMessage {
+                digests: batch_ids.clone(),
+                target: primary_peer_name.clone(),
+            };
             let _ = self.network.unreliable_send(worker_name, &message);
 
             debug!(

--- a/primary/src/block_synchronizer/mod.rs
+++ b/primary/src/block_synchronizer/mod.rs
@@ -897,14 +897,14 @@ impl BlockSynchronizer {
                 .name;
 
             let message = WorkerSynchronizeMessage {
-                digests: batch_ids.clone(),
+                digests: batch_ids,
                 target: primary_peer_name.clone(),
             };
             let _ = self.network.unreliable_send(worker_name, &message);
 
             debug!(
                 "Sent request for batch ids {:?} to worker id {}",
-                batch_ids, worker_id
+                message.digests, worker_id
             );
         }
     }

--- a/primary/src/header_waiter.rs
+++ b/primary/src/header_waiter.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use crate::{
     metrics::PrimaryMetrics,
-    primary::{PayloadToken, PrimaryMessage, PrimaryWorkerMessage},
+    primary::{PayloadToken, PrimaryMessage},
 };
 use config::{Committee, SharedWorkerCache, WorkerId};
 use crypto::PublicKey;
@@ -28,7 +28,7 @@ use types::{
     error::{DagError, DagResult},
     metered_channel::{Receiver, Sender},
     try_fut_and_permit, BatchDigest, CertificateDigest, Header, HeaderDigest,
-    ReconfigureNotification, Round,
+    ReconfigureNotification, Round, WorkerSynchronizeMessage,
 };
 
 #[cfg(test)]
@@ -231,7 +231,7 @@ impl HeaderWaiter {
                                     .name;
 
                                 // TODO [issue #423]: This network transmission needs to be reliable: the worker may crash-recover.
-                                let message = PrimaryWorkerMessage::Synchronize(digests, author.clone());
+                                let message = WorkerSynchronizeMessage{digests, target: author.clone()};
                                 let _ = self.network.unreliable_send(worker_name, &message);
                             }
                         }

--- a/primary/src/tests/block_remover_tests.rs
+++ b/primary/src/tests/block_remover_tests.rs
@@ -481,7 +481,7 @@ pub fn worker_listener(
 ) -> JoinHandle<()> {
     let pubkey = keypair.public().clone();
     println!("[{}] Setting up server", pubkey);
-    let (mut recv, network) = PrimaryToWorkerMockServer::spawn(keypair, address);
+    let (mut recv, _, network) = PrimaryToWorkerMockServer::spawn(keypair, address);
     tokio::spawn(async move {
         let _network = network;
         let message = recv.recv().await.unwrap();

--- a/primary/src/tests/block_waiter_tests.rs
+++ b/primary/src/tests/block_waiter_tests.rs
@@ -770,7 +770,7 @@ pub fn worker_listener(
     tx_batch_messages: metered_channel::Sender<BatchResult>,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
-        let (mut recv, _network) = PrimaryToWorkerMockServer::spawn(keypair, address);
+        let (mut recv, _, _network) = PrimaryToWorkerMockServer::spawn(keypair, address);
         let mut counter = 0;
         loop {
             let message = recv

--- a/types/build.rs
+++ b/types/build.rs
@@ -66,6 +66,15 @@ fn build_anemo_services(out_dir: &Path) {
                 .codec_path("anemo::rpc::codec::BincodeCodec")
                 .build(),
         )
+        .method(
+            anemo_build::manual::Method::builder()
+                .name("synchronize")
+                .route_name("Synchronize")
+                .request_type("crate::WorkerSynchronizeMessage")
+                .response_type("()")
+                .codec_path("anemo::rpc::codec::BincodeCodec")
+                .build(),
+        )
         .build();
 
     let worker_to_primary = anemo_build::manual::Service::builder()

--- a/types/src/primary.rs
+++ b/types/src/primary.rs
@@ -702,8 +702,6 @@ pub enum ReconfigureNotification {
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum PrimaryWorkerMessage {
-    /// The primary indicates that the worker need to sync the target missing batches.
-    Synchronize(Vec<BatchDigest>, /* target */ PublicKey),
     /// The primary indicates a round update.
     Cleanup(Round),
     /// Reconfigure the worker.
@@ -712,6 +710,13 @@ pub enum PrimaryWorkerMessage {
     RequestBatch(BatchDigest),
     /// Delete the batches, dictated from the provided vector of digest, from the worker node
     DeleteBatches(Vec<BatchDigest>),
+}
+
+/// Used by the primary to request that the worker sync the target missing batches.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct WorkerSynchronizeMessage {
+    pub digests: Vec<BatchDigest>,
+    pub target: PublicKey,
 }
 
 #[derive(Clone, Default, Debug, Eq, PartialEq)]

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -33,6 +33,7 @@ prometheus = "0.13.2"
 
 anemo = { git = "https://github.com/mystenlabs/anemo.git", rev = "b145cbcf4a1917197e2b9ee6a1523afdb623dbf2" }
 anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "b145cbcf4a1917197e2b9ee6a1523afdb623dbf2" }
+anyhow = "1.0.65"
 
 store = { version = "0.1.0", package = "typed-store" }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }
@@ -40,6 +41,7 @@ workspace-hack = { version = "0.1", path = "../workspace-hack" }
 [dev-dependencies]
 arc-swap = { version = "1.5.1", features = ["serde"] }
 rand = "0.8.5"
+telemetry-subscribers = "0.1.0"
 tempfile = "3.3.0"
 test-utils = { path = "../test-utils", package = "narwhal-test-utils" }
 

--- a/worker/src/handlers.rs
+++ b/worker/src/handlers.rs
@@ -268,17 +268,15 @@ impl PrimaryToWorker for PrimaryReceiverHandler {
             };
         }
 
-        // reply back immediately for the available ones
-        if !available.is_empty() {
-            // Doing this will ensure the batch id will be populated to primary even
-            // when other processes fail to do so (ex we received a batch from a peer
-            // worker and message has been missed by primary).
-            for digest in available {
-                let message = WorkerPrimaryMessage::OthersBatch(digest, self.id);
-                let _ = self.tx_primary.send(message).await.tap_err(|err| {
-                    debug!("{err:?} {}", DagError::ShuttingDown);
-                });
-            }
+        // Reply back immediately for the available ones.
+        // Doing this will ensure the batch id will be populated to primary even
+        // when other processes fail to do so (ex we received a batch from a peer
+        // worker and message has been missed by primary).
+        for digest in available {
+            let message = WorkerPrimaryMessage::OthersBatch(digest, self.id);
+            let _ = self.tx_primary.send(message).await.tap_err(|err| {
+                debug!("{err:?} {}", DagError::ShuttingDown);
+            });
         }
 
         if missing.is_empty() {

--- a/worker/src/handlers.rs
+++ b/worker/src/handlers.rs
@@ -1,12 +1,162 @@
 // Copyright (c) 2021, Facebook, Inc. and its affiliates
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
+use anyhow::Result;
 use async_trait::async_trait;
+use config::{SharedWorkerCache, WorkerId};
+use crypto::{NetworkPublicKey, PublicKey};
+use fastcrypto::Hash;
+use futures::{stream::FuturesUnordered, StreamExt};
+use network::{LuckyNetwork, P2pNetwork, UnreliableNetwork};
+use std::{collections::HashSet, time::Duration};
 use store::Store;
-use types::{
-    error::DagError, metered_channel::Sender, Batch, BatchDigest, PrimaryToWorker,
-    PrimaryWorkerMessage, WorkerMessage, WorkerToWorker,
+use tap::TapFallible;
+use tokio::{
+    sync::{oneshot, watch},
+    task::JoinHandle,
+    time::{self, Timeout},
 };
+use tracing::{debug, error, trace};
+use types::{
+    error::DagError,
+    metered_channel::{Receiver, Sender},
+    Batch, BatchDigest, PrimaryToWorker, PrimaryWorkerMessage, ReconfigureNotification,
+    WorkerBatchRequest, WorkerBatchResponse, WorkerMessage, WorkerPrimaryMessage,
+    WorkerSynchronizeMessage, WorkerToWorker,
+};
+
+#[cfg(test)]
+#[path = "tests/handlers_tests.rs"]
+pub mod handlers_tests;
+
+// Makes it possible via channels for anemo RPC handler functions to send child RPCs.
+// TODO: replace this once anemo adds support for access to the network within handlers.
+pub struct ChildRpcSender {
+    // The public key of this authority.
+    name: PublicKey,
+    // The id of this worker.
+    id: WorkerId,
+    // The worker information cache.
+    worker_cache: SharedWorkerCache,
+    // Timeout on RequestBatches RPC.
+    request_batches_timeout: Duration,
+    // Incoming RequestBatches requests to be sent out. Uses `unreliable_send` if a target is
+    // provided, or `lucky_broadcast` if a target node count is provided.
+    rx_request_batches_rpc: Receiver<(
+        Option<NetworkPublicKey>,
+        Option<usize>,
+        WorkerBatchRequest,
+        oneshot::Sender<Result<anemo::Response<WorkerBatchResponse>>>,
+    )>,
+    /// Receive reconfiguration updates.
+    rx_reconfigure: watch::Receiver<ReconfigureNotification>,
+    // Network to use for sending requests.
+    network: P2pNetwork,
+}
+
+impl ChildRpcSender {
+    #[must_use]
+    pub fn spawn(
+        name: PublicKey,
+        id: WorkerId,
+        worker_cache: SharedWorkerCache,
+        request_batches_timeout: Duration,
+        rx_request_batches_rpc: Receiver<(
+            Option<NetworkPublicKey>,
+            Option<usize>,
+            WorkerBatchRequest,
+            oneshot::Sender<Result<anemo::Response<WorkerBatchResponse>>>,
+        )>,
+        rx_reconfigure: watch::Receiver<ReconfigureNotification>,
+        network: P2pNetwork,
+    ) -> JoinHandle<()> {
+        tokio::spawn(async move {
+            Self {
+                name,
+                id,
+                worker_cache,
+                request_batches_timeout,
+                rx_request_batches_rpc,
+                rx_reconfigure,
+                network,
+            }
+            .run()
+            .await;
+        })
+    }
+
+    async fn handle_worker_batch_responses(
+        responses: Vec<Timeout<JoinHandle<Result<anemo::Response<WorkerBatchResponse>>>>>,
+        response_channel: oneshot::Sender<Result<anemo::Response<WorkerBatchResponse>>>,
+    ) {
+        let mut results: FuturesUnordered<_> = responses.into_iter().collect();
+        let mut last_result: Result<anemo::Response<WorkerBatchResponse>> = Err(anyhow::anyhow!(
+            "no WorkerBatchResponse received (or request(s) timed out)"
+        ));
+        while let Some(result) = results.next().await {
+            match result {
+                Ok(Ok(Ok(result))) => {
+                    let _ = response_channel.send(Ok(result));
+                    return;
+                }
+                Ok(Ok(Err(e))) => last_result = Err(e),
+                _ => (),
+            }
+        }
+        let _ = response_channel.send(last_result);
+    }
+
+    async fn run(&mut self) {
+        let mut inflight_requests = FuturesUnordered::new();
+        loop {
+            tokio::select! {
+                Some((target, num_nodes, request, response_channel)) = self.rx_request_batches_rpc.recv() => {
+                    if target.is_some() && num_nodes.is_some() {
+                        panic!("cannot set both target and num_nodes");
+                    }
+                    if let Some(target) = target {
+                        match self.network.unreliable_send(target, &request) {
+                            Ok(handle) => {
+                                inflight_requests.push(Self::handle_worker_batch_responses(
+                                    vec![time::timeout(self.request_batches_timeout, handle)], response_channel))
+                            },
+                            Err(e) => {
+                                let _ = response_channel.send(Err(e));
+                            },
+                        }
+                    } else if let Some(num_nodes) = num_nodes {
+                        let names = self.worker_cache.load()
+                            .others_workers(&self.name, &self.id)
+                            .into_iter()
+                            .map(|(_, info)| info.name)
+                            .collect();
+                        let handles: Vec<_> = self.network.lucky_broadcast(names, &request, num_nodes)
+                            .into_iter()
+                            .flatten()
+                            .map(|handle| time::timeout(self.request_batches_timeout, handle))
+                            .collect();
+                        if handles.is_empty() {
+                            let _ = response_channel.send(
+                                Err(anyhow::anyhow!("could not lucky_broadcast WorkerBatchRequest to any node")));
+                        } else {
+                            inflight_requests.push(Self::handle_worker_batch_responses(handles, response_channel));
+                        };
+                    } else {
+                        panic!("one of target or num_nodes must be set");
+                    }
+                },
+                result = self.rx_reconfigure.changed() => {
+                    result.expect("Committee channel dropped");
+                    if let ReconfigureNotification::Shutdown = self.rx_reconfigure.borrow().clone() {
+                        return
+                    }
+                },
+                Some(_) = inflight_requests.next() => {},
+                else => { break }
+            }
+        }
+    }
+}
 
 /// Defines how the network receiver handles incoming workers messages.
 #[derive(Clone)]
@@ -19,7 +169,7 @@ pub struct WorkerReceiverHandler {
 impl WorkerToWorker for WorkerReceiverHandler {
     async fn send_message(
         &self,
-        request: anemo::Request<types::WorkerMessage>,
+        request: anemo::Request<WorkerMessage>,
     ) -> Result<anemo::Response<()>, anemo::rpc::Status> {
         let message = request.into_body();
         match message {
@@ -34,8 +184,8 @@ impl WorkerToWorker for WorkerReceiverHandler {
     }
     async fn request_batches(
         &self,
-        request: anemo::Request<types::WorkerBatchRequest>,
-    ) -> Result<anemo::Response<types::WorkerBatchResponse>, anemo::rpc::Status> {
+        request: anemo::Request<WorkerBatchRequest>,
+    ) -> Result<anemo::Response<WorkerBatchResponse>, anemo::rpc::Status> {
         let message = request.into_body();
         // TODO [issue #7]: Do some accounting to prevent bad actors from monopolizing our resources
         // TODO: Add a limit on number of requested batches
@@ -47,14 +197,31 @@ impl WorkerToWorker for WorkerReceiverHandler {
             .into_iter()
             .flatten()
             .collect();
-        Ok(anemo::Response::new(types::WorkerBatchResponse { batches }))
+        Ok(anemo::Response::new(WorkerBatchResponse { batches }))
     }
 }
 
 /// Defines how the network receiver handles incoming primary messages.
 #[derive(Clone)]
 pub struct PrimaryReceiverHandler {
+    pub id: WorkerId,
+    // The worker information cache.
+    pub worker_cache: SharedWorkerCache,
+    pub store: Store<BatchDigest, Batch>,
+    // Number of random nodes to query when retrying batch requests.
+    pub request_batches_retry_nodes: usize,
     pub tx_synchronizer: Sender<PrimaryWorkerMessage>,
+    // Output channel to send child worker batch requests.
+    pub tx_request_batches_rpc: Sender<(
+        Option<NetworkPublicKey>,
+        Option<usize>,
+        WorkerBatchRequest,
+        oneshot::Sender<Result<anemo::Response<WorkerBatchResponse>>>,
+    )>,
+    // Output channel to send messages to primary.
+    pub tx_primary: Sender<WorkerPrimaryMessage>,
+    // Output channel to process received batches.
+    pub tx_batch_processor: Sender<Batch>,
 }
 
 #[async_trait]
@@ -72,5 +239,141 @@ impl PrimaryToWorker for PrimaryReceiverHandler {
             .map_err(|e| anemo::rpc::Status::internal(e.to_string()))?;
 
         Ok(anemo::Response::new(()))
+    }
+    async fn synchronize(
+        &self,
+        request: anemo::Request<WorkerSynchronizeMessage>,
+    ) -> Result<anemo::Response<()>, anemo::rpc::Status> {
+        let message = request.into_body();
+
+        let mut missing = HashSet::new();
+        let mut available = HashSet::new();
+
+        for digest in message.digests.iter() {
+            // Check if we already have the batch.
+            match self.store.read(*digest).await {
+                Ok(None) => {
+                    missing.insert(*digest);
+                    debug!("Requesting sync for batch {digest}");
+                }
+                Ok(Some(_)) => {
+                    available.insert(*digest);
+                    trace!("Digest {digest} already in store, nothing to sync");
+                    continue;
+                }
+                Err(e) => {
+                    error!("{e}");
+                    continue;
+                }
+            };
+        }
+
+        // reply back immediately for the available ones
+        if !available.is_empty() {
+            // Doing this will ensure the batch id will be populated to primary even
+            // when other processes fail to do so (ex we received a batch from a peer
+            // worker and message has been missed by primary).
+            for digest in available {
+                let message = WorkerPrimaryMessage::OthersBatch(digest, self.id);
+                let _ = self.tx_primary.send(message).await.tap_err(|err| {
+                    debug!("{err:?} {}", DagError::ShuttingDown);
+                });
+            }
+        }
+
+        if missing.is_empty() {
+            debug!(
+                "All batches are already available {:?} nothing to request from peers",
+                message.digests
+            );
+            return Ok(anemo::Response::new(()));
+        }
+
+        // Send sync request to a single node.
+        let worker_name = match self.worker_cache.load().worker(&message.target, &self.id) {
+            Ok(worker_info) => worker_info.name,
+            Err(e) => {
+                return Err(anemo::rpc::Status::internal(format!(
+                    "The primary asked us to sync with an unknown node: {e}"
+                )));
+            }
+        };
+
+        debug!(
+            "Sending WorkerBatchRequest message to {} for missing batches {:?}",
+            worker_name,
+            missing.clone()
+        );
+
+        // TODO: restore a metric tracking number of batches with inflight requests?
+        let (tx_batch_response, rx_batch_response) = oneshot::channel();
+        let message = WorkerBatchRequest {
+            digests: missing.iter().cloned().collect(),
+        };
+        self.tx_request_batches_rpc
+            .send((Some(worker_name), None, message, tx_batch_response))
+            .await
+            .map_err(|e| anemo::rpc::Status::internal(e.to_string()))?;
+        let response = rx_batch_response
+            .await
+            .map_err(|e| anemo::rpc::Status::internal(e.to_string()))?;
+        if let Ok(response) = response {
+            for batch in response.into_body().batches {
+                let digest = &batch.digest();
+                if missing.remove(digest) {
+                    // Only send batch to processor if we haven't received it already
+                    // from another source.
+                    if self.tx_batch_processor.send(batch).await.is_err() {
+                        // Assume error sending to processor means we're shutting down.
+                        return Err(anemo::rpc::Status::internal("shutting down"));
+                    }
+                }
+            }
+        }
+
+        if missing.is_empty() {
+            // If nothing remains to fetch, we're done.
+            return Ok(anemo::Response::new(()));
+        }
+
+        // If first request timed out or was missing batches, try broadcasting to some others.
+        // TODO: refactor this to retry forever unless RPC is canceled. This will require more
+        // invasive changes to primary code and cancellation propagation support in anemo.
+        let (tx_batch_response, rx_batch_response) = oneshot::channel();
+        let message = WorkerBatchRequest {
+            digests: missing.iter().cloned().collect(),
+        };
+        self.tx_request_batches_rpc
+            .send((
+                None,
+                Some(self.request_batches_retry_nodes),
+                message,
+                tx_batch_response,
+            ))
+            .await
+            .map_err(|e| anemo::rpc::Status::internal(e.to_string()))?;
+        let response = rx_batch_response
+            .await
+            .map_err(|e| anemo::rpc::Status::internal(e.to_string()))?;
+        if let Ok(response) = response {
+            for batch in response.into_body().batches {
+                if missing.remove(&batch.digest()) {
+                    // Only send batch to processor if we haven't received it already
+                    // from another source.
+                    if self.tx_batch_processor.send(batch).await.is_err() {
+                        // Assume error sending to processor means we're shutting down.
+                        return Err(anemo::rpc::Status::internal("shutting down"));
+                    }
+                }
+            }
+        }
+
+        if missing.is_empty() {
+            // If nothing remains to fetch, we're done.
+            return Ok(anemo::Response::new(()));
+        }
+        Err(anemo::rpc::Status::unknown(format!(
+            "Unable to retrieve batches after retry: {missing:?}"
+        )))
     }
 }

--- a/worker/src/metrics.rs
+++ b/worker/src/metrics.rs
@@ -82,8 +82,10 @@ impl Default for WorkerMetrics {
 pub struct WorkerChannelMetrics {
     /// occupancy of the channel from various handlers to the `worker::PrimaryConnector`
     pub tx_primary: IntGauge,
-    /// occupancy of the channel from the `worker::PrimaryReceiverHandler` to the `worker::Synchronizer`
+    /// occupancy of the channel from the `handlers::PrimaryReceiverHandler` to the `worker::Synchronizer`
     pub tx_synchronizer: IntGauge,
+    /// occupancy of the channel from the `handlers::PrimaryReceiverHandler` to the `handlers::ChildRpcSender`
+    pub tx_request_batches_rpc: IntGauge,
     /// occupancy of the channel from the `worker::TxReceiverhandler` to the `worker::BatchMaker`
     pub tx_batch_maker: IntGauge,
     /// occupancy of the channel from the `worker::BatchMaker` to the `worker::QuorumWaiter`
@@ -107,6 +109,11 @@ impl WorkerChannelMetrics {
             tx_synchronizer: register_int_gauge_with_registry!(
                 "tx_synchronizer",
                 "occupancy of the channel from the `worker::PrimaryReceiverHandler` to the `worker::Synchronizer`",
+                registry
+            ).unwrap(),
+            tx_request_batches_rpc: register_int_gauge_with_registry!(
+                "tx_request_batches_rpc",
+                "occupancy of the channel from the `handlers::PrimaryReceiverHandler` to the `handlers::ChildRpcSender`",
                 registry
             ).unwrap(),
             tx_batch_maker: register_int_gauge_with_registry!(

--- a/worker/src/synchronizer.rs
+++ b/worker/src/synchronizer.rs
@@ -1,115 +1,63 @@
 // Copyright (c) 2021, Facebook, Inc. and its affiliates
 // Copyright (c) 2022, Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use crate::metrics::WorkerMetrics;
-use config::{SharedCommittee, SharedWorkerCache, WorkerCache, WorkerId, WorkerIndex};
-use crypto::PublicKey;
-use fastcrypto::Hash;
-use futures::stream::{futures_unordered::FuturesUnordered, StreamExt as _};
-use network::{LuckyNetwork, P2pNetwork, UnreliableNetwork};
+
+use config::{SharedCommittee, SharedWorkerCache, WorkerCache, WorkerIndex};
+
+use network::P2pNetwork;
 use primary::PrimaryWorkerMessage;
-use std::{
-    collections::{BTreeMap, HashMap, HashSet},
-    sync::Arc,
-    time::{SystemTime, UNIX_EPOCH},
-};
+use std::{collections::BTreeMap, sync::Arc};
 use store::Store;
-use tap::{TapFallible, TapOptional};
-use tokio::{
-    sync::watch,
-    task::JoinHandle,
-    time::{sleep, Duration, Instant},
-};
-use tracing::{debug, error, info, trace, warn};
+use tap::TapOptional;
+use tokio::{sync::watch, task::JoinHandle};
+use tracing::{error, warn};
 use types::{
-    error::DagError,
     metered_channel::{Receiver, Sender},
-    Batch, BatchDigest, ReconfigureNotification, Round, WorkerBatchRequest, WorkerPrimaryError,
-    WorkerPrimaryMessage,
+    Batch, BatchDigest, ReconfigureNotification, WorkerPrimaryError, WorkerPrimaryMessage,
 };
 
 #[cfg(test)]
 #[path = "tests/synchronizer_tests.rs"]
 pub mod synchronizer_tests;
 
-/// Resolution of the timer managing retrials of sync requests (in ms).
-const TIMER_RESOLUTION: u64 = 1_000;
-
 // The `Synchronizer` is responsible to keep the worker in sync with the others.
 pub struct Synchronizer {
-    /// The public key of this authority.
-    name: PublicKey,
-    /// The id of this worker.
-    id: WorkerId,
     /// The committee information.
     committee: SharedCommittee,
     /// The worker information cache.
     worker_cache: SharedWorkerCache,
     // The persistent storage.
     store: Store<BatchDigest, Batch>,
-    /// The depth of the garbage collection.
-    gc_depth: Round,
-    /// The delay to wait before re-trying to send sync requests.
-    sync_retry_delay: Duration,
-    /// Determine with how many nodes to sync when re-trying to send sync-requests. These nodes
-    /// are picked at random from the committee.
-    sync_retry_nodes: usize,
     /// Input channel to receive the commands from the primary.
     rx_message: Receiver<PrimaryWorkerMessage>,
     /// A network sender to send requests to the other workers.
     network: P2pNetwork,
-    /// Loosely keep track of the primary's round number (only used for cleanup).
-    round: Round,
-    /// Keeps the digests (of batches) that are waiting to be processed by the primary. Their
-    /// processing will resume when we get the missing batches in the store or we no longer need them.
-    /// It also keeps the round number and a time stamp (`u128`) of each request we sent.
-    pending: HashMap<BatchDigest, (Round, u128)>,
     /// Send reconfiguration update to other tasks.
     tx_reconfigure: watch::Sender<ReconfigureNotification>,
     /// Output channel to send out the batch requests.
     tx_primary: Sender<WorkerPrimaryMessage>,
-    /// Output channel to process received batches.
-    tx_batch_processor: Sender<Batch>,
-    /// Metrics handler
-    metrics: Arc<WorkerMetrics>,
 }
 
 impl Synchronizer {
     #[must_use]
     pub fn spawn(
-        name: PublicKey,
-        id: WorkerId,
         committee: SharedCommittee,
         worker_cache: SharedWorkerCache,
         store: Store<BatchDigest, Batch>,
-        gc_depth: Round,
-        sync_retry_delay: Duration,
-        sync_retry_nodes: usize,
         rx_message: Receiver<PrimaryWorkerMessage>,
         tx_reconfigure: watch::Sender<ReconfigureNotification>,
         tx_primary: Sender<WorkerPrimaryMessage>,
-        tx_batch_processor: Sender<Batch>,
-        metrics: Arc<WorkerMetrics>,
         network: P2pNetwork,
     ) -> JoinHandle<()> {
         tokio::spawn(async move {
             Self {
-                name,
-                id,
                 committee,
                 worker_cache,
                 store,
-                gc_depth,
-                sync_retry_delay,
-                sync_retry_nodes,
                 rx_message,
                 network,
-                round: Round::default(),
-                pending: HashMap::new(),
                 tx_reconfigure,
                 tx_primary,
-                tx_batch_processor,
-                metrics,
             }
             .run()
             .await;
@@ -118,101 +66,12 @@ impl Synchronizer {
 
     /// Main loop listening to the primary's messages.
     async fn run(&mut self) {
-        let mut waiting = FuturesUnordered::new();
-
-        let timer = sleep(Duration::from_millis(TIMER_RESOLUTION));
-        tokio::pin!(timer);
-
         loop {
             tokio::select! {
                 // Handle primary's messages.
                 Some(message) = self.rx_message.recv() => match message {
-                    PrimaryWorkerMessage::Synchronize(digests, target) => {
-                        let mut missing = HashSet::new();
-                        let mut available = HashSet::new();
-
-                        for digest in digests.iter() {
-                            // Ensure we do not send the same sync request twice.
-                            if self.pending.contains_key(digest) {
-                                continue;
-                            }
-
-                            // Check if we received the batch in the meantime.
-                            match self.store.read(*digest).await {
-                                Ok(None) => {
-                                    missing.insert(*digest);
-                                    debug!("Requesting sync for batch {digest}");
-                                },
-                                Ok(Some(_)) => {
-                                    // The batch arrived in the meantime: no need to request it.
-                                    available.insert(*digest);
-                                    trace!("Digest {digest} already in store, nothing to sync");
-                                    continue;
-                                },
-                                Err(e) => {
-                                    error!("{e}");
-                                    continue;
-                                }
-                            };
-                        }
-
-                        // reply back immediately for the available ones
-                        if !available.is_empty() {
-                            // Doing this will ensure the batch id will be populated to primary even
-                            // when other processes fail to do so (ex we received a batch from a peer
-                            // worker and message has been missed by primary).
-                            for digest in available {
-                                let message = WorkerPrimaryMessage::OthersBatch(digest, self.id);
-                                let _ = self.tx_primary.send(message).await.tap_err(|err|{
-                                    debug!("{err:?} {}", DagError::ShuttingDown);
-                                });
-                            }
-                        }
-
-                        if !missing.is_empty() {
-                            let now = SystemTime::now()
-                            .duration_since(UNIX_EPOCH)
-                            .expect("Failed to measure time")
-                            .as_millis();
-
-                            // now add all requests as pending
-                            for digest in missing.iter() {
-                                self.pending.insert(*digest, (self.round, now));
-                            }
-
-                            // Send sync request to a single node. If this fails, we will send it
-                            // to other nodes when a timer times out.
-                            let worker_name = match self.worker_cache.load().worker(&target, &self.id) {
-                                Ok(worker_info) => worker_info.name,
-                                Err(e) => {
-                                    error!("The primary asked us to sync with an unknown node: {e}");
-                                    continue;
-                                }
-                            };
-
-                            debug!("Sending WorkerBatchRequest message to {} for missing batches {:?}", worker_name, missing.clone());
-
-                            // TODO: restore ability to cancel these requests when primary->worker RPCs are
-                            // made synchronous and this one becomes a child of those.
-                            let message = WorkerBatchRequest{digests: missing.into_iter().collect::<Vec<_>>() };
-                            if let Ok(request) = self.network.unreliable_send(worker_name, &message) {
-                                waiting.push(request);
-                            }
-                        } else {
-                            debug!("All batches are already available {:?} nothing to request from peers", digests);
-                        }
-                    },
-                    PrimaryWorkerMessage::Cleanup(round) => {
-                        // Keep track of the primary's round number.
-                        self.round = round;
-
-                        // Cleanup internal state.
-                        if self.round < self.gc_depth {
-                            continue;
-                        }
-
-                        let mut gc_round = self.round - self.gc_depth;
-                        self.pending.retain(|_, (r, _)| r > &mut gc_round);
+                    PrimaryWorkerMessage::Cleanup(_) => {
+                        // TODO: this message does nothing, remove it.
                     },
                     PrimaryWorkerMessage::Reconfigure(message) => {
                         // Reconfigure this task and update the shared committee.
@@ -237,11 +96,6 @@ impl Synchronizer {
                                                 .clone()
                                         )).collect(),
                                 }));
-
-                                self.pending.clear();
-                                self.round = 0;
-                                waiting.clear();
-
 
                                 false
                             }
@@ -288,70 +142,6 @@ impl Synchronizer {
                     PrimaryWorkerMessage::DeleteBatches(digests) => {
                         self.handle_delete_batches(digests).await;
                     }
-                },
-
-                // Stream out the futures of the `FuturesUnordered` that completed.
-                Some(result) = waiting.next() => match result {
-                    Ok(Ok(response)) => {
-                        for batch in response.into_body().batches {
-                            // TODO: remove duplicate hashing of batch after primary-to-worker
-                            // communication is refactored to be synchronous.
-                            if self.pending.remove(&batch.digest()).is_some() {
-                                // Only send batch to processor if we haven't received it already
-                                // from another source.
-                                if self.tx_batch_processor.send(batch).await.is_err() {
-                                    // Assume error sending to processor means we're shutting down.
-                                    break
-                                }
-                            }
-                        }
-                    },
-                    Ok(Err(e)) => info!("{e}"),  // occasional RPC errors are expected
-                    Err(e) => error!("{e}"),
-                },
-
-                // Triggers on timer's expiration.
-                () = &mut timer => {
-                    // We optimistically sent sync requests to a single node. If this timer triggers,
-                    // it means we were wrong to trust it. We are done waiting for a reply and we now
-                    // broadcast the request to a bunch of other nodes (selected at random).
-                    let now = SystemTime::now()
-                        .duration_since(UNIX_EPOCH)
-                        .expect("Failed to measure time")
-                        .as_millis();
-
-                    let mut retry = Vec::new();
-                    for (digest, (_, timestamp)) in self.pending.iter_mut() {
-                        if *timestamp + self.sync_retry_delay.as_millis() < now {
-                            debug!("Requesting sync for batch {digest} (retry)");
-                            retry.push(*digest);
-                            // reset the time at which this request was last issued
-                            *timestamp = now;
-                        }
-                    }
-                    if !retry.is_empty() {
-                        let names = self.worker_cache.load()
-                            .others_workers(&self.name, &self.id)
-                            .into_iter()
-                            .map(|(_, info)| info.name)
-                            .collect();
-                        let message = WorkerBatchRequest{digests: retry};
-                        for fut in self.network
-                            .lucky_broadcast(names, &message, self.sync_retry_nodes)
-                            .into_iter()
-                            .flatten()
-                        {
-                            waiting.push(fut);
-                        }
-                    }
-
-                    // Reschedule the timer.
-                    timer.as_mut().reset(Instant::now() + Duration::from_millis(TIMER_RESOLUTION));
-
-                    // Report list of pending elements
-                    self.metrics.pending_elements_worker_synchronizer
-                    .with_label_values(&[&self.committee.load().epoch.to_string()])
-                    .set(self.pending.len() as i64);
                 },
             }
         }

--- a/worker/src/tests/handlers_tests.rs
+++ b/worker/src/tests/handlers_tests.rs
@@ -1,0 +1,132 @@
+// Copyright (c) 2021, Facebook, Inc. and its affiliates
+// Copyright (c) 2022, Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use super::*;
+use fastcrypto::Hash;
+use test_utils::CommitteeFixture;
+
+#[tokio::test]
+async fn synchronize() {
+    telemetry_subscribers::init_for_testing();
+
+    let (tx_synchronizer, _rx_synchronizer) = test_utils::test_channel!(1);
+    let (tx_primary, _rx_primary) = test_utils::test_channel!(1);
+    let (tx_request_batches_rpc, mut rx_request_batches_rpc) = test_utils::test_channel!(1);
+    let (tx_batch_processor, mut rx_batch_processor) = test_utils::test_channel!(1);
+
+    let fixture = CommitteeFixture::builder().randomize_ports(true).build();
+    let worker_cache = fixture.shared_worker_cache();
+    let id = 0;
+
+    // Create a new test store.
+    let store = test_utils::open_batch_store();
+
+    let handler = PrimaryReceiverHandler {
+        id,
+        worker_cache,
+        store,
+        request_batches_retry_nodes: 3, // Not used in this test.
+        tx_synchronizer,
+        tx_request_batches_rpc,
+        tx_primary,
+        tx_batch_processor,
+    };
+
+    // Set up mock behavior for child RequestBatches RPC.
+    let target_primary = fixture.authorities().nth(1).unwrap();
+    let target_worker = target_primary.worker(id);
+    let target_worker_network_key = target_worker.info().name.clone();
+    let target = target_primary.public_key();
+    let batch = test_utils::batch();
+    let missing = vec![batch.digest()];
+    let message = WorkerSynchronizeMessage {
+        digests: missing.clone(),
+        target,
+    };
+    let responder_handle = tokio::spawn(async move {
+        let (target, num_nodes, request, response_channel) =
+            rx_request_batches_rpc.recv().await.unwrap();
+        assert_eq!(target.unwrap(), target_worker_network_key);
+        assert!(num_nodes.is_none());
+        assert_eq!(request, WorkerBatchRequest { digests: missing });
+
+        // Reply with batch.
+        assert!(response_channel
+            .send(Ok(anemo::Response::new(WorkerBatchResponse {
+                batches: vec![batch.clone()]
+            })))
+            .is_ok());
+
+        // Ensure the handler sends the returned batch to the processor.
+        let recv_batch = rx_batch_processor.recv().await.unwrap();
+        let recv_digest = &recv_batch.digest();
+        debug!("Received batch {recv_digest:?} from handler for processing");
+        assert_eq!(recv_batch, batch);
+    });
+
+    // Send a sync request.
+    handler
+        .synchronize(anemo::Request::new(message))
+        .await
+        .unwrap();
+    responder_handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn synchronize_when_batch_exists() {
+    telemetry_subscribers::init_for_testing();
+
+    let (tx_synchronizer, _rx_synchronizer) = test_utils::test_channel!(1);
+    let (tx_primary, mut rx_primary) = test_utils::test_channel!(1);
+    let (tx_request_batches_rpc, _rx_request_batches_rpc) = test_utils::test_channel!(1);
+    let (tx_batch_processor, _rx_batch_processor) = test_utils::test_channel!(1);
+
+    let fixture = CommitteeFixture::builder().randomize_ports(true).build();
+    let worker_cache = fixture.shared_worker_cache();
+    let id = 0;
+
+    // Create a new test store.
+    let store = test_utils::open_batch_store();
+
+    let handler = PrimaryReceiverHandler {
+        id,
+        worker_cache,
+        store: store.clone(),
+        request_batches_retry_nodes: 3, // Not used in this test.
+        tx_synchronizer,
+        tx_request_batches_rpc,
+        tx_primary,
+        tx_batch_processor,
+    };
+
+    // Store the batch.
+    let batch = test_utils::batch();
+    let batch_id = batch.digest();
+    let missing = vec![batch_id];
+    store.write(batch_id, batch).await;
+
+    // Set up mock behavior for child RequestBatches RPC.
+    let target_primary = fixture.authorities().nth(1).unwrap();
+    let target = target_primary.public_key();
+    let message = WorkerSynchronizeMessage {
+        digests: missing.clone(),
+        target,
+    };
+    let responder_handle = tokio::spawn(async move {
+        if let WorkerPrimaryMessage::OthersBatch(recv_digest, recv_id) =
+            rx_primary.recv().await.unwrap()
+        {
+            assert_eq!(recv_digest, batch_id);
+            assert_eq!(recv_id, id);
+        } else {
+            panic!("received unexpected WorkerPrimaryMessage");
+        }
+    });
+
+    // Send a sync request.
+    handler
+        .synchronize(anemo::Request::new(message))
+        .await
+        .unwrap();
+    responder_handle.await.unwrap();
+}

--- a/worker/src/tests/synchronizer_tests.rs
+++ b/worker/src/tests/synchronizer_tests.rs
@@ -4,168 +4,14 @@
 use super::*;
 use arc_swap::ArcSwap;
 use fastcrypto::Hash;
-use prometheus::Registry;
-use test_utils::{
-    batch, batches, open_batch_store, test_network, CommitteeFixture, WorkerToWorkerMockServer,
-};
+use std::time::Duration;
+use test_utils::{batch, batches, open_batch_store, test_network, CommitteeFixture};
 use tokio::time::timeout;
-
-#[tokio::test]
-async fn synchronize() {
-    let (tx_message, rx_message) = test_utils::test_channel!(1);
-    let (tx_primary, _) = test_utils::test_channel!(1);
-    let (tx_batch_processor, _) = test_utils::test_channel!(1);
-
-    let fixture = CommitteeFixture::builder().randomize_ports(true).build();
-    let committee = fixture.committee();
-    let worker_cache = fixture.shared_worker_cache();
-    let id = 0;
-    let my_primary = fixture.authorities().next().unwrap();
-    let myself = my_primary.worker(id);
-
-    let (tx_reconfiguration, _rx_reconfiguration) =
-        watch::channel(ReconfigureNotification::NewEpoch(committee.clone()));
-
-    // Create a new test store.
-    let store = open_batch_store();
-
-    let metrics = Arc::new(WorkerMetrics::new(&Registry::new()));
-
-    let network = test_network(myself.keypair(), &myself.info().worker_address);
-    // Spawn a `Synchronizer` instance.
-    let _synchronizer_handle = Synchronizer::spawn(
-        my_primary.public_key(),
-        id,
-        Arc::new(ArcSwap::from_pointee(committee.clone())),
-        worker_cache.clone(),
-        store.clone(),
-        /* gc_depth */ 50, // Not used in this test.
-        /* sync_retry_delay */
-        Duration::from_millis(1_000_000), // Ensure it is not triggered.
-        /* sync_retry_nodes */ 3, // Not used in this test.
-        rx_message,
-        tx_reconfiguration,
-        tx_primary,
-        tx_batch_processor,
-        metrics,
-        P2pNetwork::new(network.clone()),
-    );
-
-    // Spawn a listener to receive our batch requests.
-    let target_primary = fixture.authorities().nth(1).unwrap();
-    let target_worker = target_primary.worker(id);
-    let target = target_primary.public_key();
-    let missing = vec![batch().digest()];
-    let expected = WorkerBatchRequest {
-        digests: missing.clone(),
-    };
-    let (_, mut rx_worker_batch_request, _network) = WorkerToWorkerMockServer::spawn(
-        target_worker.keypair(),
-        target_worker.info().worker_address.clone(),
-    );
-
-    // ensure that the networks are connected
-    network
-        .connect(network::multiaddr_to_address(&target_worker.info().worker_address).unwrap())
-        .await
-        .unwrap();
-
-    // Send a sync request.
-    let message = PrimaryWorkerMessage::Synchronize(missing, target);
-    tx_message.send(message).await.unwrap();
-
-    // Ensure the target receives the sync request.
-    assert_eq!(rx_worker_batch_request.recv().await.unwrap(), expected);
-}
-
-#[tokio::test]
-async fn synchronize_when_batch_exists() {
-    let (tx_message, rx_message) = test_utils::test_channel!(1);
-    let (tx_primary, mut rx_primary) = test_utils::test_channel!(1);
-    let (tx_batch_processor, _) = test_utils::test_channel!(1);
-
-    let fixture = CommitteeFixture::builder().randomize_ports(true).build();
-    let committee = fixture.committee();
-    let worker_cache = fixture.shared_worker_cache();
-    let id = 0;
-    let my_primary = fixture.authorities().next().unwrap();
-    let myself = my_primary.worker(id);
-
-    let (tx_reconfiguration, _rx_reconfiguration) =
-        watch::channel(ReconfigureNotification::NewEpoch(committee.clone()));
-
-    // Create a new test store.
-    let store = open_batch_store();
-
-    let metrics = Arc::new(WorkerMetrics::new(&Registry::new()));
-
-    let network = test_network(myself.keypair(), &myself.info().worker_address);
-    // Spawn a `Synchronizer` instance.
-    let _synchronizer_handle = Synchronizer::spawn(
-        my_primary.public_key(),
-        id,
-        Arc::new(ArcSwap::from_pointee(committee.clone())),
-        worker_cache.clone(),
-        store.clone(),
-        /* gc_depth */ 50, // Not used in this test.
-        /* sync_retry_delay */
-        Duration::from_millis(1_000_000), // Ensure it is not triggered.
-        /* sync_retry_nodes */ 3, // Not used in this test.
-        rx_message,
-        tx_reconfiguration,
-        tx_primary,
-        tx_batch_processor,
-        metrics,
-        P2pNetwork::new(network.clone()),
-    );
-
-    // Spawn a listener to receive our batch requests.
-    let target_primary = fixture.authorities().nth(1).unwrap();
-    let target_worker = target_primary.worker(id);
-    let target = target_primary.public_key();
-    let (mut handle, _, _network) = WorkerToWorkerMockServer::spawn(
-        target_worker.keypair(),
-        target_worker.info().worker_address.clone(),
-    );
-
-    // ensure that the networks are connected
-    network
-        .connect(network::multiaddr_to_address(&target_worker.info().worker_address).unwrap())
-        .await
-        .unwrap();
-
-    let batch = batch();
-    let batch_id = batch.digest();
-    let missing = vec![batch_id];
-
-    // now store the batch
-    store.write(batch_id, batch).await;
-
-    // Send a sync request.
-    let message = PrimaryWorkerMessage::Synchronize(missing, target);
-    tx_message.send(message).await.unwrap();
-
-    // Ensure the target does NOT receive the sync request - we practically timeout waiting.
-    let result = timeout(Duration::from_secs(1), handle.recv()).await;
-    assert!(result.is_err());
-
-    // Now ensure that the batch is forwarded directly to primary
-    let result_batch_message: WorkerPrimaryMessage = rx_primary.recv().await.unwrap();
-
-    match result_batch_message {
-        WorkerPrimaryMessage::OthersBatch(result_digest, worker_id) => {
-            assert_eq!(result_digest, batch_id, "Batch id mismatch");
-            assert_eq!(worker_id, id, "Worker id mismatch");
-        }
-        _ => panic!("Unexpected message received!"),
-    }
-}
 
 #[tokio::test]
 async fn test_successful_request_batch() {
     let (tx_message, rx_message) = test_utils::test_channel!(1);
     let (tx_primary, mut rx_primary) = test_utils::test_channel!(1);
-    let (tx_batch_processor, _) = test_utils::test_channel!(1);
 
     let fixture = CommitteeFixture::builder().randomize_ports(true).build();
     let committee = fixture.committee();
@@ -180,25 +26,15 @@ async fn test_successful_request_batch() {
     // Create a new test store.
     let store = open_batch_store();
 
-    let metrics = Arc::new(WorkerMetrics::new(&Registry::new()));
-
     let network = test_network(myself.keypair(), &myself.info().worker_address);
     // Spawn a `Synchronizer` instance.
     let _synchronizer_handle = Synchronizer::spawn(
-        my_primary.public_key(),
-        id,
         Arc::new(ArcSwap::from_pointee(committee.clone())),
         worker_cache,
         store.clone(),
-        /* gc_depth */ 50, // Not used in this test.
-        /* sync_retry_delay */
-        Duration::from_millis(1_000_000), // Ensure it is not triggered.
-        /* sync_retry_nodes */ 3, // Not used in this test.
         rx_message,
         tx_reconfiguration,
         tx_primary,
-        tx_batch_processor,
-        metrics,
         P2pNetwork::new(network),
     );
 
@@ -233,7 +69,6 @@ async fn test_successful_request_batch() {
 async fn test_request_batch_not_found() {
     let (tx_message, rx_message) = test_utils::test_channel!(1);
     let (tx_primary, mut rx_primary) = test_utils::test_channel!(1);
-    let (tx_batch_processor, _) = test_utils::test_channel!(1);
 
     let fixture = CommitteeFixture::builder().randomize_ports(true).build();
     let committee = fixture.committee();
@@ -248,25 +83,15 @@ async fn test_request_batch_not_found() {
     // Create a new test store.
     let store = open_batch_store();
 
-    let metrics = Arc::new(WorkerMetrics::new(&Registry::new()));
-
     let network = test_network(myself.keypair(), &myself.info().worker_address);
     // Spawn a `Synchronizer` instance.
     let _synchronizer_handle = Synchronizer::spawn(
-        my_primary.public_key(),
-        id,
         Arc::new(ArcSwap::from_pointee(committee.clone())),
         worker_cache,
         store.clone(),
-        /* gc_depth */ 50, // Not used in this test.
-        /* sync_retry_delay */
-        Duration::from_millis(1_000_000), // Ensure it is not triggered.
-        /* sync_retry_nodes */ 3, // Not used in this test.
         rx_message,
         tx_reconfiguration,
         tx_primary,
-        tx_batch_processor,
-        metrics,
         P2pNetwork::new(network),
     );
 
@@ -301,7 +126,6 @@ async fn test_request_batch_not_found() {
 async fn test_successful_batch_delete() {
     let (tx_message, rx_message) = test_utils::test_channel!(1);
     let (tx_primary, mut rx_primary) = test_utils::test_channel!(1);
-    let (tx_batch_processor, _) = test_utils::test_channel!(1);
 
     let fixture = CommitteeFixture::builder().randomize_ports(true).build();
     let committee = fixture.committee();
@@ -316,25 +140,15 @@ async fn test_successful_batch_delete() {
     // Create a new test store.
     let store = open_batch_store();
 
-    let metrics = Arc::new(WorkerMetrics::new(&Registry::new()));
-
     let network = test_network(myself.keypair(), &myself.info().worker_address);
     // Spawn a `Synchronizer` instance.
     let _synchronizer_handle = Synchronizer::spawn(
-        my_primary.public_key(),
-        id,
         Arc::new(ArcSwap::from_pointee(committee.clone())),
         worker_cache,
         store.clone(),
-        /* gc_depth */ 50, // Not used in this test.
-        /* sync_retry_delay */
-        Duration::from_millis(1_000_000), // Ensure it is not triggered.
-        /* sync_retry_nodes */ 3, // Not used in this test.
         rx_message,
         tx_reconfiguration,
         tx_primary,
-        tx_batch_processor,
-        metrics,
         P2pNetwork::new(network),
     );
 


### PR DESCRIPTION
Moves implementation to a linear async function in the handler. Gets rid of all parts of the synchronizer that previously existed only to track pending batch requests to other workers.

NOTE: this changes retries of worker->worker block requests to happen only once instead of perpetually. Additional retries beyond that point will have to be driven by the primary.